### PR TITLE
[FEAT] Lesson 도메인 및 API 정리

### DIFF
--- a/docs/api/Lessons.md
+++ b/docs/api/Lessons.md
@@ -2,39 +2,111 @@
 
 수업 일정, 교사 출석, 학생 출석, 수업 노트를 관리합니다.
 
+Lesson은 Subject에서 생성되는 개별 수업 단위입니다. DailySchedule 도입 전까지 학생 출석, 교사 출석, 수업 노트는 현행 Lesson 단위 구조를 유지합니다.
+
 ## 권한 정책
 
 | API | 권한 |
 |-----|------|
-| `GET /api/v1/lessons` | 인증 사용자 |
-| `GET /api/v1/lessons/me` | `VOLUNTEER`, `MANAGER`, `ADMIN` |
-| `GET /api/v1/lessons/{lessonId}` | 담당 봉사자, `MANAGER`, `ADMIN` |
-| `GET /api/v1/lessons/{lessonId}/student-attendances` | 담당 봉사자, `MANAGER`, `ADMIN` |
-| `GET /api/v1/lessons/{lessonId}/note` | 담당 봉사자, `MANAGER`, `ADMIN` |
-| `POST /api/v1/lessons` | `MANAGER`, `ADMIN` |
-| `PATCH /api/v1/lessons/{lessonId}` | `MANAGER`, `ADMIN` |
-| `PATCH /api/v1/lessons/{lessonId}/teacher-attendance` | 담당 봉사자, `MANAGER`, `ADMIN` |
-| `PATCH /api/v1/lessons/{lessonId}/student-attendances` | 담당 봉사자, `MANAGER`, `ADMIN` |
-| `PATCH /api/v1/lessons/{lessonId}/status` | 담당 봉사자, `MANAGER`, `ADMIN` |
-| `PUT /api/v1/lessons/{lessonId}/note` | 담당 봉사자, `MANAGER`, `ADMIN` |
-| `DELETE /api/v1/lessons/{lessonId}` | `MANAGER`, `ADMIN` |
+| `GET /api/v1/lessons` | 전체 공개 |
+| `GET /api/v1/lessons/me` | `VOLUNTEER`, `MANAGER`, `ADMIN`, `lesson:read:*` |
+| `GET /api/v1/lessons/{lessonId}` | 담당 교사, `MANAGER`, `ADMIN`, `lesson:read:*` |
+| `GET /api/v1/lessons/{lessonId}/student-attendances` | 담당 교사, `MANAGER`, `ADMIN`, `lesson:read:*` |
+| `GET /api/v1/lessons/{lessonId}/note` | 담당 교사, `MANAGER`, `ADMIN`, `lesson:read:*` |
+| `POST /api/v1/lessons` | `ADMIN`, `lesson:write:*` |
+| `PATCH /api/v1/lessons/{lessonId}` | `ADMIN`, `lesson:manage:*` |
+| `PATCH /api/v1/lessons/{lessonId}/teacher-attendance` | 담당 교사, `ADMIN`, `lesson:manage:*` |
+| `PATCH /api/v1/lessons/{lessonId}/student-attendances` | 담당 교사, `ADMIN`, `lesson:manage:*` |
+| `PATCH /api/v1/lessons/{lessonId}/status` | `ADMIN`, `lesson:manage:*` |
+| `PUT /api/v1/lessons/{lessonId}/note` | 담당 교사, `ADMIN`, `lesson:manage:*` |
+| `DELETE /api/v1/lessons/{lessonId}` | `ADMIN`, `lesson:manage:*` |
 
-`MANAGER`와 `ADMIN`은 모든 수업에 접근할 수 있습니다. `VOLUNTEER`는 본인이 담당하는 수업에 대해서만 상세 조회, 출석 처리, 상태 변경, 노트 조회/수정이 가능합니다.
+접근 범위:
 
-## 주요 규칙
+- `GET /api/v1/lessons`는 인증 없이 조회할 수 있으며, 응답에는 `teacherName`, `subjectName`이 포함됩니다.
+- `VOLUNTEER`와 `MANAGER`는 본인이 담당 교사인 수업의 출석/노트 변경만 수행할 수 있습니다.
+- `MANAGER`, `ADMIN`, `lesson:read:*` 권한 보유자는 모든 수업의 상세, 출석부, 노트를 조회할 수 있습니다.
+- `ADMIN`, `lesson:manage:*` 권한 보유자는 모든 수업의 수정, 삭제, 출석/노트 변경, 상태 변경을 수행할 수 있습니다.
+- `MANAGER` 역할만으로는 수업 생성/수정/삭제/상태 변경 권한을 갖지 않습니다. 필요한 경우 `lesson:write:*` 또는 `lesson:manage:*` 권한을 별도로 부여합니다.
 
-- 수업 생성/수정/삭제는 운영 관리 작업이므로 `MANAGER` 이상만 수행합니다.
-- 수업 생성/수정 시 담당 교사는 `VOLUNTEER` 역할 사용자여야 합니다.
+## 권한 코드
+
+Lesson 도메인은 다음 권한 코드를 사용합니다.
+
+| 권한 코드 | 설명 |
+|-----------|------|
+| `lesson:read:*` | 모든 수업 상세, 출석부, 노트 조회 |
+| `lesson:write:*` | 수업 직접 생성 |
+| `lesson:manage:*` | 수업 수정, 삭제, 상태 변경, 출석/노트 변경 |
+
+## 조회 정책
+
+- 목록 조회는 `from`, `to` 기간 필터를 사용합니다.
+- 기간은 시작일과 종료일을 모두 포함합니다.
+- 날짜 범위는 최대 31일입니다.
+- `from`은 `to`보다 이후일 수 없습니다.
+- 목록은 수업 날짜 오름차순, 교시 오름차순으로 정렬됩니다.
+- 삭제된 수업은 목록, 상세, 내 수업 조회에서 제외됩니다.
+
+## 생성/수정 정책
+
+- 직접 수업 생성은 `ADMIN` 또는 `lesson:write:*` 권한이 필요합니다.
+- 수업 수정은 `ADMIN` 또는 `lesson:manage:*` 권한이 필요합니다.
+- 수업 생성/수정 시 담당 교사는 `VOLUNTEER`, `MANAGER`, `ADMIN` 역할 사용자만 허용됩니다.
+- 시작 시간은 종료 시간보다 빨라야 합니다.
 - 동일 교사의 같은 날짜 수업 시간이 겹치면 생성/수정이 실패합니다.
-- 수업 삭제는 소프트 삭제로 처리합니다.
+- Subject 기반 자동 Lesson 생성 중 충돌 날짜를 스킵하는 정책은 이번 Lesson API 정리 범위에서 변경하지 않습니다. 해당 정책 개선은 별도 이슈에서 다룹니다.
+
+## 상태 정책
+
+Lesson 상태는 다음 값을 사용합니다.
+
+| 상태 | 설명 |
+|------|------|
+| `SCHEDULED` | 예정 또는 아직 운영 기록이 확정되지 않은 수업 |
+| `COMPLETED` | 운영자가 완료 처리한 수업 |
+| `CANCELED` | 결강 또는 운영상 이유로 취소 처리한 수업 |
+
+일반 상태 변경 API에서는 다음 전이만 허용합니다.
+
+| 현재 상태 | 변경 상태 | 허용 여부 |
+|-----------|-----------|-----------|
+| `SCHEDULED` | `COMPLETED` | 허용 |
+| `SCHEDULED` | `CANCELED` | 허용 |
+| `COMPLETED` | `SCHEDULED` | 금지 |
+| `COMPLETED` | `CANCELED` | 금지 |
+| `CANCELED` | `SCHEDULED` | 금지 |
+| `CANCELED` | `COMPLETED` | 금지 |
+
+같은 상태로 다시 변경하는 요청은 멱등하게 성공 처리합니다.
+
+시간이 지났다는 이유만으로 수업을 자동 완료 처리하지 않습니다. 출석, 노트, 일일 운영 마감 기준의 자동 상태 전이는 향후 DailySchedule 도메인에서 별도로 설계합니다.
+
+## 삭제 정책
+
+- 수업 삭제는 soft delete 방식으로 처리합니다.
+- 이미 삭제된 수업에 다시 삭제 요청을 보내면 멱등하게 성공합니다.
+- 삭제된 수업은 목록/상세/내 수업 조회에서 제외됩니다.
+- 삭제된 수업은 상태, 출석, 노트 변경 대상에서 제외됩니다.
+- 삭제된 수업을 대상으로 내부 이벤트가 들어오면 변경하지 않고 로그를 남긴 뒤 무시합니다.
+
+## 출석/노트 정책
+
+- 학생 출석부와 수업 노트는 DailySchedule 도입 전까지 Lesson 단위로 유지합니다.
+- 교사는 본인이 담당하는 수업의 교사 출석, 학생 출석, 수업 노트를 처리할 수 있습니다.
+- `ADMIN` 또는 `lesson:manage:*` 권한 보유자는 모든 수업의 출석과 노트를 처리할 수 있습니다.
+- `lesson:read:*` 권한은 출석부와 노트 조회에는 사용할 수 있지만, 변경에는 사용할 수 없습니다.
+- 수업 노트는 공백일 수 없습니다.
+- 출석/수업일지의 DailySchedule 이전은 별도 이슈에서 처리합니다.
 
 ## 대표 실패 케이스
 
 | 상황 | HTTP Status |
 |------|-------------|
-| 인증 없이 접근 | `401 Unauthorized` |
-| 권한 없는 사용자가 생성/수정/삭제 시도 | `403 Forbidden` |
-| 담당자가 아닌 봉사자가 타인 수업 상세/출석/노트 접근 | `404 Not Found` |
-| 존재하지 않는 수업 | `404 Not Found` |
+| 인증 없이 보호 API 접근 | `401 Unauthorized` |
+| 권한 없는 사용자가 생성/수정/삭제/상태 변경 시도 | `403 Forbidden` |
+| 담당자가 아닌 교사가 타인 수업 출석/노트 변경 시도 | `404 Not Found` |
+| 존재하지 않거나 삭제된 수업 접근 | `404 Not Found` |
 | 수업 시간이 유효하지 않음 | `400 Bad Request` |
+| 수업 상태 전이가 유효하지 않음 | `400 Bad Request` |
 | 같은 교사의 수업 시간이 겹침 | `409 Conflict` |

--- a/docs/api/Lessons.md
+++ b/docs/api/Lessons.md
@@ -43,10 +43,37 @@ Lesson 도메인은 다음 권한 코드를 사용합니다.
 
 - 목록 조회는 `from`, `to` 기간 필터를 사용합니다.
 - 기간은 시작일과 종료일을 모두 포함합니다.
-- 날짜 범위는 최대 31일입니다.
+- 날짜 범위는 최대 42일입니다.
 - `from`은 `to`보다 이후일 수 없습니다.
 - 목록은 수업 날짜 오름차순, 교시 오름차순으로 정렬됩니다.
 - 삭제된 수업은 목록, 상세, 내 수업 조회에서 제외됩니다.
+
+캘린더 뷰 사용 방식:
+
+- 주간 뷰는 해당 주의 시작일과 종료일을 `from`, `to`로 전달합니다.
+- 월간 뷰는 월간 캘린더 그리드에 노출되는 시작일과 종료일을 `from`, `to`로 전달합니다.
+- 월간 캘린더가 앞뒤 달 날짜를 포함해 6주 그리드로 표시되는 경우에도 최대 42일 범위 안에서 한 번에 조회할 수 있습니다.
+- 응답은 날짜별로 그룹핑하지 않고 flat list로 반환합니다. 클라이언트는 `date`를 기준으로 캘린더 셀에 배치합니다.
+
+예시:
+
+```http
+GET /api/v1/lessons?from=2026-02-01&to=2026-03-14
+```
+
+```json
+[
+  {
+    "lessonId": 1,
+    "date": "2026-02-03",
+    "period": 1,
+    "startTime": "19:20:00",
+    "endTime": "20:00:00",
+    "teacherName": "홍길동",
+    "subjectName": "한글 기초"
+  }
+]
+```
 
 ## 생성/수정 정책
 
@@ -56,6 +83,46 @@ Lesson 도메인은 다음 권한 코드를 사용합니다.
 - 시작 시간은 종료 시간보다 빨라야 합니다.
 - 동일 교사의 같은 날짜 수업 시간이 겹치면 생성/수정이 실패합니다.
 - Subject 기반 자동 Lesson 생성 중 충돌 날짜를 스킵하는 정책은 이번 Lesson API 정리 범위에서 변경하지 않습니다. 해당 정책 개선은 별도 이슈에서 다룹니다.
+
+수업 생성 요청:
+
+```http
+POST /api/v1/lessons
+Content-Type: application/json
+```
+
+```json
+{
+  "subjectId": 1,
+  "teacherId": 2,
+  "date": "2026-02-20",
+  "startTime": "19:20:00",
+  "endTime": "20:00:00",
+  "period": 1
+}
+```
+
+수업 생성 응답:
+
+```http
+HTTP/1.1 201 Created
+Content-Type: application/json
+```
+
+```json
+{
+  "lessonId": 1,
+  "date": "2026-02-20",
+  "period": 1,
+  "startTime": "19:20:00",
+  "endTime": "20:00:00",
+  "status": "SCHEDULED",
+  "teacherAttendance": "ABSENT",
+  "teacherName": "홍길동",
+  "subjectName": "한글 기초",
+  "note": null
+}
+```
 
 ## 상태 정책
 

--- a/src/main/java/geumjeongyahak/common/security/config/WebSecurityConfig.java
+++ b/src/main/java/geumjeongyahak/common/security/config/WebSecurityConfig.java
@@ -112,6 +112,7 @@ public class WebSecurityConfig {
                 // 공개 조회 API (목록 위주)
                 .requestMatchers(HttpMethod.GET, "/api/v1/classrooms").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/departments").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/lessons").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/channels").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/channels/*/posts", "/api/v1/channels/*/posts/**").permitAll()
                 // 그 외는 인증 필요

--- a/src/main/java/geumjeongyahak/common/validation/validator/LessonRangeValidator.java
+++ b/src/main/java/geumjeongyahak/common/validation/validator/LessonRangeValidator.java
@@ -9,7 +9,7 @@ import geumjeongyahak.domain.lesson.v1.dto.request.LessonRangeRequest;
 
 public class LessonRangeValidator implements ConstraintValidator<ValidLessonRange, LessonRangeRequest> {
 
-    private static final long MAX_RANGE_DAYS = 31;
+    private static final long MAX_RANGE_DAYS = 42;
 
     @Override
     public boolean isValid(LessonRangeRequest value, ConstraintValidatorContext context) {

--- a/src/main/java/geumjeongyahak/domain/base/enums/ResourceType.java
+++ b/src/main/java/geumjeongyahak/domain/base/enums/ResourceType.java
@@ -12,6 +12,7 @@ public enum ResourceType {
     SUBJECT("subject"),
     STUDENT("student"),
     DEPARTMENT("department"),
+    LESSON("lesson"),
     USER("user"),
     PURCHASE_REQUEST("purchase-request");
 

--- a/src/main/java/geumjeongyahak/domain/base/model/PermissionRegistry.java
+++ b/src/main/java/geumjeongyahak/domain/base/model/PermissionRegistry.java
@@ -30,6 +30,8 @@ public class PermissionRegistry {
             ActionType.WRITE, ActionType.MANAGE);
         allow(ResourceType.SUBJECT, PermissionScope.GLOBAL_ONLY,
             ActionType.WRITE, ActionType.MANAGE);
+        allow(ResourceType.LESSON, PermissionScope.GLOBAL_ONLY,
+            ActionType.READ, ActionType.WRITE, ActionType.MANAGE);
         allow(ResourceType.CHANNEL, PermissionScope.BOTH,
             ActionType.READ, ActionType.WRITE, ActionType.MANAGE);
         allow(ResourceType.PURCHASE_REQUEST, PermissionScope.GLOBAL_ONLY,
@@ -39,6 +41,7 @@ public class PermissionRegistry {
         RESOURCE_LABELS.put(ResourceType.SUBJECT, "과목");
         RESOURCE_LABELS.put(ResourceType.STUDENT, "학생");
         RESOURCE_LABELS.put(ResourceType.DEPARTMENT, "부서");
+        RESOURCE_LABELS.put(ResourceType.LESSON, "수업");
         RESOURCE_LABELS.put(ResourceType.USER, "사용자");
         RESOURCE_LABELS.put(ResourceType.PURCHASE_REQUEST, "구입 요청");
 

--- a/src/main/java/geumjeongyahak/domain/lesson/exception/InvalidLessonStatusTransitionException.java
+++ b/src/main/java/geumjeongyahak/domain/lesson/exception/InvalidLessonStatusTransitionException.java
@@ -1,0 +1,15 @@
+package geumjeongyahak.domain.lesson.exception;
+
+import geumjeongyahak.common.exception.BadRequestException;
+import geumjeongyahak.domain.lesson.enums.LessonStatus;
+
+public class InvalidLessonStatusTransitionException extends BadRequestException {
+
+    public InvalidLessonStatusTransitionException(LessonStatus currentStatus, LessonStatus nextStatus) {
+        super(
+            LessonErrorCode.INVALID_LESSON_STATUS_TRANSITION,
+            "수업 상태는 SCHEDULED에서 COMPLETED 또는 CANCELED로만 변경할 수 있습니다. "
+                + "(currentStatus=" + currentStatus + ", nextStatus=" + nextStatus + ")"
+        );
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/lesson/exception/LessonErrorCode.java
+++ b/src/main/java/geumjeongyahak/domain/lesson/exception/LessonErrorCode.java
@@ -11,6 +11,7 @@ public enum LessonErrorCode implements ErrorCode {
     LESSON_NOT_FOUND(HttpStatus.NOT_FOUND, "RES-06-001", "수업을 찾을 수 없습니다."),
     STUDENT_NOT_ENROLLED(HttpStatus.NOT_FOUND, "RES-06-002", "수업에 등록된 학생이 아닙니다."),
     INVALID_LESSON_SCHEDULE(HttpStatus.BAD_REQUEST, "VAL-06-001", "수업 스케줄이 유효하지 않습니다."),
+    INVALID_LESSON_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "VAL-06-002", "수업 상태 전이가 유효하지 않습니다."),
     DUPLICATE_LESSON(HttpStatus.CONFLICT, "BIZ-06-001", "이미 존재하는 수업입니다.");
 
     private final HttpStatus status;

--- a/src/main/java/geumjeongyahak/domain/lesson/service/LessonService.java
+++ b/src/main/java/geumjeongyahak/domain/lesson/service/LessonService.java
@@ -15,6 +15,7 @@ import geumjeongyahak.domain.lesson.entity.Lesson;
 import geumjeongyahak.domain.lesson.enums.LessonStatus;
 import geumjeongyahak.domain.lesson.enums.TeacherAttendanceStatus;
 import geumjeongyahak.domain.lesson.exception.InvalidLessonScheduleException;
+import geumjeongyahak.domain.lesson.exception.InvalidLessonStatusTransitionException;
 import geumjeongyahak.domain.lesson.exception.LessonDuplicateException;
 import geumjeongyahak.domain.lesson.exception.LessonNotFoundException;
 import geumjeongyahak.domain.lesson.repository.LessonRepository;
@@ -239,6 +240,7 @@ public class LessonService {
             log.warn("수업 상태 변경 실패 - 수업을 찾을 수 없습니다. ID: {}", lessonId);
             return new LessonNotFoundException(lessonId);
         });
+        validateLessonStatusTransition(lesson.getStatus(), status);
         lesson.updateStatus(status);
         log.debug("수업 상태 변경 완료 (status={})", status);
         return LessonDetailResponse.from(lesson);
@@ -332,6 +334,19 @@ public class LessonService {
             && teacher.getRole() != RoleType.ADMIN) {
             throw new BusinessException(CommonErrorCode.INVALID_INPUT, "봉사자, 매니저 또는 관리자 사용자만 교사로 배정할 수 있습니다.");
         }
+    }
+
+    private void validateLessonStatusTransition(LessonStatus currentStatus, LessonStatus nextStatus) {
+        if (currentStatus == nextStatus) {
+            return;
+        }
+
+        if (currentStatus == LessonStatus.SCHEDULED
+            && (nextStatus == LessonStatus.COMPLETED || nextStatus == LessonStatus.CANCELED)) {
+            return;
+        }
+
+        throw new InvalidLessonStatusTransitionException(currentStatus, nextStatus);
     }
 
     /**

--- a/src/main/java/geumjeongyahak/domain/lesson/service/LessonService.java
+++ b/src/main/java/geumjeongyahak/domain/lesson/service/LessonService.java
@@ -317,8 +317,12 @@ public class LessonService {
     @Transactional
     public void applyTeacherExcused(Long lessonId) {
         log.debug("교사 출석 공결 처리 (lessonId={})", lessonId);
-        Lesson lesson = lessonRepository.findById(lessonId)
-            .orElseThrow(() -> new LessonNotFoundException(lessonId));
+        Optional<Lesson> lessonOpt = findActiveLessonForEvent(lessonId, "결석 승인");
+        if (lessonOpt.isEmpty()) {
+            return;
+        }
+
+        Lesson lesson = lessonOpt.get();
         lesson.updateTeacherAttendance(TeacherAttendanceStatus.EXCUSED);
     }
 
@@ -336,12 +340,28 @@ public class LessonService {
     @Transactional
     public void applyTeacherExchange(Long lessonId, Long newTeacherId) {
         log.debug("담당 교사 교환 처리 (lessonId={}, newTeacherId={})", lessonId, newTeacherId);
-        Lesson lesson = lessonRepository.findById(lessonId)
-            .orElseThrow(() -> new LessonNotFoundException(lessonId));
+        Optional<Lesson> lessonOpt = findActiveLessonForEvent(lessonId, "수업 교환 수락");
+        if (lessonOpt.isEmpty()) {
+            return;
+        }
+
+        Lesson lesson = lessonOpt.get();
         User newTeacher = userRepository.findById(newTeacherId)
             .orElseThrow(() -> new UserNotFoundException(newTeacherId));
 
         lesson.changeTeacher(newTeacher);
+    }
+
+    private Optional<Lesson> findActiveLessonForEvent(Long lessonId, String eventName) {
+        Lesson lesson = lessonRepository.findById(lessonId)
+            .orElseThrow(() -> new LessonNotFoundException(lessonId));
+
+        if (lesson.getIsDeleted()) {
+            log.warn("{} 이벤트 처리 스킵 - 삭제된 수업입니다. lessonId={}", eventName, lessonId);
+            return Optional.empty();
+        }
+
+        return Optional.of(lesson);
     }
 
     @Transactional

--- a/src/main/java/geumjeongyahak/domain/lesson/v1/controller/LessonAdminController.java
+++ b/src/main/java/geumjeongyahak/domain/lesson/v1/controller/LessonAdminController.java
@@ -16,6 +16,7 @@ import geumjeongyahak.common.security.service.CustomUserDetails;
 import geumjeongyahak.domain.lesson.service.LessonService;
 import geumjeongyahak.domain.lesson.v1.dto.request.CreateLessonRequest;
 import geumjeongyahak.domain.lesson.v1.dto.request.UpdateLessonRequest;
+import geumjeongyahak.domain.lesson.v1.dto.request.UpdateLessonStatusRequest;
 import geumjeongyahak.domain.lesson.v1.dto.response.LessonDetailResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -29,9 +30,12 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Tag(name = "Lesson", description = "수업 관리 API")
 public class LessonAdminController {
+    private static final String LESSON_WRITE_ACCESS = "hasRole('ADMIN') or hasAuthority('lesson:write:*')";
+    private static final String LESSON_MANAGE_ACCESS = "hasRole('ADMIN') or hasAuthority('lesson:manage:*')";
+
     private final LessonService lessonService;
 
-    @PreAuthorize("hasRole('ADMIN') or hasAuthority('lesson:manage:*')")
+    @PreAuthorize(LESSON_WRITE_ACCESS)
     @Operation(summary = "수업 생성", description = "수업을 생성합니다.")
     @PostMapping
     public ResponseEntity<LessonDetailResponse> createLesson(
@@ -47,7 +51,7 @@ public class LessonAdminController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PreAuthorize("hasRole('ADMIN') or hasAuthority('lesson:manage:*')")
+    @PreAuthorize(LESSON_MANAGE_ACCESS)
     @Operation(summary = "수업 수정", description = "수업을 수정합니다.")
     @PatchMapping("/{lessonId}")
     public ResponseEntity<LessonDetailResponse> updateLesson(
@@ -58,8 +62,26 @@ public class LessonAdminController {
         LessonDetailResponse response = lessonService.updateLesson(lessonId, request);
         return ResponseEntity.ok(response);
     }
+
+    @PreAuthorize(LESSON_MANAGE_ACCESS)
+    @Operation(summary = "수업 상태 변경", description = "수업 상태를 변경합니다.")
+    @PatchMapping("/{lessonId}/status")
+    public ResponseEntity<LessonDetailResponse> updateLessonStatus(
+        @PathVariable Long lessonId,
+        @Valid @RequestBody UpdateLessonStatusRequest request,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        log.debug("PATCH /api/v1/lessons/{}/status - 수업 상태 변경 요청", lessonId);
+        LessonDetailResponse response = lessonService.updateLessonStatus(
+            userDetails.getUserId(),
+            lessonId,
+            request.status(),
+            true
+        );
+        return ResponseEntity.ok(response);
+    }
   
-    @PreAuthorize("hasRole('ADMIN') or hasAuthority('lesson:manage:*')")
+    @PreAuthorize(LESSON_MANAGE_ACCESS)
     @Operation(summary = "수업 삭제", description = "수업을 삭제합니다.")
     @DeleteMapping("/{lessonId}")
     public ResponseEntity<Void> deleteLesson(@PathVariable Long lessonId) {

--- a/src/main/java/geumjeongyahak/domain/lesson/v1/controller/LessonController.java
+++ b/src/main/java/geumjeongyahak/domain/lesson/v1/controller/LessonController.java
@@ -7,7 +7,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,10 +24,9 @@ public class LessonController {
 
     private final LessonService lessonService;
 
-    @PreAuthorize("isAuthenticated()")
     @Operation(
         summary = "전체 수업 조회",
-        description = "인증된 사용자가 기간 조건에 해당하는 전체 수업 목록을 조회합니다. "
+        description = "기간 조건에 해당하는 전체 수업 목록을 조회합니다. "
             + "수업 목록은 날짜와 교시 기준으로 정렬되어 반환됩니다. "
             + "조회 API는 side effect 를 발생시키지 않습니다."
     )

--- a/src/main/java/geumjeongyahak/domain/lesson/v1/controller/LessonManageController.java
+++ b/src/main/java/geumjeongyahak/domain/lesson/v1/controller/LessonManageController.java
@@ -15,11 +15,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import geumjeongyahak.common.security.service.CustomUserDetails;
+import geumjeongyahak.common.security.service.DomainPermissionChecker;
+import geumjeongyahak.domain.base.enums.ActionType;
+import geumjeongyahak.domain.base.enums.ResourceType;
 import geumjeongyahak.domain.lesson.service.LessonService;
 import geumjeongyahak.domain.lesson.service.StudentAttendanceService;
 import geumjeongyahak.domain.lesson.v1.dto.request.LessonRangeRequest;
 import geumjeongyahak.domain.lesson.v1.dto.request.UpdateLessonNoteRequest;
-import geumjeongyahak.domain.lesson.v1.dto.request.UpdateLessonStatusRequest;
 import geumjeongyahak.domain.lesson.v1.dto.request.UpdateStudentAttendancesRequest;
 import geumjeongyahak.domain.lesson.v1.dto.request.UpdateTeacherAttendanceRequest;
 import geumjeongyahak.domain.lesson.v1.dto.response.LessonDetailResponse;
@@ -36,10 +38,16 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/api/v1/lessons")
 @RequiredArgsConstructor
 public class LessonManageController {
+    private static final String TEACHER_OR_LESSON_READ_ACCESS =
+        "hasRole('VOLUNTEER') or hasRole('MANAGER') or hasRole('ADMIN') or hasAuthority('lesson:read:*')";
+    private static final String ASSIGNABLE_TEACHER_OR_LESSON_MANAGE_ACCESS =
+        "hasRole('VOLUNTEER') or hasRole('MANAGER') or hasRole('ADMIN') or hasAuthority('lesson:manage:*')";
+
     private final LessonService lessonService;
     private final StudentAttendanceService studentAttendanceService;
+    private final DomainPermissionChecker domainPermissionChecker;
 
-    @PreAuthorize("isAuthenticated()")
+    @PreAuthorize(TEACHER_OR_LESSON_READ_ACCESS)
     @Operation(summary = "내 수업 목록 조회", description = "내 수업 목록을 조회합니다.")
     @GetMapping("/me")
     public ResponseEntity<List<LessonSummaryResponse>> getMyLessons(
@@ -51,7 +59,7 @@ public class LessonManageController {
         return ResponseEntity.ok(responses);
     }
 
-    @PreAuthorize("isAuthenticated()")
+    @PreAuthorize(TEACHER_OR_LESSON_READ_ACCESS)
     @Operation(summary = "수업 상세 조회", description = "수업 상세 정보를 조회합니다.")
     @GetMapping("/{lessonId}")
     public ResponseEntity<LessonDetailResponse> getLessonDetail(
@@ -59,12 +67,16 @@ public class LessonManageController {
         @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         log.debug("GET /api/v1/lessons/{} - 수업 상세 조회 요청", lessonId);
-        boolean isAdmin = userDetails.isAdmin();
-        LessonDetailResponse response = lessonService.getLessonDetail(userDetails.getUserId(), lessonId, isAdmin);
+        boolean canAccessAnyLesson = canReadAnyLesson(userDetails);
+        LessonDetailResponse response = lessonService.getLessonDetail(
+            userDetails.getUserId(),
+            lessonId,
+            canAccessAnyLesson
+        );
         return ResponseEntity.ok(response);
     }
 
-    @PreAuthorize("isAuthenticated()")
+    @PreAuthorize(TEACHER_OR_LESSON_READ_ACCESS)
     @Operation(summary = "학생 출석부 조회", description = "수업의 학생 출석부를 조회합니다.")
     @GetMapping("/{lessonId}/student-attendances")
     public ResponseEntity<List<StudentAttendanceResponse>> getStudentAttendances(
@@ -72,16 +84,16 @@ public class LessonManageController {
         @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         log.debug("GET /api/v1/lessons/{}/student-attendances - 학생 출석부 조회 요청", lessonId);
-        boolean isAdmin = userDetails.isAdmin();
+        boolean canAccessAnyLesson = canReadAnyLesson(userDetails);
         List<StudentAttendanceResponse> response = studentAttendanceService.getStudentAttendances(
             userDetails.getUserId(),
             lessonId,
-            isAdmin
+            canAccessAnyLesson
         );
         return ResponseEntity.ok(response);
     }
 
-    @PreAuthorize("isAuthenticated()")
+    @PreAuthorize(TEACHER_OR_LESSON_READ_ACCESS)
     @Operation(summary = "수업 노트 조회", description = "수업 노트를 조회합니다.")
     @GetMapping("/{lessonId}/note")
     public ResponseEntity<LessonNoteResponse> getNote(
@@ -89,15 +101,15 @@ public class LessonManageController {
         @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         log.debug("GET /api/v1/lessons/{}/note - 수업 노트 조회 요청", lessonId);
-        boolean isAdmin = userDetails.isAdmin();
+        boolean canAccessAnyLesson = canReadAnyLesson(userDetails);
 
         LessonNoteResponse response = lessonService.getNote(
-            userDetails.getUserId(), lessonId, isAdmin
+            userDetails.getUserId(), lessonId, canAccessAnyLesson
         );
         return ResponseEntity.ok(response);
     }
 
-      @PreAuthorize("isAuthenticated()")
+    @PreAuthorize(ASSIGNABLE_TEACHER_OR_LESSON_MANAGE_ACCESS)
     @Operation(summary = "교사 출석 처리", description = "교사 출석 상태를 처리합니다.")
     @PatchMapping("/{lessonId}/teacher-attendance")
     public ResponseEntity<LessonDetailResponse> updateLessonAttendance(
@@ -107,17 +119,17 @@ public class LessonManageController {
     ) {
         log.debug("PATCH /api/v1/lessons/{}/teacher-attendance - 교사 출석 처리 요청 (status={})",
             lessonId, request.status());
-        boolean isAdmin = userDetails.isAdmin();
+        boolean canAccessAnyLesson = canManageAnyLesson(userDetails);
         LessonDetailResponse response = lessonService.updateTeacherAttendance(
             userDetails.getUserId(),
             lessonId,
             request.status(),
-            isAdmin
+            canAccessAnyLesson
         );
         return ResponseEntity.ok(response);
     }
 
-    @PreAuthorize("isAuthenticated()")
+    @PreAuthorize(ASSIGNABLE_TEACHER_OR_LESSON_MANAGE_ACCESS)
     @Operation(summary = "학생 출석 처리", description = "학생 출석 상태를 처리합니다.")
     @PatchMapping("/{lessonId}/student-attendances")
     public ResponseEntity<List<StudentAttendanceResponse>> updateStudentAttendance(
@@ -126,36 +138,17 @@ public class LessonManageController {
         @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         log.debug("PATCH /api/v1/lessons/{}/student-attendances - 학생 출석 처리 요청", lessonId);
-        boolean isAdmin = userDetails.isAdmin();
+        boolean canAccessAnyLesson = canManageAnyLesson(userDetails);
         List<StudentAttendanceResponse> response = studentAttendanceService.updateStudentAttendances(
             userDetails.getUserId(),
             lessonId,
             request,
-            isAdmin
+            canAccessAnyLesson
         );
         return ResponseEntity.ok(response);
     }
 
-    @PreAuthorize("isAuthenticated()")
-    @Operation(summary = "수업 상태 변경", description = "수업 상태를 변경합니다.")
-    @PatchMapping("/{lessonId}/status")
-    public ResponseEntity<LessonDetailResponse> updateLessonStatus(
-        @PathVariable Long lessonId,
-        @Valid @RequestBody UpdateLessonStatusRequest request,
-        @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
-        log.debug("PATCH /api/v1/lessons/{}/status - 수업 상태 변경 요청", lessonId);
-        boolean isAdmin = userDetails.isAdmin();
-        LessonDetailResponse response = lessonService.updateLessonStatus(
-            userDetails.getUserId(),
-            lessonId,
-            request.status(),
-            isAdmin
-        );
-        return ResponseEntity.ok(response);
-    }
-
-    @PreAuthorize("isAuthenticated()")
+    @PreAuthorize(ASSIGNABLE_TEACHER_OR_LESSON_MANAGE_ACCESS)
     @Operation(summary = "수업 노트 업데이트", description = "수업 노트를 업데이트합니다.")
     @PutMapping("/{lessonId}/note")
     public ResponseEntity<LessonNoteResponse> upsertNote(
@@ -164,12 +157,20 @@ public class LessonManageController {
         @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         log.debug("PUT /api/v1/lessons/{}/note - 수업 노트 업데이트 요청", lessonId);
-        boolean isAdmin = userDetails.isAdmin();
+        boolean canAccessAnyLesson = canManageAnyLesson(userDetails);
 
         LessonNoteResponse response = lessonService.upsertNote(
-            userDetails.getUserId(), lessonId, request.note(), isAdmin
+            userDetails.getUserId(), lessonId, request.note(), canAccessAnyLesson
         );
         return ResponseEntity.ok(response);
     }
-    
+
+    private boolean canReadAnyLesson(CustomUserDetails userDetails) {
+        return userDetails.isAdminOrManager()
+            || domainPermissionChecker.hasPermission(userDetails, ResourceType.LESSON, ActionType.READ, null);
+    }
+
+    private boolean canManageAnyLesson(CustomUserDetails userDetails) {
+        return domainPermissionChecker.hasPermission(userDetails, ResourceType.LESSON, ActionType.MANAGE, null);
+    }
 }

--- a/src/test/java/geumjeongyahak/e2e/lesson/LessonBaseTest.java
+++ b/src/test/java/geumjeongyahak/e2e/lesson/LessonBaseTest.java
@@ -17,6 +17,9 @@ import geumjeongyahak.domain.lesson.entity.StudentAttendance;
 import geumjeongyahak.domain.lesson.repository.LessonRepository;
 import geumjeongyahak.domain.lesson.repository.StudentAttendanceRepository;
 import geumjeongyahak.domain.student.repository.StudentRepository;
+import geumjeongyahak.domain.users.entity.User;
+import geumjeongyahak.domain.users.entity.UserPermission;
+import geumjeongyahak.domain.users.repository.UserPermissionRepository;
 import geumjeongyahak.e2e.util.TestLessonHelper;
 
 @Tag("lesson")
@@ -42,6 +45,9 @@ public class LessonBaseTest extends BaseE2ETest {
 
     @Autowired
     protected StudentAttendanceRepository studentAttendanceRepository;
+
+    @Autowired
+    protected UserPermissionRepository userPermissionRepository;
 
     @BeforeEach
     @Override
@@ -227,6 +233,17 @@ public class LessonBaseTest extends BaseE2ETest {
             .forEach(studentAttendanceRepository::save);
 
         return lessonId;
+    }
+
+    protected String createAccessTokenWithPermission(
+        String nicknamePrefix,
+        RoleType role,
+        String permissionCode
+    ) {
+        String nickname = nicknamePrefix + System.nanoTime();
+        User user = userTestHelper.createTestUser(nickname, role);
+        userPermissionRepository.save(new UserPermission(user, permissionCode));
+        return userTestHelper.generateAccessTokenByNickname(nickname);
     }
 
     protected void deleteLesson(Long lessonId, String token) {

--- a/src/test/java/geumjeongyahak/e2e/lesson/LessonCreateTest.java
+++ b/src/test/java/geumjeongyahak/e2e/lesson/LessonCreateTest.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import geumjeongyahak.domain.auth.enums.RoleType;
 
 @DisplayName("E2E: Lesson 생성 테스트")
 public class LessonCreateTest extends LessonBaseTest {
@@ -19,14 +20,33 @@ public class LessonCreateTest extends LessonBaseTest {
     }
 
     @Test
-    @DisplayName("매니저 권한으로 수업 생성 성공(201)")
-    void createLesson_success_manager() {
+    @DisplayName("lesson:write:* 권한으로 수업 생성 성공(201)")
+    void createLesson_success_lessonWritePermission() {
         Long subjectId = createTrackedSubjectAndGetId("매니저 생성");
         Map<String, Object> request = createLessonRequest(
             subjectId, TEACHER2_ID, "2026-02-21", "19:20:00", "20:00:00", 1
         );
 
-        createLessonAndGetId(request, managerAccessToken);
+        String lessonWriteToken = createAccessTokenWithPermission("lesson-write", RoleType.VOLUNTEER, "lesson:write:*");
+        createLessonAndGetId(request, lessonWriteToken);
+    }
+
+    @Test
+    @DisplayName("매니저 역할만으로 수업 생성 실패(403)")
+    void createLesson_forbidden_managerWithoutLessonWritePermission() {
+        Long subjectId = createTrackedSubjectAndGetId("매니저 생성 제한");
+        Map<String, Object> request = createLessonRequest(
+            subjectId, TEACHER2_ID, "2026-02-21", "19:20:00", "20:00:00", 1
+        );
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(managerAccessToken))
+            .contentType("application/json")
+            .body(request)
+            .when()
+            .post()
+            .then()
+            .statusCode(403);
     }
 
     @Test

--- a/src/test/java/geumjeongyahak/e2e/lesson/LessonDeleteTest.java
+++ b/src/test/java/geumjeongyahak/e2e/lesson/LessonDeleteTest.java
@@ -1,9 +1,11 @@
 package geumjeongyahak.e2e.lesson;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.empty;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import geumjeongyahak.domain.auth.enums.RoleType;
 
 @DisplayName("E2E: Lesson 삭제 테스트")
 public class LessonDeleteTest extends LessonBaseTest {
@@ -19,12 +21,94 @@ public class LessonDeleteTest extends LessonBaseTest {
     }
 
     @Test
-    @DisplayName("매니저 권한으로 수업 삭제 성공(204)")
-    void deleteLesson_success_manager() {
+    @DisplayName("삭제된 수업은 목록과 상세 조회에서 제외된다")
+    void deleteLesson_ShouldExcludeFromListAndDetail() {
+        Long subjectId = createTrackedSubjectAndGetId("삭제 조회 제외");
+        Long lessonId = createTrackedLessonAndGetId(subjectId, TEACHER_ID, "2028-02-25", "19:20:00", "20:00:00", 1);
+
+        deleteLesson(lessonId, adminAccessToken);
+
+        given()
+            .queryParam("from", "2028-02-01")
+            .queryParam("to", "2028-02-28")
+            .when()
+            .get()
+            .then()
+            .statusCode(200)
+            .body("findAll { it.lessonId == %s }".formatted(lessonId), empty());
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .when()
+            .get("/{lessonId}", lessonId)
+            .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @DisplayName("삭제된 수업은 상태/출석/노트 변경 대상에서 제외된다")
+    void deleteLesson_ShouldBlockMutations() {
+        Long subjectId = createTrackedSubjectAndGetId("삭제 변경 차단");
+        Long lessonId = createTrackedLessonAndGetId(subjectId, TEACHER_ID, "2028-03-25", "19:20:00", "20:00:00", 1);
+
+        deleteLesson(lessonId, adminAccessToken);
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .contentType("application/json")
+            .body("""
+                { "status": "COMPLETED" }
+            """)
+            .when()
+            .patch("/{lessonId}/status", lessonId)
+            .then()
+            .statusCode(404);
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .contentType("application/json")
+            .body("""
+                { "status": "PRESENT" }
+            """)
+            .when()
+            .patch("/{lessonId}/teacher-attendance", lessonId)
+            .then()
+            .statusCode(404);
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .contentType("application/json")
+            .body("""
+                { "note": "삭제된 수업 수정 시도" }
+            """)
+            .when()
+            .put("/{lessonId}/note", lessonId)
+            .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @DisplayName("lesson:manage:* 권한으로 수업 삭제 성공(204)")
+    void deleteLesson_success_lessonManagePermission() {
         Long subjectId = createTrackedSubjectAndGetId("매니저 삭제");
         Long lessonId = createTrackedLessonAndGetId(subjectId, TEACHER_ID, "2026-02-26", "19:20:00", "20:00:00", 1);
 
-        deleteLesson(lessonId, managerAccessToken);
+        String lessonManageToken = createAccessTokenWithPermission("lesson-manage-delete", RoleType.VOLUNTEER, "lesson:manage:*");
+        deleteLesson(lessonId, lessonManageToken);
+    }
+
+    @Test
+    @DisplayName("매니저 역할만으로 수업 삭제 실패(403)")
+    void deleteLesson_forbidden_managerWithoutLessonManagePermission() {
+        Long subjectId = createTrackedSubjectAndGetId("매니저 삭제 제한");
+        Long lessonId = createTrackedLessonAndGetId(subjectId, TEACHER_ID, "2026-02-26", "19:20:00", "20:00:00", 1);
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(managerAccessToken))
+            .when()
+            .delete("/{lessonId}", lessonId)
+            .then()
+            .statusCode(403);
     }
 
     @Test

--- a/src/test/java/geumjeongyahak/e2e/lesson/LessonNoteE2ETest.java
+++ b/src/test/java/geumjeongyahak/e2e/lesson/LessonNoteE2ETest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.notNullValue;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import geumjeongyahak.domain.auth.enums.RoleType;
 
 @DisplayName("E2E: 수업일지(메모) 테스트")
 public class LessonNoteE2ETest extends LessonBaseTest {
@@ -87,6 +88,25 @@ public class LessonNoteE2ETest extends LessonBaseTest {
             .then()
             .statusCode(200)
             .body("note", is("관리자 메모"));
+    }
+
+    @Test
+    @DisplayName("lesson:read:* 권한으로 타인 수업 메모 조회 가능(200)")
+    void getNote_LessonReadPermission_OthersLesson_Success() {
+        long othersLessonId = createIsolatedLesson(3L, "note-read-permission");
+        String lessonReadToken = createAccessTokenWithPermission(
+            "lesson-read-note",
+            RoleType.VOLUNTEER,
+            "lesson:read:*"
+        );
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(lessonReadToken))
+            .when()
+            .get("/{lessonId}/note", othersLessonId)
+            .then()
+            .statusCode(200)
+            .body("lessonId", is((int) othersLessonId));
     }
 
     @Test

--- a/src/test/java/geumjeongyahak/e2e/lesson/LessonReadTest.java
+++ b/src/test/java/geumjeongyahak/e2e/lesson/LessonReadTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.notNullValue;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import geumjeongyahak.domain.auth.enums.RoleType;
 
 @DisplayName("E2E: 수업 조회 테스트")
 public class LessonReadTest extends LessonBaseTest {
@@ -56,15 +57,21 @@ public class LessonReadTest extends LessonBaseTest {
     }
 
     @Test
-    @DisplayName("인증 없이 전체 수업 목록 조회 실패(401 Unauthorized)")
-    void getAllLessons_Unauthorized() {
+    @DisplayName("인증 없이 전체 수업 목록 조회 성공(200 OK)")
+    void getAllLessons_PublicSuccess() {
+        createTrackedLessonFixture("read-list-public", TEACHER_ID, "2042-05-15", "THURSDAY", 4, "2027-05-15", "19:20:00", "20:00:00", 1);
+
         given()
-            .queryParam("from", "2026-02-01")
-            .queryParam("to", "2026-12-31")
+            .queryParam("from", "2027-05-01")
+            .queryParam("to", "2027-05-31")
             .when()
             .get()
             .then()
-            .statusCode(401)
+            .statusCode(200)
+            .body("$", is(notNullValue()))
+            .body("lessonId", everyItem(notNullValue()))
+            .body("teacherName", everyItem(notNullValue()))
+            .body("subjectName", everyItem(notNullValue()))
             .log().all();
     }
 
@@ -225,6 +232,38 @@ public class LessonReadTest extends LessonBaseTest {
             .body("period", anyOf(is(1), is(2), is(3)))
             .body("status", notNullValue())
             .body("teacherAttendance", notNullValue())
+            .log().all();
+    }
+
+    @Test
+    @DisplayName("lesson:read:* 권한으로 타인 수업 상세 조회 가능(200 OK)")
+    void getLessonDetail_LessonReadPermission_CanAccessOthersLesson() {
+        long othersLessonId = createTrackedLessonFixture(
+            "read-detail-permission",
+            TEACHER2_ID,
+            "2042-07-10",
+            "THURSDAY",
+            4,
+            "2027-07-10",
+            "19:20:00",
+            "20:00:00",
+            1
+        );
+        String lessonReadToken = createAccessTokenWithPermission(
+            "lesson-read-detail",
+            RoleType.VOLUNTEER,
+            "lesson:read:*"
+        );
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(lessonReadToken))
+            .when()
+            .get("/{lessonId}", othersLessonId)
+            .then()
+            .statusCode(200)
+            .body("lessonId", is((int) othersLessonId))
+            .body("teacherName", notNullValue())
+            .body("subjectName", notNullValue())
             .log().all();
     }
 

--- a/src/test/java/geumjeongyahak/e2e/lesson/LessonReadTest.java
+++ b/src/test/java/geumjeongyahak/e2e/lesson/LessonReadTest.java
@@ -90,7 +90,23 @@ public class LessonReadTest extends LessonBaseTest {
     }
 
     @Test
-    @DisplayName("기간 범위 초과(예: 31일 초과) 시 400 Bad Request")
+    @DisplayName("월간 캘린더 그리드 범위(42일) 조회 성공(200 OK)")
+    void getAllLessons_MaxCalendarRange_Success() {
+        createTrackedLessonFixture("read-list-calendar-range", TEACHER_ID, "2042-05-16", "FRIDAY", 5, "2026-03-14", "19:20:00", "20:00:00", 1);
+
+        given()
+            .queryParam("from", "2026-02-01")
+            .queryParam("to", "2026-03-14")
+            .when()
+            .get()
+            .then()
+            .statusCode(200)
+            .body("$", is(notNullValue()))
+            .log().all();
+    }
+
+    @Test
+    @DisplayName("기간 범위 초과(42일 초과) 시 400 Bad Request")
     void getAllLessons_RangeTooLarge_BadRequest() {
         given()
             .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
@@ -161,7 +177,7 @@ public class LessonReadTest extends LessonBaseTest {
     void getMyLessons_RangeTooLarge_BadRequest() {
         given()
             .header(AUTH_HEADER, getAuthHeader(volunteerAccessToken))
-            // (예시) 31일 초과로 요청
+            // 42일 초과로 요청
             .queryParam("from", "2026-02-01")
             .queryParam("to", "2026-03-15")
             .when()

--- a/src/test/java/geumjeongyahak/e2e/lesson/LessonStatusUpdateTest.java
+++ b/src/test/java/geumjeongyahak/e2e/lesson/LessonStatusUpdateTest.java
@@ -5,13 +5,14 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import geumjeongyahak.domain.auth.enums.RoleType;
 
 @DisplayName("E2E: 수업 상태 변경 테스트")
 public class LessonStatusUpdateTest extends LessonBaseTest {
 
     @Test
-    @DisplayName("수업 상태 변경 성공(200) - 교사(본인 수업) + 재조회로 반영 확인")
-    void updateLessonStatus_Success_MyLesson_ThenGet() {
+    @DisplayName("수업 상태 변경 실패(403) - 교사(본인 수업)")
+    void updateLessonStatus_Forbidden_VolunteerMyLesson() {
         long lessonId = createTrackedLessonFixture(
             "status-my-lesson",
             TEACHER_ID,
@@ -33,24 +34,13 @@ public class LessonStatusUpdateTest extends LessonBaseTest {
             .when()
             .patch("/{lessonId}/status", lessonId)
             .then()
-            .statusCode(200)
-            .body("lessonId", is((int) lessonId))
-            .body("status", is("COMPLETED"));
-
-        // 재조회 - DB 반영 확인
-        given()
-            .header(AUTH_HEADER, getAuthHeader(volunteerAccessToken))
-            .when()
-            .get("/{lessonId}", lessonId)
-            .then()
-            .statusCode(200)
-            .body("status", is("COMPLETED"))
+            .statusCode(403)
             .log().all();
     }
 
     @Test
-    @DisplayName("수업 상태 변경 실패(404) - 교사(타인 수업)")
-    void updateLessonStatus_Fail_OthersLesson() {
+    @DisplayName("수업 상태 변경 실패(403) - 매니저 역할만 보유")
+    void updateLessonStatus_Forbidden_ManagerWithoutLessonManagePermission() {
         long othersLessonId = createTrackedLessonFixture(
             "status-other-lesson",
             TEACHER2_ID,
@@ -64,7 +54,7 @@ public class LessonStatusUpdateTest extends LessonBaseTest {
         );
 
         given()
-            .header(AUTH_HEADER, getAuthHeader(volunteerAccessToken))
+            .header(AUTH_HEADER, getAuthHeader(managerAccessToken))
             .contentType("application/json")
             .body("""
                 { "status": "COMPLETED" }
@@ -72,7 +62,7 @@ public class LessonStatusUpdateTest extends LessonBaseTest {
             .when()
             .patch("/{lessonId}/status", othersLessonId)
             .then()
-            .statusCode(404)
+            .statusCode(403)
             .log().all();
     }
 
@@ -107,6 +97,37 @@ public class LessonStatusUpdateTest extends LessonBaseTest {
     }
 
     @Test
+    @DisplayName("수업 상태 변경 성공(200) - lesson:manage:* 권한")
+    void updateLessonStatus_Success_LessonManagePermission() {
+        long lessonId = createTrackedLessonFixture(
+            "status-manage-permission",
+            TEACHER2_ID,
+            "2042-01-10",
+            "FRIDAY",
+            5,
+            "2027-01-10",
+            "19:20:00",
+            "20:00:00",
+            1
+        );
+        String lessonManageToken = createAccessTokenWithPermission("lesson-manage-status", RoleType.VOLUNTEER, "lesson:manage:*");
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(lessonManageToken))
+            .contentType("application/json")
+            .body("""
+                { "status": "CANCELED" }
+            """)
+            .when()
+            .patch("/{lessonId}/status", lessonId)
+            .then()
+            .statusCode(200)
+            .body("lessonId", is((int) lessonId))
+            .body("status", is("CANCELED"))
+            .log().all();
+    }
+
+    @Test
     @DisplayName("수업 상태 변경 실패(401) - 인증 없음")
     void updateLessonStatus_Unauthorized() {
         given()
@@ -136,7 +157,7 @@ public class LessonStatusUpdateTest extends LessonBaseTest {
         );
 
         given()
-            .header(AUTH_HEADER, getAuthHeader(volunteerAccessToken))
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
             .contentType("application/json")
             .body("""
                 { }
@@ -145,6 +166,86 @@ public class LessonStatusUpdateTest extends LessonBaseTest {
             .patch("/{lessonId}/status", lessonId)
             .then()
             .statusCode(400)
+            .log().all();
+    }
+
+    @Test
+    @DisplayName("완료된 수업을 예정 상태로 되돌릴 수 없다(400)")
+    void updateLessonStatus_InvalidTransition_CompletedToScheduled() {
+        long lessonId = createTrackedLessonFixture(
+            "status-invalid-completed",
+            TEACHER_ID,
+            "2042-01-11",
+            "MONDAY",
+            1,
+            "2027-01-11",
+            "19:20:00",
+            "20:00:00",
+            1
+        );
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .contentType("application/json")
+            .body("""
+                { "status": "COMPLETED" }
+            """)
+            .when()
+            .patch("/{lessonId}/status", lessonId)
+            .then()
+            .statusCode(200);
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .contentType("application/json")
+            .body("""
+                { "status": "SCHEDULED" }
+            """)
+            .when()
+            .patch("/{lessonId}/status", lessonId)
+            .then()
+            .statusCode(400)
+            .body("code", is("VAL-06-002"))
+            .log().all();
+    }
+
+    @Test
+    @DisplayName("취소된 수업을 예정 상태로 되돌릴 수 없다(400)")
+    void updateLessonStatus_InvalidTransition_CanceledToScheduled() {
+        long lessonId = createTrackedLessonFixture(
+            "status-invalid-canceled",
+            TEACHER_ID,
+            "2042-01-12",
+            "TUESDAY",
+            2,
+            "2027-01-12",
+            "20:10:00",
+            "20:50:00",
+            2
+        );
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .contentType("application/json")
+            .body("""
+                { "status": "CANCELED" }
+            """)
+            .when()
+            .patch("/{lessonId}/status", lessonId)
+            .then()
+            .statusCode(200);
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .contentType("application/json")
+            .body("""
+                { "status": "SCHEDULED" }
+            """)
+            .when()
+            .patch("/{lessonId}/status", lessonId)
+            .then()
+            .statusCode(400)
+            .body("code", is("VAL-06-002"))
             .log().all();
     }
 }

--- a/src/test/java/geumjeongyahak/e2e/lesson/LessonUpdateTest.java
+++ b/src/test/java/geumjeongyahak/e2e/lesson/LessonUpdateTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.equalTo;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import geumjeongyahak.domain.auth.enums.RoleType;
 
 @DisplayName("E2E: Lesson 부분 수정(PATCH) 테스트")
 public class LessonUpdateTest extends LessonBaseTest {
@@ -36,8 +37,8 @@ public class LessonUpdateTest extends LessonBaseTest {
     }
 
     @Test
-    @DisplayName("매니저: date/startTime/endTime만 부분 수정 성공(200)")
-    void patchLesson_success_manager() {
+    @DisplayName("lesson:manage:* 권한으로 date/startTime/endTime만 부분 수정 성공(200)")
+    void patchLesson_success_lessonManagePermission() {
         Long subjectId = createTrackedSubjectAndGetId("매니저 수정");
         Long lessonId = createTrackedLessonAndGetId(subjectId, TEACHER_ID, "2026-02-21", "19:20:00", "20:00:00", 1);
 
@@ -47,8 +48,10 @@ public class LessonUpdateTest extends LessonBaseTest {
             "endTime", "20:10:00"
         );
 
+        String lessonManageToken = createAccessTokenWithPermission("lesson-manage-update", RoleType.VOLUNTEER, "lesson:manage:*");
+
         given()
-            .header(AUTH_HEADER, getAuthHeader(managerAccessToken))
+            .header(AUTH_HEADER, getAuthHeader(lessonManageToken))
             .contentType("application/json")
             .body(patch)
             .when()
@@ -57,6 +60,24 @@ public class LessonUpdateTest extends LessonBaseTest {
             .statusCode(200)
             .body("lessonId", equalTo(lessonId.intValue()))
             .body("date", equalTo("2026-02-22"));
+    }
+
+    @Test
+    @DisplayName("매니저 역할만으로 수업 부분 수정 실패(403)")
+    void patchLesson_forbidden_managerWithoutLessonManagePermission() {
+        Long subjectId = createTrackedSubjectAndGetId("매니저 수정 제한");
+        Long lessonId = createTrackedLessonAndGetId(subjectId, TEACHER_ID, "2026-02-21", "19:20:00", "20:00:00", 1);
+
+        Map<String, Object> patch = Map.of("period", 2);
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(managerAccessToken))
+            .contentType("application/json")
+            .body(patch)
+            .when()
+            .patch("/{lessonId}", lessonId)
+            .then()
+            .statusCode(403);
     }
 
     @Test

--- a/src/test/java/geumjeongyahak/e2e/lesson/StudentAttendanceReadTest.java
+++ b/src/test/java/geumjeongyahak/e2e/lesson/StudentAttendanceReadTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.notNullValue;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import geumjeongyahak.domain.auth.enums.RoleType;
 
 @DisplayName("E2E: 학생 출석부 조회 테스트")
 public class StudentAttendanceReadTest extends LessonBaseTest {
@@ -91,6 +92,41 @@ public class StudentAttendanceReadTest extends LessonBaseTest {
             .statusCode(200)
             .body("$", notNullValue())
             .body("size()", greaterThanOrEqualTo(0))
+            .body("studentId", everyItem(notNullValue()))
+            .body("studentName", everyItem(notNullValue()))
+            .body("status", everyItem(notNullValue()))
+            .log().all();
+    }
+
+    @Test
+    @DisplayName("학생 출석부 조회 성공(200 OK) - lesson:read:* 권한")
+    void getStudentAttendances_Success_LessonReadPermission() {
+        long othersLessonId = createTrackedLessonFixtureWithAttendances(
+            "student-read-permission-lesson",
+            TEACHER2_ID,
+            "2042-03-06",
+            "THURSDAY",
+            4,
+            "2027-03-06",
+            "19:20:00",
+            "20:00:00",
+            1,
+            1L, 2L
+        );
+        String lessonReadToken = createAccessTokenWithPermission(
+            "lesson-read-attendance",
+            RoleType.VOLUNTEER,
+            "lesson:read:*"
+        );
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(lessonReadToken))
+            .when()
+            .get("/{lessonId}/student-attendances", othersLessonId)
+            .then()
+            .statusCode(200)
+            .body("$", notNullValue())
+            .body("size()", is(2))
             .body("studentId", everyItem(notNullValue()))
             .body("studentName", everyItem(notNullValue()))
             .body("status", everyItem(notNullValue()))


### PR DESCRIPTION
## 개요

Lesson 도메인의 API 권한, 상태 전이, 삭제 처리, 캘린더 조회 정책을 최신 운영 정책에 맞게 정리했습니다.

## 변경 유형

- [x] 새 기능 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 문서 수정 (docs)
- [x] 테스트 (test)
- [ ] 기타 (chore)

## 변경 내용

- Lesson API 권한 정책을 최신 정책에 맞게 수정했습니다.
- Lesson 도메인 권한 코드(`lesson:read:*`, `lesson:write:*`, `lesson:manage:*`)를 추가했습니다.
- 삭제된 Lesson에 대한 조회/변경을 차단하고, 삭제된 Lesson 대상 내부 이벤트는 로그를 남기고 무시하도록 수정했습니다.
- Lesson 상태 변경 API에서 `SCHEDULED -> COMPLETED/CANCELED` 전이만 허용하도록 제한했습니다.
- Lesson 목록 조회 범위를 42일로 확장해 주간/월간 캘린더 뷰에서 사용할 수 있도록 정리했습니다.
- Lesson API 문서를 최신 요청/응답 형식과 정책 기준으로 갱신했습니다.
- 권한, 상태 전이, 삭제 Lesson 처리, 캘린더 조회 범위 관련 E2E 테스트를 보강했습니다.

## 관련 이슈

Closes #54

## 스크린샷 (선택)

## 체크리스트

- [x] 코드 컨벤션을 준수했습니다
- [x] 테스트 코드를 작성/수정했습니다
- [x] 모든 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요한 경우)

## 리뷰어에게

Lesson 상태 변경 권한을 `ADMIN` 또는 `lesson:manage:*`로 제한했고, 일반 교사는 상태를 직접 변경하지 못하도록 했습니다.

캘린더 조회는 별도 endpoint를 추가하지 않고 기존 `GET /api/v1/lessons?from=&to=` API를 확장하는 방식으로 처리했습니다. 월간 6주 그리드를 지원하기 위해 조회 가능 범위를 42일로 완화했습니다.