### PR TITLE
[FIX] 이미지, 첨부파일 삭제시 실제 업로드된 파일 삭제에 반영되도록 수정

### DIFF
--- a/src/main/java/geumjeongyahak/common/security/config/WebSecurityConfig.java
+++ b/src/main/java/geumjeongyahak/common/security/config/WebSecurityConfig.java
@@ -105,7 +105,7 @@ public class WebSecurityConfig {
                 // 관리자 로그인 페이지로 redirect 용
                 .requestMatchers(HttpMethod.GET, "/").permitAll()
                 // 정적 리소스 및 문서/헬스체크
-                .requestMatchers("/favicon.ico", "/icons/**", "/site.webmanifest", "/actuator/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/swagger-ui").permitAll()
+                .requestMatchers("/favicon.ico", "/sw.js", "/icons/**", "/site.webmanifest", "/actuator/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/swagger-ui").permitAll()
                 // 인증 API (로그인, 회원가입, 토큰 재발급, 로그아웃)
                 .requestMatchers("/api/v1/auth/login", "/api/v1/auth/signup", "/api/v1/auth/refresh", "/api/v1/auth/logout").permitAll()
                 .requestMatchers("/api/v1/auth/google/**").permitAll()

--- a/src/main/java/geumjeongyahak/domain/file/config/FileCleanupProperties.java
+++ b/src/main/java/geumjeongyahak/domain/file/config/FileCleanupProperties.java
@@ -1,0 +1,26 @@
+package geumjeongyahak.domain.file.config;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Setter
+@Validated
+@Component
+@ConfigurationProperties(prefix = "app.file.cleanup")
+public class FileCleanupProperties {
+
+    @Min(1)
+    private long retentionDays = 7;
+
+    @Min(1)
+    private int chunkSize = 100;
+
+    @NotBlank
+    private String cron = "0 0 3 * * *";
+}

--- a/src/main/java/geumjeongyahak/domain/file/entity/File.java
+++ b/src/main/java/geumjeongyahak/domain/file/entity/File.java
@@ -53,6 +53,9 @@ public class File {
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -78,5 +81,6 @@ public class File {
 
     public void delete() {
         this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/geumjeongyahak/domain/file/repository/FileRepository.java
+++ b/src/main/java/geumjeongyahak/domain/file/repository/FileRepository.java
@@ -1,5 +1,8 @@
 package geumjeongyahak.domain.file.repository;
 
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -10,4 +13,8 @@ import geumjeongyahak.domain.file.entity.File;
 public interface FileRepository extends JpaRepository<File, UUID> {
 
     Optional<File> findByIdAndIsDeletedFalse(UUID id);
+
+    List<File> findAllByIdInAndIsDeletedFalse(Collection<UUID> ids);
+
+    List<File> findByIsDeletedTrueAndDeletedAtBefore(LocalDateTime threshold);
 }

--- a/src/main/java/geumjeongyahak/domain/file/service/FileCleanupScheduler.java
+++ b/src/main/java/geumjeongyahak/domain/file/service/FileCleanupScheduler.java
@@ -1,0 +1,64 @@
+package geumjeongyahak.domain.file.service;
+
+import geumjeongyahak.domain.file.config.FileCleanupProperties;
+import geumjeongyahak.domain.file.entity.File;
+import geumjeongyahak.domain.file.repository.FileRepository;
+import geumjeongyahak.domain.post.repository.PostAttachmentRepository;
+import geumjeongyahak.domain.post.repository.PostFileRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FileCleanupScheduler {
+
+    private final FileRepository fileRepository;
+    private final PostFileRepository postFileRepository;
+    private final PostAttachmentRepository postAttachmentRepository;
+    private final StorageService storageService;
+    private final FileCleanupProperties fileCleanupProperties;
+
+    @Scheduled(cron = "${app.file.cleanup.cron}")
+    @Transactional
+    public void cleanupDeletedFiles() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(fileCleanupProperties.getRetentionDays());
+        List<File> candidates = fileRepository.findByIsDeletedTrueAndDeletedAtBefore(threshold);
+
+        if (candidates.isEmpty()) {
+            return;
+        }
+
+        int chunkSize = fileCleanupProperties.getChunkSize();
+        int processed = 0;
+
+        for (int i = 0; i < candidates.size(); i += chunkSize) {
+            List<File> chunk = candidates.subList(i, Math.min(i + chunkSize, candidates.size()));
+            processed += processChunk(chunk);
+        }
+
+        log.info("파일 Hard Delete 스케줄러 실행 완료 (count={})", processed);
+    }
+
+    private int processChunk(List<File> files) {
+        int count = 0;
+        for (File file : files) {
+            boolean gcsDeleted = storageService.delete(file.getStorageKey());
+            if (!gcsDeleted) {
+                log.warn("GCS 삭제 실패, DB 레코드 유지 (fileId={}, path={})", file.getId(), file.getStorageKey());
+                continue;
+            }
+            postFileRepository.deleteByFileId(file.getId());
+            postAttachmentRepository.deleteByFileId(file.getId());
+            fileRepository.delete(file);
+            count++;
+        }
+        return count;
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/file/service/FileDeleteEventHandler.java
+++ b/src/main/java/geumjeongyahak/domain/file/service/FileDeleteEventHandler.java
@@ -1,0 +1,46 @@
+package geumjeongyahak.domain.file.service;
+
+import geumjeongyahak.domain.file.repository.FileRepository;
+import geumjeongyahak.domain.post.event.PostDeletedEvent;
+import geumjeongyahak.domain.post.event.PostImageDeleteRequestedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.Set;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FileDeleteEventHandler {
+
+    private final FileRepository fileRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePostDeleted(PostDeletedEvent event) {
+        deleteFiles(event.getFileIds());
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePostImageDeleteRequested(PostImageDeleteRequestedEvent event) {
+        deleteFiles(event.getFileIds());
+    }
+
+    private void deleteFiles(Set<UUID> fileIds) {
+        if (fileIds.isEmpty()) {
+            return;
+        }
+
+        fileRepository.findAllByIdInAndIsDeletedFalse(fileIds).forEach(file -> {
+            file.delete();
+            log.info("고아 파일 Soft Delete (fileId={})", file.getId());
+        });
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/file/service/GcsStorageService.java
+++ b/src/main/java/geumjeongyahak/domain/file/service/GcsStorageService.java
@@ -66,11 +66,13 @@ public class GcsStorageService implements StorageService {
     }
 
     @Override
-    public void delete(String path) {
+    public boolean delete(String path) {
         try {
             storage.delete(bucketName, path);
+            return true;
         } catch (RuntimeException exception) {
             log.warn("GCS 파일 삭제 실패: path={}", path, exception);
+            return false;
         }
     }
 

--- a/src/main/java/geumjeongyahak/domain/file/service/StorageService.java
+++ b/src/main/java/geumjeongyahak/domain/file/service/StorageService.java
@@ -10,7 +10,7 @@ public interface StorageService {
 
     StoredFile upload(byte[] content, String contentType, String originalFilename, String directory);
 
-    void delete(String path);
+    boolean delete(String path);
 
     String getPublicUrl(String path);
 

--- a/src/main/java/geumjeongyahak/domain/post/event/PostDeletedEvent.java
+++ b/src/main/java/geumjeongyahak/domain/post/event/PostDeletedEvent.java
@@ -1,0 +1,28 @@
+package geumjeongyahak.domain.post.event;
+
+import geumjeongyahak.common.event.dto.BaseEventDto;
+import lombok.Getter;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+@Getter
+public class PostDeletedEvent extends BaseEventDto {
+
+    private final Long postId;
+    private final Set<UUID> fileIds;
+
+    public PostDeletedEvent(Long postId, Set<UUID> fileIds) {
+        this.postId = postId;
+        this.fileIds = Set.copyOf(fileIds);
+    }
+
+    @Override
+    public Map<String, Object> getEventData() {
+        return Map.of(
+                "postId", postId,
+                "fileIds", fileIds
+        );
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/post/event/PostImageDeleteRequestedEvent.java
+++ b/src/main/java/geumjeongyahak/domain/post/event/PostImageDeleteRequestedEvent.java
@@ -1,0 +1,28 @@
+package geumjeongyahak.domain.post.event;
+
+import geumjeongyahak.common.event.dto.BaseEventDto;
+import lombok.Getter;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+@Getter
+public class PostImageDeleteRequestedEvent extends BaseEventDto {
+
+    private final Long postId;
+    private final Set<UUID> fileIds;
+
+    public PostImageDeleteRequestedEvent(Long postId, Set<UUID> fileIds) {
+        this.postId = postId;
+        this.fileIds = Set.copyOf(fileIds);
+    }
+
+    @Override
+    public Map<String, Object> getEventData() {
+        return Map.of(
+                "postId", postId,
+                "fileIds", fileIds
+        );
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/post/repository/PostAttachmentRepository.java
+++ b/src/main/java/geumjeongyahak/domain/post/repository/PostAttachmentRepository.java
@@ -1,8 +1,13 @@
 package geumjeongyahak.domain.post.repository;
 
 import geumjeongyahak.domain.post.entity.PostAttachment;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -13,4 +18,17 @@ public interface PostAttachmentRepository extends JpaRepository<PostAttachment, 
     long countByPostId(Long postId);
 
     Optional<PostAttachment> findByPostIdAndFileId(Long postId, UUID fileId);
+
+    @Query("SELECT pa.file.id FROM PostAttachment pa WHERE pa.post.id = :postId")
+    List<UUID> findFileIdsByPostId(@Param("postId") Long postId);
+
+    @Query("SELECT DISTINCT pa.file.id FROM PostAttachment pa WHERE pa.file.id IN :fileIds AND pa.post.id <> :postId")
+    List<UUID> findReferencedFileIdsByFileIdInAndPostIdNot(
+            @Param("fileIds") Collection<UUID> fileIds,
+            @Param("postId") Long postId
+    );
+
+    @Modifying
+    @Query("DELETE FROM PostAttachment pa WHERE pa.file.id = :fileId")
+    void deleteByFileId(@Param("fileId") UUID fileId);
 }

--- a/src/main/java/geumjeongyahak/domain/post/repository/PostFileRepository.java
+++ b/src/main/java/geumjeongyahak/domain/post/repository/PostFileRepository.java
@@ -1,8 +1,13 @@
 package geumjeongyahak.domain.post.repository;
 
 import geumjeongyahak.domain.post.entity.PostFile;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -13,4 +18,20 @@ public interface PostFileRepository extends JpaRepository<PostFile, Long> {
     long countByPostId(Long postId);
 
     Optional<PostFile> findFirstByPostIdOrderBySortOrderAsc(Long postId);
+
+    @Query("SELECT pf FROM PostFile pf JOIN FETCH pf.file WHERE pf.post.id = :postId ORDER BY pf.sortOrder ASC")
+    List<PostFile> findAllByPostIdWithFileOrderBySortOrderAsc(@Param("postId") Long postId);
+
+    @Query("SELECT pf.file.id FROM PostFile pf WHERE pf.post.id = :postId")
+    List<UUID> findFileIdsByPostId(@Param("postId") Long postId);
+
+    @Query("SELECT DISTINCT pf.file.id FROM PostFile pf WHERE pf.file.id IN :fileIds AND pf.post.id <> :postId")
+    List<UUID> findReferencedFileIdsByFileIdInAndPostIdNot(
+            @Param("fileIds") Collection<UUID> fileIds,
+            @Param("postId") Long postId
+    );
+
+    @Modifying
+    @Query("DELETE FROM PostFile pf WHERE pf.file.id = :fileId")
+    void deleteByFileId(@Param("fileId") UUID fileId);
 }

--- a/src/main/java/geumjeongyahak/domain/post/service/PostActionService.java
+++ b/src/main/java/geumjeongyahak/domain/post/service/PostActionService.java
@@ -13,7 +13,6 @@ import geumjeongyahak.domain.post.enums.PostStatus;
 import geumjeongyahak.domain.post.event.PostChangedEvent;
 import geumjeongyahak.domain.post.event.PostPublishedEvent;
 import geumjeongyahak.domain.post.exception.PostErrorCode;
-import geumjeongyahak.domain.post.repository.PostFileRepository;
 import geumjeongyahak.domain.post.repository.PostRepository;
 import geumjeongyahak.domain.post.v1.dto.response.PostDetailResponse;
 import geumjeongyahak.domain.users.entity.User;
@@ -34,11 +33,11 @@ import java.time.LocalDateTime;
 public class PostActionService {
 
     private final PostRepository postRepository;
-    private final PostFileRepository postFileRepository;
     private final ChannelProxyService channelProxyService;
     private final UserProxyService userProxyService;
     private final EventPublisher eventPublisher;
     private final PostProperties postProperties;
+    private final PostContentImageCleanupService postContentImageCleanupService;
 
     @Transactional
     public PostDetailResponse createDraft(Long channelId, CustomUserDetails userDetails) {
@@ -84,6 +83,7 @@ public class PostActionService {
         draft.updateDraftExpiration(nextDraftExpiration());
 
         postRepository.save(draft);
+        postContentImageCleanupService.deleteUnusedImages(postId, draft.getContentHtml());
         log.info("게시글 초안 저장 완료 - channelId: {}, postId: {}", channelId, postId);
         return reloadForResponse(channelId, postId);
     }
@@ -101,8 +101,7 @@ public class PostActionService {
 
         String thumbnail = command.thumbnailUrl() != null
                 ? command.thumbnailUrl()
-                : postFileRepository.findFirstByPostIdOrderBySortOrderAsc(postId)
-                        .map(pf -> pf.getFile().getPublicUrl())
+                : postContentImageCleanupService.findFirstUsedImageUrl(postId, command.contentHtml())
                         .orElse(null);
 
         draft.update(
@@ -117,6 +116,7 @@ public class PostActionService {
         draft.publish();
 
         Post publishedPost = postRepository.save(draft);
+        postContentImageCleanupService.deleteUnusedImages(postId, publishedPost.getContentHtml());
         publishPostEvents(publishedPost);
 
         log.info("게시글 발행 완료 - channelId: {}, postId: {}", channelId, postId);

--- a/src/main/java/geumjeongyahak/domain/post/service/PostContentImageCleanupService.java
+++ b/src/main/java/geumjeongyahak/domain/post/service/PostContentImageCleanupService.java
@@ -1,0 +1,104 @@
+package geumjeongyahak.domain.post.service;
+
+import geumjeongyahak.common.event.EventPublisher;
+import geumjeongyahak.domain.file.entity.File;
+import geumjeongyahak.domain.post.entity.PostFile;
+import geumjeongyahak.domain.post.event.PostImageDeleteRequestedEvent;
+import geumjeongyahak.domain.post.repository.PostFileRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.HtmlUtils;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PostContentImageCleanupService {
+
+    private static final Pattern IMG_SRC_PATTERN = Pattern.compile(
+            "<img\\b[^>]*\\bsrc\\s*=\\s*([\"'])(.*?)\\1",
+            Pattern.CASE_INSENSITIVE | Pattern.DOTALL
+    );
+
+    private final PostFileRepository postFileRepository;
+    private final EventPublisher eventPublisher;
+
+    public void deleteUnusedImages(Long postId, String contentHtml) {
+        Set<UUID> unusedFileIds = findUnusedImageFileIds(postId, contentHtml);
+        if (unusedFileIds.isEmpty()) {
+            return;
+        }
+
+        eventPublisher.publish(new PostImageDeleteRequestedEvent(postId, unusedFileIds));
+        log.info("게시글 미사용 이미지 삭제 이벤트 발행 - postId: {}, count: {}", postId, unusedFileIds.size());
+    }
+
+    public Optional<String> findFirstUsedImageUrl(Long postId, String contentHtml) {
+        Set<String> usedImageUrls = extractImageUrls(contentHtml);
+        if (usedImageUrls.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return findLinkedImages(postId).stream()
+                .map(PostFile::getFile)
+                .filter(file -> !file.isDeleted())
+                .map(File::getPublicUrl)
+                .filter(StringUtils::hasText)
+                .filter(usedImageUrls::contains)
+                .findFirst();
+    }
+
+    private Set<UUID> findUnusedImageFileIds(Long postId, String contentHtml) {
+        Set<String> usedImageUrls = extractImageUrls(contentHtml);
+        List<PostFile> linkedImages = findLinkedImages(postId);
+
+        Set<UUID> unusedFileIds = new LinkedHashSet<>();
+        for (PostFile linkedImage : linkedImages) {
+            File file = linkedImage.getFile();
+            if (file.isDeleted()) {
+                continue;
+            }
+            if (!StringUtils.hasText(file.getPublicUrl()) || !usedImageUrls.contains(file.getPublicUrl())) {
+                unusedFileIds.add(file.getId());
+            }
+        }
+        if (unusedFileIds.isEmpty()) {
+            return unusedFileIds;
+        }
+
+        Set<UUID> referencedFileIds = new LinkedHashSet<>(
+                postFileRepository.findReferencedFileIdsByFileIdInAndPostIdNot(unusedFileIds, postId)
+        );
+        unusedFileIds.removeAll(referencedFileIds);
+        return unusedFileIds;
+    }
+
+    private List<PostFile> findLinkedImages(Long postId) {
+        return postFileRepository.findAllByPostIdWithFileOrderBySortOrderAsc(postId);
+    }
+
+    private Set<String> extractImageUrls(String contentHtml) {
+        if (!StringUtils.hasText(contentHtml)) {
+            return Set.of();
+        }
+
+        Set<String> urls = new LinkedHashSet<>();
+        Matcher matcher = IMG_SRC_PATTERN.matcher(contentHtml);
+        while (matcher.find()) {
+            String url = HtmlUtils.htmlUnescape(matcher.group(2)).trim();
+            if (StringUtils.hasText(url)) {
+                urls.add(url);
+            }
+        }
+        return urls;
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/post/service/PostCrudService.java
+++ b/src/main/java/geumjeongyahak/domain/post/service/PostCrudService.java
@@ -15,10 +15,13 @@ import geumjeongyahak.domain.channel.service.ChannelProxyService;
 import geumjeongyahak.domain.post.config.PostProperties;
 import geumjeongyahak.domain.post.entity.Post;
 import geumjeongyahak.domain.post.event.PostChangedEvent;
+import geumjeongyahak.domain.post.event.PostDeletedEvent;
 import geumjeongyahak.domain.post.exception.PostErrorCode;
 import geumjeongyahak.domain.post.enums.PostStatus;
 import geumjeongyahak.domain.post.repository.PostRepository;
 import geumjeongyahak.domain.post.repository.PostSpecs;
+import geumjeongyahak.domain.post.repository.PostAttachmentRepository;
+import geumjeongyahak.domain.post.repository.PostFileRepository;
 import geumjeongyahak.domain.post.v1.dto.request.CreatePostRequest;
 import geumjeongyahak.domain.post.v1.dto.request.PostSearchRequest;
 import geumjeongyahak.domain.post.v1.dto.request.UpdatePostRequest;
@@ -30,6 +33,10 @@ import geumjeongyahak.domain.users.service.UserProxyService;
 import geumjeongyahak.common.security.service.CustomUserDetails;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
 import org.springframework.data.domain.Pageable;
 
 @Slf4j
@@ -43,6 +50,9 @@ public class PostCrudService {
     private final PostSearchSpecificationBuilder postSearchSpecificationBuilder;
     private final EventPublisher eventPublisher;
     private final PostProperties postProperties;
+    private final PostFileRepository postFileRepository;
+    private final PostAttachmentRepository postAttachmentRepository;
+    private final PostContentImageCleanupService postContentImageCleanupService;
 
     @Transactional
     public PostDetailResponse createPost(Long channelId, CustomUserDetails userDetails, CreatePostRequest request) {
@@ -137,6 +147,7 @@ public class PostCrudService {
         }
 
         postRepository.save(post);
+        postContentImageCleanupService.deleteUnusedImages(postId, post.getContentHtml());
         publishPostChangedEvent(channelId);
         return reloadForResponse(channelId, postId);
     }
@@ -144,9 +155,29 @@ public class PostCrudService {
     @Transactional
     public void deletePost(Long channelId, CustomUserDetails userDetails, Long postId) {
         Post post = getPostWithoutDeleted(channelId, postId);
+        Set<UUID> unreferencedFileIds = findUnreferencedFileIds(postId);
+
         post.delete();
         postRepository.save(post);
         publishPostChangedEvent(channelId);
+        eventPublisher.publish(new PostDeletedEvent(postId, unreferencedFileIds));
+    }
+
+    private Set<UUID> findUnreferencedFileIds(Long postId) {
+        Set<UUID> fileIds = new HashSet<>();
+        fileIds.addAll(postFileRepository.findFileIdsByPostId(postId));
+        fileIds.addAll(postAttachmentRepository.findFileIdsByPostId(postId));
+
+        if (fileIds.isEmpty()) {
+            return Set.of();
+        }
+
+        Set<UUID> referencedFileIds = new HashSet<>();
+        referencedFileIds.addAll(postFileRepository.findReferencedFileIdsByFileIdInAndPostIdNot(fileIds, postId));
+        referencedFileIds.addAll(postAttachmentRepository.findReferencedFileIdsByFileIdInAndPostIdNot(fileIds, postId));
+
+        fileIds.removeAll(referencedFileIds);
+        return fileIds;
     }
 
     private PostDetailResponse reloadForResponse(Long channelId, Long postId) {

--- a/src/main/java/geumjeongyahak/domain/student/service/StudentAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/student/service/StudentAdminViewService.java
@@ -1,0 +1,114 @@
+package geumjeongyahak.domain.student.service;
+
+import geumjeongyahak.domain.base.dto.response.AdminPage;
+import geumjeongyahak.domain.base.dto.response.AdminSorts;
+import geumjeongyahak.domain.classroom.service.ClassroomAdminViewService;
+import geumjeongyahak.domain.classroom.service.ClassroomAdminViewService.AdminClassroomRow;
+import geumjeongyahak.domain.classroom.service.ClassroomAdminViewService.ClassroomFilter;
+import geumjeongyahak.domain.student.enums.StudentStatus;
+import geumjeongyahak.domain.student.v1.dto.request.CreateStudentRequest;
+import geumjeongyahak.domain.student.v1.dto.request.StudentSearchRequest;
+import geumjeongyahak.domain.student.v1.dto.request.UpdateStudentRequest;
+import geumjeongyahak.domain.student.v1.dto.response.StudentResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StudentAdminViewService {
+
+    private final StudentService studentService;
+    private final ClassroomAdminViewService classroomAdminViewService;
+
+    public AdminPage<StudentResponse> getStudents(StudentFilter filter) {
+        StudentSearchRequest request = new StudentSearchRequest();
+        request.setName(filter.name());
+        request.setStatus(filter.status());
+        request.setClassroomId(filter.classroomId());
+
+        List<StudentResponse> rows = studentService.getAllStudents(request);
+        return AdminPage.from(sortStudents(rows, filter.sort()), filter.page(), filter.size());
+    }
+
+    private List<StudentResponse> sortStudents(List<StudentResponse> rows, String sort) {
+        return AdminSorts.sort(rows, sort, Map.of(
+                "id", Comparator.comparing(StudentResponse::id),
+                "name", Comparator.comparing(StudentResponse::name, Comparator.nullsLast(String::compareToIgnoreCase)),
+                "classroomName", Comparator.comparing(StudentResponse::classroomName, Comparator.nullsLast(String::compareToIgnoreCase)),
+                "status", Comparator.comparing(StudentResponse::status, Comparator.nullsLast(String::compareToIgnoreCase))
+        ), "name,ASC");
+    }
+
+    public StudentResponse getStudent(Long studentId) {
+        return studentService.getStudentById(studentId);
+    }
+
+    @Transactional
+    public Long createStudent(String name, String phoneNumber, String description, Long classroomId) {
+        return studentService.createStudent(new CreateStudentRequest(
+                name,
+                phoneNumber,
+                description,
+                classroomId
+        )).id();
+    }
+
+    @Transactional
+    public void updateStudent(
+            Long studentId,
+            String name,
+            String phoneNumber,
+            String description,
+            StudentStatus status,
+            Long classroomId
+    ) {
+        studentService.updateStudent(studentId, new UpdateStudentRequest(
+                name,
+                phoneNumber,
+                description,
+                status,
+                classroomId
+        ));
+    }
+
+    @Transactional
+    public void deleteStudent(Long studentId) {
+        studentService.deleteStudentById(studentId);
+    }
+
+    public List<ClassroomOption> getClassroomOptions() {
+        return classroomAdminViewService.getClassrooms(new ClassroomFilter(null, null, "name,ASC"))
+                .stream()
+                .map(ClassroomOption::from)
+                .toList();
+    }
+
+    public StudentStatus[] getStatuses() {
+        return StudentStatus.values();
+    }
+
+    public record StudentFilter(
+            String name,
+            StudentStatus status,
+            Long classroomId,
+            Integer page,
+            Integer size,
+            String sort
+    ) {
+    }
+
+    public record ClassroomOption(
+            Long id,
+            String name
+    ) {
+        private static ClassroomOption from(AdminClassroomRow classroom) {
+            return new ClassroomOption(classroom.id(), classroom.name());
+        }
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/student/v1/controller/StudentViewController.java
+++ b/src/main/java/geumjeongyahak/domain/student/v1/controller/StudentViewController.java
@@ -1,0 +1,116 @@
+package geumjeongyahak.domain.student.v1.controller;
+
+import geumjeongyahak.domain.student.enums.StudentStatus;
+import geumjeongyahak.domain.student.service.StudentAdminViewService;
+import geumjeongyahak.domain.student.service.StudentAdminViewService.StudentFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequestMapping("/admin/student/students")
+@RequiredArgsConstructor
+public class StudentViewController {
+
+    private final StudentAdminViewService studentAdminViewService;
+
+    @GetMapping
+    public String students(
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) StudentStatus status,
+            @RequestParam(required = false) Long classroomId,
+            @RequestParam(required = false) Integer page,
+            @RequestParam(required = false) Integer size,
+            @RequestParam(required = false) String sort,
+            Model model,
+            Authentication authentication
+    ) {
+        StudentFilter filter = new StudentFilter(name, status, classroomId, page, size, sort);
+        model.addAttribute("active", "students");
+        model.addAttribute("adminName", authentication.getName());
+        model.addAttribute("filter", filter);
+        model.addAttribute("studentsPage", studentAdminViewService.getStudents(filter));
+        model.addAttribute("studentStatuses", studentAdminViewService.getStatuses());
+        model.addAttribute("classrooms", studentAdminViewService.getClassroomOptions());
+        return "admin/student/students";
+    }
+
+    @GetMapping("/new")
+    public String newStudent(Model model, Authentication authentication) {
+        model.addAttribute("active", "students");
+        model.addAttribute("adminName", authentication.getName());
+        model.addAttribute("classrooms", studentAdminViewService.getClassroomOptions());
+        return "admin/student/students-form";
+    }
+
+    @PostMapping
+    public String createStudent(
+            @RequestParam String name,
+            @RequestParam(required = false) String phoneNumber,
+            @RequestParam(required = false) String description,
+            @RequestParam Long classroomId,
+            RedirectAttributes redirectAttributes
+    ) {
+        Long studentId = studentAdminViewService.createStudent(name, phoneNumber, description, classroomId);
+        redirectAttributes.addFlashAttribute("message", "학생을 등록했습니다.");
+        return "redirect:/admin/student/students/" + studentId;
+    }
+
+    @GetMapping("/{studentId}")
+    public String studentDetail(
+            @PathVariable Long studentId,
+            Model model,
+            Authentication authentication
+    ) {
+        model.addAttribute("active", "students");
+        model.addAttribute("adminName", authentication.getName());
+        model.addAttribute("student", studentAdminViewService.getStudent(studentId));
+        return "admin/student/students-detail";
+    }
+
+    @GetMapping("/{studentId}/edit")
+    public String editStudent(
+            @PathVariable Long studentId,
+            Model model,
+            Authentication authentication
+    ) {
+        model.addAttribute("active", "students");
+        model.addAttribute("adminName", authentication.getName());
+        model.addAttribute("student", studentAdminViewService.getStudent(studentId));
+        model.addAttribute("studentStatuses", studentAdminViewService.getStatuses());
+        model.addAttribute("classrooms", studentAdminViewService.getClassroomOptions());
+        return "admin/student/students-edit";
+    }
+
+    @PostMapping("/{studentId}")
+    public String updateStudent(
+            @PathVariable Long studentId,
+            @RequestParam String name,
+            @RequestParam(required = false) String phoneNumber,
+            @RequestParam(required = false) String description,
+            @RequestParam StudentStatus status,
+            @RequestParam Long classroomId,
+            RedirectAttributes redirectAttributes
+    ) {
+        studentAdminViewService.updateStudent(studentId, name, phoneNumber, description, status, classroomId);
+        redirectAttributes.addFlashAttribute("message", "학생 정보를 수정했습니다.");
+        return "redirect:/admin/student/students/" + studentId;
+    }
+
+    @PostMapping("/{studentId}/delete")
+    public String deleteStudent(
+            @PathVariable Long studentId,
+            RedirectAttributes redirectAttributes
+    ) {
+        studentAdminViewService.deleteStudent(studentId);
+        redirectAttributes.addFlashAttribute("message", "학생을 삭제했습니다.");
+        return "redirect:/admin/student/students";
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,5 +51,9 @@ app:
         - text/plain
         - application/vnd.ms-powerpoint
         - application/vnd.openxmlformats-officedocument.presentationml.presentation
+    cleanup:
+      retention-days: 7
+      chunk-size: 100
+      cron: "0 0 3 * * *"
   post:
     draft-expiration-minutes: 60

--- a/src/main/resources/static/site.webmanifest
+++ b/src/main/resources/static/site.webmanifest
@@ -1,7 +1,22 @@
 {
   "name": "금정열린배움터 관리자",
   "short_name": "금정야학",
+  "description": "금정열린배움터 관리자 콘솔",
+  "start_url": "/admin",
+  "scope": "/",
   "icons": [
+    {
+      "src": "/icons/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/icons/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
     {
       "src": "/icons/geumjeongyahak-icon.svg",
       "sizes": "any",
@@ -11,5 +26,6 @@
   ],
   "theme_color": "#89ca6b",
   "background_color": "#ffffff",
-  "display": "standalone"
+  "display": "standalone",
+  "orientation": "portrait-primary"
 }

--- a/src/main/resources/static/sw.js
+++ b/src/main/resources/static/sw.js
@@ -1,0 +1,46 @@
+const CACHE_NAME = 'sonmoum-admin-static-v1';
+const STATIC_ASSETS = [
+  '/site.webmanifest',
+  '/icons/geumjeongyahak-icon.svg',
+  '/icons/android-chrome-192x192.png',
+  '/icons/android-chrome-512x512.png',
+  '/icons/apple-touch-icon.png',
+  '/icons/favicon-32x32.png',
+  '/icons/favicon-16x16.png'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then((cache) => cache.addAll(STATIC_ASSETS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys()
+      .then((keys) => Promise.all(keys
+        .filter((key) => key !== CACHE_NAME)
+        .map((key) => caches.delete(key))))
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const request = event.request;
+  const url = new URL(request.url);
+
+  if (request.method !== 'GET' || url.origin !== self.location.origin) {
+    return;
+  }
+
+  if (!STATIC_ASSETS.includes(url.pathname)) {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(request)
+      .then((cached) => cached || fetch(request))
+  );
+});

--- a/src/main/resources/templates/admin/auth/login.html
+++ b/src/main/resources/templates/admin/auth/login.html
@@ -3,9 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#89ca6b">
     <title>관리자 로그인 | 금정열린배움터</title>
     <link rel="icon" type="image/svg+xml" th:href="@{/icons/geumjeongyahak-icon.svg}">
-    <link rel="apple-touch-icon" th:href="@{/icons/geumjeongyahak-icon.svg}">
+    <link rel="apple-touch-icon" th:href="@{/icons/apple-touch-icon.png}">
     <link rel="manifest" th:href="@{/site.webmanifest}">
     <style>
         :root {
@@ -110,5 +111,12 @@
     <div class="message error" th:if="${param.denied}">관리자 페이지 접근 권한이 없습니다.</div>
     <div class="message success" th:if="${param.logout}">로그아웃되었습니다.</div>
 </main>
+<script>
+if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/sw.js').catch(() => {});
+    });
+}
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -11,10 +11,14 @@
             </div>
         </div>
 
-        <section class="metric-grid">
+        <section class="metric-grid dashboard-swipe swipe-grid">
             <a class="metric" th:href="@{/admin/user/users}">
                 <span>사용자</span>
                 <strong th:text="${summary.userCount}">0</strong>
+            </a>
+            <a class="metric" th:href="@{/admin/student/students}">
+                <span>학생</span>
+                <strong th:text="${summary.studentCount}">0</strong>
             </a>
             <a class="metric" th:href="@{/admin/department/departments}">
                 <span>부서</span>
@@ -30,15 +34,19 @@
             </a>
         </section>
 
-        <div class="grid-2" style="grid-template-columns: 1fr 1fr; gap: 24px;">
+        <div class="dashboard-grid">
             <section class="panel">
                 <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 20px;">
                     <h2 style="margin: 0;">사용자 및 권한 관리</h2>
                 </div>
-                <div class="metric-grid" style="grid-template-columns: 1fr 1fr;">
+                <div class="dashboard-card-grid">
                     <a class="metric" th:href="@{/admin/user/users}">
                         <span>사용자 관리</span>
                         <p style="font-size: 13px; margin: 4px 0 0;">전체 사용자 및 권한 조회/수정</p>
+                    </a>
+                    <a class="metric" th:href="@{/admin/student/students}">
+                        <span>학생 관리</span>
+                        <p style="font-size: 13px; margin: 4px 0 0;">학생 정보와 소속 분반 관리</p>
                     </a>
                     <a class="metric" th:href="@{/admin/department/departments}">
                         <span>부서 관리</span>
@@ -51,7 +59,7 @@
                 <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 20px;">
                     <h2 style="margin: 0;">게시판 및 교육 운영</h2>
                 </div>
-                <div class="metric-grid" style="grid-template-columns: 1fr 1fr;">
+                <div class="dashboard-card-grid">
                     <a class="metric" th:href="@{/admin/channel/channels}">
                         <span>채널 관리</span>
                         <p style="font-size: 13px; margin: 4px 0 0;">소통 채널 및 게시판 설정</p>
@@ -72,7 +80,7 @@
             <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 20px;">
                 <h2 style="margin: 0;">결재 및 행정 지원</h2>
             </div>
-            <div class="metric-grid">
+            <div class="metric-grid dashboard-swipe swipe-grid">
                 <a class="metric" th:href="@{/admin/request/purchase/purchase-requests}">
                     <span>전체 구매 요청</span>
                     <p style="font-size: 13px; margin: 4px 0 0;">물품 구매 요청 이력 확인</p>

--- a/src/main/resources/templates/admin/fragments/layout.html
+++ b/src/main/resources/templates/admin/fragments/layout.html
@@ -3,9 +3,10 @@
 <head th:fragment="head(title)">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#89ca6b">
     <title th:text="${title} + ' | 금정열린배움터 관리자'">관리자 | 금정열린배움터</title>
     <link rel="icon" type="image/svg+xml" th:href="@{/icons/geumjeongyahak-icon.svg}">
-    <link rel="apple-touch-icon" th:href="@{/icons/geumjeongyahak-icon.svg}">
+    <link rel="apple-touch-icon" th:href="@{/icons/apple-touch-icon.png}">
     <link rel="manifest" th:href="@{/site.webmanifest}">
     <style>
         :root {
@@ -19,6 +20,7 @@
             --green-dark: #4f9d34;
             --danger: #c0473b;
             --warning: #b77a1c;
+            --mobile-content-min: 360px;
         }
         * { box-sizing: border-box; }
         body {
@@ -122,6 +124,19 @@
         }
         .metric span { display: block; color: var(--muted); font-weight: 800; }
         .metric strong { display: block; margin-top: 10px; font-size: 34px; line-height: 1; }
+        .dashboard-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 24px;
+        }
+        .dashboard-card-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 14px;
+        }
+        .swipe-grid {
+            min-width: 0;
+        }
         .form-grid { display: grid; gap: 10px; }
         .filter-grid {
             display: grid;
@@ -278,6 +293,9 @@
             border: 1px solid var(--line);
             border-radius: 6px;
             color: #4f5953;
+            line-height: 1.35;
+            white-space: normal;
+            overflow-wrap: anywhere;
         }
         .status-PENDING { background: #fff6df; color: var(--warning); }
         .status-APPROVED { background: #edf8e8; color: var(--green-dark); }
@@ -317,9 +335,82 @@
         @media (max-width: 980px) {
             .shell { grid-template-columns: 1fr; }
             aside { border-right: 0; border-bottom: 1px solid var(--line); }
+            nav {
+                display: flex;
+                gap: 8px;
+                overflow-x: auto;
+                padding-bottom: 4px;
+                scrollbar-width: thin;
+            }
+            nav a { flex: 0 0 auto; }
             .content { padding: 20px 16px; }
-            .metric-grid, .grid-2 { grid-template-columns: 1fr; }
+            .metric-grid, .grid-2, .dashboard-grid { grid-template-columns: 1fr; }
             .filter-grid { grid-template-columns: 1fr; }
+        }
+        @media (max-width: 720px) {
+            body {
+                overflow-x: hidden;
+            }
+            .content {
+                overflow-x: auto;
+                overscroll-behavior-x: contain;
+                scrollbar-width: thin;
+            }
+            .content > .topline,
+            .content > .flash,
+            .content > main,
+            .content > form,
+            .content > section {
+                min-width: var(--mobile-content-min);
+            }
+            .page-title {
+                align-items: stretch;
+                flex-direction: column;
+            }
+            h1 { font-size: 26px; }
+            .metric-grid.dashboard-swipe {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+            }
+            .dashboard-card-grid {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+            }
+            .swipe-grid {
+                display: grid;
+                grid-auto-columns: minmax(172px, calc((var(--mobile-content-min) - 12px) / 2));
+                grid-auto-flow: column;
+                grid-template-columns: none !important;
+                gap: 12px;
+                overflow-x: auto;
+                padding-bottom: 8px;
+                scroll-snap-type: x proximity;
+                scrollbar-width: thin;
+            }
+            .swipe-grid > .metric {
+                scroll-snap-align: start;
+                min-width: 0;
+            }
+            .metric {
+                padding: 16px;
+            }
+            .metric span {
+                line-height: 1.35;
+                white-space: normal;
+                overflow-wrap: keep-all;
+            }
+            .metric strong { font-size: 30px; }
+            .pill {
+                max-width: 100%;
+                justify-content: center;
+                line-height: 1.35;
+                white-space: normal;
+                overflow-wrap: anywhere;
+                text-align: center;
+            }
+            .detail-grid { grid-template-columns: 1fr; }
+            .inline-form {
+                align-items: stretch;
+                flex-direction: column;
+            }
         }
     </style>
 </head>
@@ -336,6 +427,7 @@
         <nav>
             <a th:href="@{/admin}" th:classappend="${active == 'dashboard'} ? 'active'">대시보드</a>
             <a th:href="@{/admin/user/users}" th:classappend="${active == 'users'} ? 'active'">사용자</a>
+            <a th:href="@{/admin/student/students}" th:classappend="${active == 'students'} ? 'active'">학생</a>
             <a th:href="@{/admin/channel/channels}" th:classappend="${active == 'channels'} ? 'active'">채널</a>
             <a th:href="@{/admin/post/posts}" th:classappend="${active == 'posts'} ? 'active'">게시글</a>
             <a th:href="@{/admin/department/departments}" th:classappend="${active == 'departments'} ? 'active'">부서</a>
@@ -359,6 +451,12 @@
         <th:block th:replace="${content}"></th:block>
     </div>
     <script>
+if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/sw.js').catch(() => {});
+    });
+}
+
 document.querySelectorAll('.permission-form').forEach((form) => {
     const permissionSelect = form.querySelector('select[name="permissionKey"]');
     const scopeSelect = form.querySelector('select[name="scopeTarget"]');

--- a/src/main/resources/templates/admin/student/students-detail.html
+++ b/src/main/resources/templates/admin/student/students-detail.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/layout :: head('학생 상세')}"></head>
+<body>
+<div th:replace="~{admin/fragments/layout :: shell(~{::main})}">
+    <main class="stack">
+        <div class="page-title">
+            <div>
+                <h1 th:text="${student.name}">학생</h1>
+                <p th:text="${student.description ?: '등록된 설명이 없습니다.'}">설명</p>
+            </div>
+            <div class="inline-form">
+                <a class="button secondary" th:href="@{/admin/student/students/{studentId}/edit(studentId=${student.id})}">수정</a>
+                <form th:action="@{/admin/student/students/{studentId}/delete(studentId=${student.id})}" method="post" onsubmit="return confirm('이 학생을 삭제하시겠습니까?');">
+                    <button class="button danger" type="submit">삭제</button>
+                </form>
+            </div>
+        </div>
+        <section class="panel detail-grid">
+            <div class="detail-item"><span>ID</span><strong th:text="${student.id}">1</strong></div>
+            <div class="detail-item"><span>상태</span><strong><span class="pill" th:text="${student.status}">ENROLLED</span></strong></div>
+            <div class="detail-item"><span>연락처</span><strong th:text="${student.phoneNumber ?: '-'}">010</strong></div>
+            <div class="detail-item"><span>분반</span><strong><a class="link" th:href="@{/admin/classroom/classrooms/{classroomId}(classroomId=${student.classroomId})}" th:text="${student.classroomName}">벚꽃반</a></strong></div>
+            <div class="detail-item" style="grid-column: 1 / -1;"><span>설명</span><strong th:text="${student.description ?: '-'}">설명</strong></div>
+        </section>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/student/students-edit.html
+++ b/src/main/resources/templates/admin/student/students-edit.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/layout :: head('학생 수정')}"></head>
+<body>
+<div th:replace="~{admin/fragments/layout :: shell(~{::main})}">
+    <main class="stack">
+        <div class="page-title">
+            <div>
+                <h1>학생 수정</h1>
+                <p th:text="${student.name}">학생</p>
+            </div>
+        </div>
+        <form class="panel form-grid" th:action="@{/admin/student/students/{studentId}(studentId=${student.id})}" method="post">
+            <label>이름 <input name="name" th:value="${student.name}" maxlength="50" required></label>
+            <label>연락처 <input name="phoneNumber" th:value="${student.phoneNumber}" placeholder="010-1234-5678"></label>
+            <label>상태
+                <select name="status" required>
+                    <option th:each="status : ${studentStatuses}" th:value="${status.name()}" th:text="${status.name()}" th:selected="${student.status == status.name()}">ENROLLED</option>
+                </select>
+            </label>
+            <label>분반
+                <select name="classroomId" required>
+                    <option th:each="classroom : ${classrooms}" th:value="${classroom.id}" th:text="${classroom.name}" th:selected="${student.classroomId == classroom.id}">분반</option>
+                </select>
+            </label>
+            <label>설명 <textarea name="description" th:text="${student.description}"></textarea></label>
+            <button class="button" type="submit">수정</button>
+        </form>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/student/students-form.html
+++ b/src/main/resources/templates/admin/student/students-form.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/layout :: head('학생 등록')}"></head>
+<body>
+<div th:replace="~{admin/fragments/layout :: shell(~{::main})}">
+    <main class="stack">
+        <div class="page-title">
+            <div>
+                <h1>학생 등록</h1>
+                <p>신규 학생의 기본 정보와 소속 분반을 등록합니다.</p>
+            </div>
+        </div>
+        <form class="panel form-grid" th:action="@{/admin/student/students}" method="post">
+            <label>이름 <input name="name" maxlength="50" required></label>
+            <label>연락처 <input name="phoneNumber" placeholder="010-1234-5678"></label>
+            <label>분반
+                <select name="classroomId" required>
+                    <option th:each="classroom : ${classrooms}" th:value="${classroom.id}" th:text="${classroom.name}">분반</option>
+                </select>
+            </label>
+            <label>설명 <textarea name="description"></textarea></label>
+            <button class="button" type="submit">등록</button>
+        </form>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/student/students.html
+++ b/src/main/resources/templates/admin/student/students.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/layout :: head('학생 관리')}"></head>
+<body>
+<div th:replace="~{admin/fragments/layout :: shell(~{::main})}">
+    <main class="stack">
+        <div class="page-title">
+            <div>
+                <h1>학생</h1>
+                <p>이름, 상태, 소속 분반 기준으로 학생 정보를 조회합니다.</p>
+            </div>
+            <a class="button" th:href="@{/admin/student/students/new}">학생 등록</a>
+        </div>
+
+        <form class="panel filter-grid" th:action="@{/admin/student/students}" method="get">
+            <label>검색어
+                <input name="name" th:value="${filter.name}" placeholder="학생 이름">
+            </label>
+            <label>상태
+                <select name="status">
+                    <option value="">전체</option>
+                    <option th:each="status : ${studentStatuses}" th:value="${status.name()}" th:text="${status.name()}" th:selected="${filter.status == status}">ENROLLED</option>
+                </select>
+            </label>
+            <label>분반
+                <select name="classroomId">
+                    <option value="">전체</option>
+                    <option th:each="classroom : ${classrooms}" th:value="${classroom.id}" th:text="${classroom.name}" th:selected="${filter.classroomId == classroom.id}">분반</option>
+                </select>
+            </label>
+            <label>페이지 크기
+                <select name="size">
+                    <option value="10" th:selected="${studentsPage.size == 10}">10</option>
+                    <option value="20" th:selected="${studentsPage.size == 20}">20</option>
+                    <option value="50" th:selected="${studentsPage.size == 50}">50</option>
+                    <option value="100" th:selected="${studentsPage.size == 100}">100</option>
+                </select>
+            </label>
+            <label>정렬
+                <select name="sort">
+                    <option value="name,ASC" th:selected="${filter.sort == null || filter.sort == 'name,ASC'}">이름 오름차순</option>
+                    <option value="name,DESC" th:selected="${filter.sort == 'name,DESC'}">이름 내림차순</option>
+                    <option value="classroomName,ASC" th:selected="${filter.sort == 'classroomName,ASC'}">분반 오름차순</option>
+                    <option value="status,ASC" th:selected="${filter.sort == 'status,ASC'}">상태 오름차순</option>
+                    <option value="id,DESC" th:selected="${filter.sort == 'id,DESC'}">최근 등록순</option>
+                </select>
+            </label>
+            <button class="button" type="submit">조회</button>
+            <a class="reset-link" th:href="@{/admin/student/students}">초기화</a>
+        </form>
+
+        <section class="panel table-panel">
+            <div class="table-scroll">
+                <table>
+                    <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>이름</th>
+                        <th>상태</th>
+                        <th>분반</th>
+                        <th>연락처</th>
+                        <th>설명</th>
+                        <th>운영</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="student : ${studentsPage.content}">
+                        <td th:text="${student.id}">1</td>
+                        <td><a class="link" th:href="@{/admin/student/students/{studentId}(studentId=${student.id})}" th:text="${student.name}">홍길동</a></td>
+                        <td><span class="pill" th:text="${student.status}">ENROLLED</span></td>
+                        <td><a class="link" th:href="@{/admin/classroom/classrooms/{classroomId}(classroomId=${student.classroomId})}" th:text="${student.classroomName}">벚꽃반</a></td>
+                        <td th:text="${student.phoneNumber ?: '-'}">010</td>
+                        <td th:text="${student.description ?: '-'}">비고</td>
+                        <td><a class="button secondary" th:href="@{/admin/student/students/{studentId}(studentId=${student.id})}">상세</a></td>
+                    </tr>
+                    <tr th:if="${#lists.isEmpty(studentsPage.content)}">
+                        <td colspan="7" class="empty">등록된 학생이 없습니다.</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+            <div class="pager">
+                <span th:text="|총 ${studentsPage.totalElements}명 · ${studentsPage.page + 1}/${studentsPage.totalPages == 0 ? 1 : studentsPage.totalPages} 페이지|">총 0명</span>
+                <div>
+                    <a class="reset-link" th:classappend="${!studentsPage.hasPrevious()} ? 'disabled'" th:href="@{/admin/student/students(name=${filter.name},status=${filter.status},classroomId=${filter.classroomId},size=${studentsPage.size},sort=${filter.sort},page=${studentsPage.previousPage()})}">이전</a>
+                    <a class="reset-link" th:classappend="${!studentsPage.hasNext()} ? 'disabled'" th:href="@{/admin/student/students(name=${filter.name},status=${filter.status},classroomId=${filter.classroomId},size=${studentsPage.size},sort=${filter.sort},page=${studentsPage.nextPage()})}">다음</a>
+                </div>
+            </div>
+        </section>
+    </main>
+</div>
+</body>
+</html>

--- a/src/test/java/geumjeongyahak/e2e/TestStorageConfig.java
+++ b/src/test/java/geumjeongyahak/e2e/TestStorageConfig.java
@@ -1,6 +1,8 @@
 package geumjeongyahak.e2e;
 
 import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 import org.springframework.boot.test.context.TestConfiguration;
@@ -25,40 +27,52 @@ public class TestStorageConfig {
 
     @Bean
     @Primary
-    StorageService testStorageService() {
-        return new StorageService() {
-            private static final String TEST_BUCKET = "test-bucket";
+    ControlledStorageService testStorageService() {
+        return new ControlledStorageService();
+    }
 
-            @Override
-            public StoredFile upload(MultipartFile file, String directory) {
-                return upload(
-                    new byte[0],
-                    file.getContentType(),
-                    file.getOriginalFilename(),
-                    directory
-                );
-            }
+    public static class ControlledStorageService implements StorageService {
+        private static final String TEST_BUCKET = "test-bucket";
+        private final Set<String> failDeletePaths = new HashSet<>();
 
-            @Override
-            public StoredFile upload(byte[] content, String contentType, String originalFilename, String directory) {
-                String safeName = originalFilename == null ? "file" : originalFilename.replace(" ", "_");
-                String path = directory + "/" + UUID.randomUUID() + "-" + safeName;
-                return new StoredFile(path, TEST_BUCKET, getPublicUrl(path));
-            }
+        public void failDeleteFor(String path) {
+            failDeletePaths.add(path);
+        }
 
-            @Override
-            public void delete(String path) {
-            }
+        public void resetFailPaths() {
+            failDeletePaths.clear();
+        }
 
-            @Override
-            public String getPublicUrl(String path) {
-                return "https://test-storage.local/" + TEST_BUCKET + "/" + path;
-            }
+        @Override
+        public StoredFile upload(MultipartFile file, String directory) {
+            return upload(
+                new byte[0],
+                file.getContentType(),
+                file.getOriginalFilename(),
+                directory
+            );
+        }
 
-            @Override
-            public String generateDownloadUrl(String path, Duration duration) {
-                return "https://test-storage.local/" + TEST_BUCKET + "/" + path + "?expires=" + duration.toMinutes();
-            }
-        };
+        @Override
+        public StoredFile upload(byte[] content, String contentType, String originalFilename, String directory) {
+            String safeName = originalFilename == null ? "file" : originalFilename.replace(" ", "_");
+            String path = directory + "/" + UUID.randomUUID() + "-" + safeName;
+            return new StoredFile(path, TEST_BUCKET, getPublicUrl(path));
+        }
+
+        @Override
+        public boolean delete(String path) {
+            return !failDeletePaths.contains(path);
+        }
+
+        @Override
+        public String getPublicUrl(String path) {
+            return "https://test-storage.local/" + TEST_BUCKET + "/" + path;
+        }
+
+        @Override
+        public String generateDownloadUrl(String path, Duration duration) {
+            return "https://test-storage.local/" + TEST_BUCKET + "/" + path + "?expires=" + duration.toMinutes();
+        }
     }
 }

--- a/src/test/java/geumjeongyahak/e2e/post/FileDeleteFlowTest.java
+++ b/src/test/java/geumjeongyahak/e2e/post/FileDeleteFlowTest.java
@@ -1,0 +1,160 @@
+package geumjeongyahak.e2e.post;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import geumjeongyahak.domain.file.entity.File;
+import geumjeongyahak.domain.file.repository.FileRepository;
+import geumjeongyahak.domain.file.service.FileCleanupScheduler;
+import geumjeongyahak.domain.post.repository.PostAttachmentRepository;
+import geumjeongyahak.domain.post.repository.PostFileRepository;
+import geumjeongyahak.e2e.TestStorageConfig;
+
+@DisplayName("E2E: 파일 삭제 플로우 테스트")
+@ResourceLock("post-e2e-shared-state")
+class FileDeleteFlowTest extends BasePostTest {
+
+    @Autowired
+    private FileRepository fileRepository;
+
+    @Autowired
+    private PostFileRepository postFileRepository;
+
+    @Autowired
+    private PostAttachmentRepository postAttachmentRepository;
+
+    @Autowired
+    private FileCleanupScheduler fileCleanupScheduler;
+
+    @Autowired
+    private TestStorageConfig.ControlledStorageService controlledStorageService;
+
+    @AfterEach
+    void resetStorage() {
+        controlledStorageService.resetFailPaths();
+    }
+
+    @Test
+    @DisplayName("게시글 삭제 시 해당 게시글에만 연결된 이미지 File이 soft delete된다")
+    void deletePost_softDeletesOrphanImageFile() {
+        Long postId = testPostHelper.createDraftAndRegister(noticeChannelId, adminAccessToken);
+
+        String fileIdStr = given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .multiPart(testFileHelper.multipartImageRequest("file", "test.png"))
+        .when()
+            .post("/api/v1/channels/{channelId}/posts/{postId}/images", noticeChannelId, postId)
+        .then()
+            .statusCode(200)
+            .extract().jsonPath().getString("fileId");
+        UUID fileId = UUID.fromString(fileIdStr);
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+        .when()
+            .delete("/api/v1/channels/{channelId}/posts/{postId}", noticeChannelId, postId)
+        .then()
+            .statusCode(204);
+
+        File file = fileRepository.findById(fileId).orElseThrow();
+        assertThat(file.isDeleted()).isTrue();
+        assertThat(file.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("게시글 삭제 시 첨부파일 File도 soft delete된다")
+    void deletePost_softDeletesOrphanAttachmentFile() {
+        Long postId = testPostHelper.createDraftAndRegister(noticeChannelId, adminAccessToken);
+
+        String fileIdStr = given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .multiPart(testFileHelper.multipartAttachmentRequest("file", "doc.pdf"))
+        .when()
+            .post("/api/v1/channels/{channelId}/posts/{postId}/attachments", noticeChannelId, postId)
+        .then()
+            .statusCode(200)
+            .extract().jsonPath().getString("fileId");
+        UUID fileId = UUID.fromString(fileIdStr);
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+        .when()
+            .delete("/api/v1/channels/{channelId}/posts/{postId}", noticeChannelId, postId)
+        .then()
+            .statusCode(204);
+
+        File file = fileRepository.findById(fileId).orElseThrow();
+        assertThat(file.isDeleted()).isTrue();
+        assertThat(file.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("다른 게시글에서도 참조 중인 File은 soft delete되지 않는다")
+    void deletePost_doesNotSoftDelete_sharedFile() {
+        Long post1Id = testPostHelper.createDraftAndRegister(noticeChannelId, adminAccessToken);
+        Long post2Id = testPostHelper.createDraftAndRegister(noticeChannelId, adminAccessToken);
+
+        String fileIdStr = given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .multiPart(testFileHelper.multipartImageRequest("file", "shared.png"))
+        .when()
+            .post("/api/v1/channels/{channelId}/posts/{postId}/images", noticeChannelId, post1Id)
+        .then()
+            .statusCode(200)
+            .extract().jsonPath().getString("fileId");
+        UUID fileId = UUID.fromString(fileIdStr);
+
+        // post2에서도 같은 File을 참조하도록 직접 연결
+        testFileHelper.linkFileToPost(post2Id, fileId);
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+        .when()
+            .delete("/api/v1/channels/{channelId}/posts/{postId}", noticeChannelId, post1Id)
+        .then()
+            .statusCode(204);
+
+        File file = fileRepository.findById(fileId).orElseThrow();
+        assertThat(file.isDeleted()).isFalse();
+        assertThat(file.getDeletedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("스케줄러 실행 시 storage 삭제 성공 파일의 PostFile/PostAttachment/File 레코드가 hard delete된다")
+    void cleanupScheduler_hardDeletesRecordsOnStorageSuccess() {
+        Long postId = testPostHelper.createDraftAndRegister(noticeChannelId, adminAccessToken);
+        UUID fileId = testFileHelper.createOrphanedFile(LocalDateTime.now().minusDays(8));
+        testFileHelper.linkFileToPost(postId, fileId);
+        testFileHelper.linkAttachmentToPost(postId, fileId);
+
+        fileCleanupScheduler.cleanupDeletedFiles();
+
+        assertThat(fileRepository.findById(fileId)).isEmpty();
+        assertThat(postFileRepository.findFileIdsByPostId(postId)).doesNotContain(fileId);
+        assertThat(postAttachmentRepository.findFileIdsByPostId(postId)).doesNotContain(fileId);
+    }
+
+    @Test
+    @DisplayName("스케줄러 실행 시 storage 삭제 실패 파일은 DB 레코드가 유지된다")
+    void cleanupScheduler_keepsDbRecordsOnStorageFailure() {
+        Long postId = testPostHelper.createDraftAndRegister(noticeChannelId, adminAccessToken);
+        String failPath = "test/orphan/fail-" + UUID.randomUUID() + ".pdf";
+        UUID fileId = testFileHelper.createOrphanedFileWithKey(LocalDateTime.now().minusDays(8), failPath);
+        testFileHelper.linkAttachmentToPost(postId, fileId);
+
+        controlledStorageService.failDeleteFor(failPath);
+        fileCleanupScheduler.cleanupDeletedFiles();
+
+        assertThat(fileRepository.findById(fileId)).isPresent();
+        assertThat(postAttachmentRepository.findFileIdsByPostId(postId)).contains(fileId);
+    }
+}

--- a/src/test/java/geumjeongyahak/e2e/post/PostFileTest.java
+++ b/src/test/java/geumjeongyahak/e2e/post/PostFileTest.java
@@ -1,17 +1,28 @@
 package geumjeongyahak.e2e.post;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+
+import java.util.UUID;
 
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import geumjeongyahak.domain.file.entity.File;
+import geumjeongyahak.domain.file.repository.FileRepository;
 import geumjeongyahak.domain.post.v1.dto.request.PublishPostRequest;
+import geumjeongyahak.domain.post.v1.dto.request.SaveDraftRequest;
 
 @DisplayName("E2E: Post 파일 및 썸네일 테스트")
 @ResourceLock("post-e2e-shared-state")
 class PostFileTest extends BasePostTest {
+
+    @Autowired
+    private FileRepository fileRepository;
 
     @Test
     @DisplayName("이미지를 업로드하면 발행 시 첫 번째 이미지가 자동으로 썸네일이 된다")
@@ -41,7 +52,7 @@ class PostFileTest extends BasePostTest {
         given()
             .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
             .contentType(ContentType.JSON)
-            .body(new PublishPostRequest("자동 썸네일 테스트", "본문", true, null))
+            .body(new PublishPostRequest("자동 썸네일 테스트", imageTag(imageUrl1), true, null))
         .when()
             .put("/api/v1/channels/{channelId}/posts/{postId}/publish", noticeChannelId, postId)
         .then()
@@ -64,5 +75,47 @@ class PostFileTest extends BasePostTest {
         .then()
             .statusCode(200)
             .body("thumbnailUrl", equalTo(customThumbnail));
+    }
+
+    @Test
+    @DisplayName("초안 저장 시 본문 HTML에서 제거된 이미지는 soft delete된다")
+    void saveDraft_softDeletesImageRemovedFromContentHtml() {
+        Long postId = testPostHelper.createDraftAndRegister(noticeChannelId, adminAccessToken);
+
+        String imageUrl = given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .multiPart(testFileHelper.multipartImageRequest("file", "used.png"))
+        .when()
+            .post("/api/v1/channels/{channelId}/posts/{postId}/images", noticeChannelId, postId)
+        .then()
+            .statusCode(200)
+            .extract().jsonPath().getString("url");
+
+        String removedFileIdStr = given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .multiPart(testFileHelper.multipartImageRequest("file", "removed.png"))
+        .when()
+            .post("/api/v1/channels/{channelId}/posts/{postId}/images", noticeChannelId, postId)
+        .then()
+            .statusCode(200)
+            .extract().jsonPath().getString("fileId");
+        UUID removedFileId = UUID.fromString(removedFileIdStr);
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .contentType(ContentType.JSON)
+            .body(new SaveDraftRequest("미사용 이미지 정리 테스트", imageTag(imageUrl), true, null))
+        .when()
+            .put("/api/v1/channels/{channelId}/posts/{postId}/draft", noticeChannelId, postId)
+        .then()
+            .statusCode(200);
+
+        File removedFile = fileRepository.findById(removedFileId).orElseThrow();
+        assertThat(removedFile.isDeleted()).isTrue();
+        assertThat(removedFile.getDeletedAt()).isNotNull();
+    }
+
+    private String imageTag(String imageUrl) {
+        return "<p>본문</p><img src=\"" + imageUrl + "\" alt=\"image\">";
     }
 }

--- a/src/test/java/geumjeongyahak/e2e/util/TestFileHelper.java
+++ b/src/test/java/geumjeongyahak/e2e/util/TestFileHelper.java
@@ -3,10 +3,18 @@ package geumjeongyahak.e2e.util;
 import io.restassured.builder.MultiPartSpecBuilder;
 import io.restassured.specification.MultiPartSpecification;
 import org.springframework.stereotype.Service;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
+import geumjeongyahak.domain.file.entity.File;
 import geumjeongyahak.domain.file.repository.FileRepository;
+import geumjeongyahak.domain.post.entity.PostAttachment;
+import geumjeongyahak.domain.post.entity.PostFile;
 import geumjeongyahak.domain.post.repository.PostAttachmentRepository;
 import geumjeongyahak.domain.post.repository.PostFileRepository;
+import geumjeongyahak.domain.post.repository.PostRepository;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Service
 @Transactional
@@ -14,14 +22,17 @@ public class TestFileHelper {
     private final FileRepository fileRepository;
     private final PostFileRepository postFileRepository;
     private final PostAttachmentRepository postAttachmentRepository;
+    private final PostRepository postRepository;
 
     public TestFileHelper(
             FileRepository fileRepository,
             PostFileRepository postFileRepository,
-            PostAttachmentRepository postAttachmentRepository) {
+            PostAttachmentRepository postAttachmentRepository,
+            PostRepository postRepository) {
         this.fileRepository = fileRepository;
         this.postFileRepository = postFileRepository;
         this.postAttachmentRepository = postAttachmentRepository;
+        this.postRepository = postRepository;
     }
 
     public MultiPartSpecification multipartImageRequest(String fieldName, String filename) {
@@ -38,6 +49,40 @@ public class TestFileHelper {
                 .fileName(filename)
                 .mimeType("application/pdf")
                 .build();
+    }
+
+    public UUID createOrphanedFile(LocalDateTime deletedAt) {
+        return createOrphanedFileWithKey(deletedAt, "test/orphan/" + UUID.randomUUID() + ".pdf");
+    }
+
+    public UUID createOrphanedFileWithKey(LocalDateTime deletedAt, String storageKey) {
+        File file = File.builder()
+                .storageKey(storageKey)
+                .bucket("test-bucket")
+                .originalName("orphan.pdf")
+                .contentType("application/pdf")
+                .fileSize(1024L)
+                .ext("pdf")
+                .publicUrl("https://test-storage.local/test-bucket/" + storageKey)
+                .build();
+        file.delete();
+        fileRepository.save(file);
+        ReflectionTestUtils.setField(file, "deletedAt", deletedAt);
+        return fileRepository.save(file).getId();
+    }
+
+    public void linkFileToPost(Long postId, UUID fileId) {
+        postFileRepository.save(PostFile.builder()
+                .post(postRepository.getReferenceById(postId))
+                .file(fileRepository.getReferenceById(fileId))
+                .build());
+    }
+
+    public void linkAttachmentToPost(Long postId, UUID fileId) {
+        postAttachmentRepository.save(PostAttachment.builder()
+                .post(postRepository.getReferenceById(postId))
+                .file(fileRepository.getReferenceById(fileId))
+                .build());
     }
 
     public void clearAll() {


### PR DESCRIPTION
## 개요

게시글 삭제 시 더 이상 참조되지 않는 이미지/첨부 파일을 안전하게 soft delete하고, 보관 기간이 지난 삭제 파일은 storage 삭제 성공 여부에 따라 DB 레코드까지 hard delete하는 파일 삭제 플로우를 추가합니다.

추가로 학생 도메인의 관리자 웹 화면을 제공해 관리자 콘솔에서 학생 목록 조회, 등록, 상세 조회, 수정, 삭제를 수행할 수 있도록 합니다.

관리자 콘솔은 모바일 화면에서 일정 폭까지 축소된 뒤 가로 스와이프가 가능하도록 개선하고, PWA 설치를 위한 manifest/service worker 기본 구성을 추가합니다.

## 변경 유형

- [x] 새 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 문서 수정 (docs)
- [x] 테스트 (test)
- [ ] 기타 (chore)

## 변경 내용

- 파일 도메인에 storage 삭제 인터페이스와 soft delete/hard delete 처리를 위한 기본 기능을 추가했습니다.
- 게시글 삭제 시 PostFile/PostAttachment가 참조하던 File ID를 수집하고, 다른 게시글에서 계속 참조 중인 파일은 제외한 뒤 고아 파일만 삭제 이벤트로 전달하도록 했습니다.
- 게시글 본문 이미지 정리 서비스를 추가해 수정된 본문에서 더 이상 사용하지 않는 이미지 삭제 요청 이벤트를 발행합니다.
- `PostDeletedEvent`를 수신하는 파일 삭제 핸들러를 추가해 전달된 File ID만 soft delete합니다.
- `FileCleanupScheduler`를 추가해 보관 기간이 지난 soft-deleted File을 chunk 단위로 처리하고, storage 삭제에 성공한 파일만 PostFile, PostAttachment, File 레코드를 hard delete합니다.
- storage 삭제 실패 시 DB 레코드를 유지해 재시도 가능한 상태로 남깁니다.
- 파일 삭제 플로우 E2E 테스트를 추가해 이미지/첨부 파일 soft delete, 공유 파일 보존, scheduler hard delete 성공/실패 케이스를 검증했습니다.
- 테스트용 storage service를 제어 가능하게 확장해 삭제 실패 시나리오를 재현할 수 있도록 했습니다.
- 학생 관리자 화면을 추가해 관리자 콘솔에서 학생 조회, 필터링, 정렬, 등록, 상세 조회, 수정, 삭제를 지원합니다.
- 관리자 대시보드와 공통 레이아웃을 모바일에서 일정 폭까지 축소 후 가로 스와이프 가능하도록 조정했습니다.
- 관리자 콘솔에 PWA manifest, PNG 아이콘 참조, service worker 등록, `/sw.js` 정적 리소스 접근 허용을 추가했습니다.

## 세부 플로우

### 게시글 삭제 시 고아 파일 soft delete

```mermaid
sequenceDiagram
    actor Admin as 관리자/API 사용자
    participant PostApi as Post API
    participant PostCrud as PostCrudService
    participant PostFile as PostFileRepository
    participant PostAttachment as PostAttachmentRepository
    participant Event as EventPublisher
    participant FileHandler as FileDeleteEventHandler
    participant FileRepo as FileRepository

    Admin->>PostApi: DELETE /api/v1/channels/{channelId}/posts/{postId}
    PostApi->>PostCrud: deletePost(channelId, userDetails, postId)
    PostCrud->>PostFile: findFileIdsByPostId(postId)
    PostCrud->>PostAttachment: findFileIdsByPostId(postId)
    PostCrud->>PostFile: findReferencedFileIdsByFileIdInAndPostIdNot(fileIds, postId)
    PostCrud->>PostAttachment: findReferencedFileIdsByFileIdInAndPostIdNot(fileIds, postId)
    PostCrud->>PostCrud: 다른 게시글 참조 fileId 제외
    PostCrud->>PostCrud: post.delete()
    PostCrud->>Event: publish(PostDeletedEvent(postId, unreferencedFileIds))
    Event->>FileHandler: handle(PostDeletedEvent)
    FileHandler->>FileRepo: findAllByIdInAndIsDeletedFalse(fileIds)
    FileHandler->>FileRepo: File.softDelete()
```

### 게시글 수정 시 미사용 본문 이미지 삭제 요청

```mermaid
sequenceDiagram
    actor Admin as 관리자/API 사용자
    participant PostApi as Post API
    participant PostCrud as PostCrudService
    participant Cleanup as PostContentImageCleanupService
    participant PostFile as PostFileRepository
    participant Event as EventPublisher

    Admin->>PostApi: PATCH/PUT 게시글 수정
    PostApi->>PostCrud: updatePost(...)
    PostCrud->>PostCrud: 게시글 본문/상태 갱신
    PostCrud->>Cleanup: deleteUnusedImages(postId, contentHtml)
    Cleanup->>PostFile: 게시글 연결 이미지 조회
    Cleanup->>Cleanup: contentHtml에 남은 이미지와 비교
    Cleanup->>Event: publish(PostImageDeleteRequestedEvent)
```

### 보관 기간 만료 파일 hard delete scheduler

```mermaid
sequenceDiagram
    participant Scheduler as FileCleanupScheduler
    participant FileRepo as FileRepository
    participant Storage as StorageService
    participant PostFile as PostFileRepository
    participant PostAttachment as PostAttachmentRepository

    Scheduler->>FileRepo: findByIsDeletedTrueAndDeletedAtBefore(threshold)
    loop chunk 단위 처리
        Scheduler->>Storage: delete(storageKey)
        alt storage 삭제 성공
            Scheduler->>PostFile: deleteByFileId(fileId)
            Scheduler->>PostAttachment: deleteByFileId(fileId)
            Scheduler->>FileRepo: delete(file)
        else storage 삭제 실패
            Scheduler->>Scheduler: DB 레코드 유지 및 warn log
        end
    end
```

### 관리자 PWA 설치 리소스 로딩

```mermaid
sequenceDiagram
    actor Admin as 관리자
    participant Browser as Browser
    participant AdminPage as 관리자 HTML
    participant Manifest as site.webmanifest
    participant SW as sw.js
    participant Cache as CacheStorage

    Admin->>Browser: /admin 접속
    Browser->>AdminPage: 관리자 HTML 요청
    AdminPage-->>Browser: manifest 링크, theme-color, service worker 등록 스크립트
    Browser->>Manifest: /site.webmanifest 요청
    Browser->>SW: /sw.js 등록
    SW->>Cache: manifest와 아이콘 정적 리소스 캐시
    Browser->>Admin: 설치 가능한 standalone 앱으로 표시
```

## 커밋 구성

- `24f8b36 feat(file): 파일/스토리지 삭제를 위한 인터페이스 및 기본 도메인 기능 추가`
- `20ec898 feat(post): 게시글 삭제 시 고아 파일 식별 및 삭제 이벤트 발행 로직 추가`
- `75f69e0 feat(file): 고아 파일 자동 정리를 위한 이벤트 핸들러 및 스케줄러 추가`
- `83ce7e6 test(file): 파일 삭제 플로우 E2E 테스트 및 테스트 유틸리티 추가`
- `57cd977 feat(student): 학생 관리자 화면 추가`
- `746852e feat(global): 관리자 PWA 및 모바일 UI 개선`

## 관련 이슈

Closes #50

## 스크린샷 (선택)

- 관리자 학생 화면은 서버 실행 후 `/admin/student/students`에서 확인할 수 있습니다.
- 파일 삭제 플로우는 API/스케줄러 동작 변경이라 별도 스크린샷은 없습니다.
- 관리자 PWA/모바일 UI는 `/admin`, `/admin/auth/login`에서 확인할 수 있습니다.

## 체크리스트

- [x] 코드 컨벤션을 준수했습니다
- [x] 테스트 코드를 작성/수정했습니다
- [x] 컴파일 검증을 통과했습니다
- [x] 문서를 업데이트했습니다

## 검증

- `./gradlew compileJava`
- `./gradlew processResources`
- `./gradlew compileTestJava`

## 리뷰어에게

- 게시글 삭제 시 파일 도메인이 Post 조인 테이블을 직접 조회하지 않고, Post 도메인이 참조 여부를 판단한 뒤 File ID만 이벤트로 넘기는 책임 분리가 의도대로 보이는지 확인해주세요.
- scheduler는 storage 삭제 성공 이후에만 DB hard delete를 수행합니다. 실패 파일을 유지하는 정책이 운영 재시도 방식과 맞는지 확인해주세요.
- 학생 관리자 화면 커밋은 현재 브랜치의 파일 삭제 플로우와 직접 관련은 약합니다. PR 범위를 좁혀야 한다면 별도 PR로 분리하는 편이 좋습니다.
- 관리자 service worker는 인증 화면/API 응답을 캐시하지 않고 manifest/icon 등 정적 설치 리소스만 캐시합니다.
