### PR TITLE
[FEAT] 관리자 대시보드에 수업 관리 현황 추가

### DIFF
--- a/src/main/java/geumjeongyahak/domain/base/service/AdminDashboardService.java
+++ b/src/main/java/geumjeongyahak/domain/base/service/AdminDashboardService.java
@@ -1,11 +1,16 @@
 package geumjeongyahak.domain.base.service;
 
+import geumjeongyahak.domain.lesson.enums.LessonStatus;
+import geumjeongyahak.domain.lesson.repository.LessonRepository;
 import geumjeongyahak.domain.classroom.repository.ClassroomRepository;
 import geumjeongyahak.domain.department.repository.DepartmentRepository;
 import geumjeongyahak.domain.purchase_request.enums.PurchaseRequestStatus;
 import geumjeongyahak.domain.purchase_request.repository.PurchaseRequestRepository;
 import geumjeongyahak.domain.student.repository.StudentRepository;
 import geumjeongyahak.domain.users.repository.UserRepository;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,14 +25,25 @@ public class AdminDashboardService {
     private final ClassroomRepository classroomRepository;
     private final PurchaseRequestRepository purchaseRequestRepository;
     private final StudentRepository studentRepository;
+    private final LessonRepository lessonRepository;
 
     public AdminDashboardSummary getSummary() {
+        LocalDate today = LocalDate.now();
+        LocalDate weekStart = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate weekEnd = today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+
         return new AdminDashboardSummary(
             userRepository.count(),
             departmentRepository.count(),
             classroomRepository.count(),
             purchaseRequestRepository.countByStatus(PurchaseRequestStatus.PENDING),
-            studentRepository.count()
+            studentRepository.count(),
+            lessonRepository.countByIsDeletedFalse(),
+            lessonRepository.countByIsDeletedFalseAndDate(today),
+            lessonRepository.countByStatusAndIsDeletedFalseAndDateBetween(LessonStatus.SCHEDULED, weekStart, weekEnd),
+            today,
+            weekStart,
+            weekEnd
         );
     }
 
@@ -36,7 +52,13 @@ public class AdminDashboardService {
         long departmentCount,
         long classroomCount,
         long pendingPurchaseRequestCount,
-        long studentCount
+        long studentCount,
+        long lessonCount,
+        long todayLessonCount,
+        long weeklyScheduledLessonCount,
+        LocalDate today,
+        LocalDate weekStart,
+        LocalDate weekEnd
     ) {
     }
 }

--- a/src/main/java/geumjeongyahak/domain/lesson/enums/LessonStatus.java
+++ b/src/main/java/geumjeongyahak/domain/lesson/enums/LessonStatus.java
@@ -1,7 +1,17 @@
 package geumjeongyahak.domain.lesson.enums;
 
 public enum LessonStatus {
-    SCHEDULED,   // 예정
-    CANCELED,    // 결강(취소)
-    COMPLETED    // 완료
+    SCHEDULED("예정"),
+    CANCELED("취소"),
+    COMPLETED("완료");
+
+    private final String displayName;
+
+    LessonStatus(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
 }

--- a/src/main/java/geumjeongyahak/domain/lesson/enums/TeacherAttendanceStatus.java
+++ b/src/main/java/geumjeongyahak/domain/lesson/enums/TeacherAttendanceStatus.java
@@ -1,8 +1,18 @@
 package geumjeongyahak.domain.lesson.enums;
 
 public enum TeacherAttendanceStatus {
-    PRESENT,
-    ABSENT,
-    LATE,
-    EXCUSED
+    PRESENT("출석"),
+    ABSENT("결석"),
+    LATE("지각"),
+    EXCUSED("공결");
+
+    private final String displayName;
+
+    TeacherAttendanceStatus(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
 }

--- a/src/main/java/geumjeongyahak/domain/lesson/repository/LessonRepository.java
+++ b/src/main/java/geumjeongyahak/domain/lesson/repository/LessonRepository.java
@@ -11,6 +11,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LessonRepository extends JpaRepository<Lesson, Long> {
 
+    long countByIsDeletedFalse();
+
+    long countByIsDeletedFalseAndDate(LocalDate date);
+
+    long countByStatusAndIsDeletedFalseAndDateBetween(LessonStatus status, LocalDate startDate, LocalDate endDate);
+
     @EntityGraph(attributePaths = {"teacher", "subject"})
     List<Lesson> findAllByIsDeletedFalseAndDateBetweenOrderByDateAscPeriodAsc(LocalDate startDate, LocalDate endDate);
 

--- a/src/main/java/geumjeongyahak/domain/lesson/repository/LessonRepository.java
+++ b/src/main/java/geumjeongyahak/domain/lesson/repository/LessonRepository.java
@@ -15,6 +15,9 @@ public interface LessonRepository extends JpaRepository<Lesson, Long> {
     List<Lesson> findAllByIsDeletedFalseAndDateBetweenOrderByDateAscPeriodAsc(LocalDate startDate, LocalDate endDate);
 
     @EntityGraph(attributePaths = {"teacher", "subject"})
+    List<Lesson> findAllByIsDeletedFalseOrderByDateAscPeriodAsc();
+
+    @EntityGraph(attributePaths = {"teacher", "subject"})
     List<Lesson> findAllByTeacherIdAndIsDeletedFalseAndDateBetweenOrderByDateAscPeriodAsc(
         Long teacherId, LocalDate startDate, LocalDate endDate
     );

--- a/src/main/java/geumjeongyahak/domain/lesson/service/LessonAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/lesson/service/LessonAdminViewService.java
@@ -1,0 +1,106 @@
+package geumjeongyahak.domain.lesson.service;
+
+import geumjeongyahak.domain.base.dto.response.AdminPage;
+import geumjeongyahak.domain.base.dto.response.AdminSorts;
+import geumjeongyahak.domain.lesson.entity.Lesson;
+import geumjeongyahak.domain.lesson.enums.LessonStatus;
+import geumjeongyahak.domain.lesson.enums.TeacherAttendanceStatus;
+import geumjeongyahak.domain.lesson.repository.LessonRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LessonAdminViewService {
+
+    private final LessonRepository lessonRepository;
+
+    public AdminPage<AdminLessonRow> getLessons(LessonFilter filter) {
+        List<AdminLessonRow> rows = lessonRepository.findAllByIsDeletedFalseOrderByDateAscPeriodAsc()
+            .stream()
+            .filter(lesson -> matchesDateRange(lesson, filter.startDate(), filter.endDate()))
+            .filter(lesson -> filter.status() == null || lesson.getStatus() == filter.status())
+            .filter(lesson -> filter.teacherAttendance() == null
+                || lesson.getTeacherAttendance() == filter.teacherAttendance())
+            .map(AdminLessonRow::from)
+            .toList();
+
+        return AdminPage.from(sortLessons(rows, filter.sort()), filter.page(), filter.size());
+    }
+
+    private boolean matchesDateRange(Lesson lesson, LocalDate startDate, LocalDate endDate) {
+        LocalDate lessonDate = lesson.getDate();
+        if (startDate != null && lessonDate.isBefore(startDate)) {
+            return false;
+        }
+        return endDate == null || !lessonDate.isAfter(endDate);
+    }
+
+    private List<AdminLessonRow> sortLessons(List<AdminLessonRow> rows, String sort) {
+        return AdminSorts.sort(rows, sort, Map.of(
+            "id", Comparator.comparing(AdminLessonRow::id, Comparator.nullsLast(Long::compareTo)),
+            "date", Comparator.comparing(AdminLessonRow::date, Comparator.nullsLast(LocalDate::compareTo)),
+            "period", Comparator.comparing(AdminLessonRow::period, Comparator.nullsLast(Integer::compareTo)),
+            "teacherName", Comparator.comparing(AdminLessonRow::teacherName, Comparator.nullsLast(String::compareToIgnoreCase)),
+            "subjectName", Comparator.comparing(AdminLessonRow::subjectName, Comparator.nullsLast(String::compareToIgnoreCase)),
+            "status", Comparator.comparing(AdminLessonRow::status, Comparator.nullsLast(String::compareToIgnoreCase)),
+            "teacherAttendance", Comparator.comparing(AdminLessonRow::teacherAttendance, Comparator.nullsLast(String::compareToIgnoreCase))
+        ), "date,ASC;period,ASC");
+    }
+
+    public LessonStatus[] getStatuses() {
+        return LessonStatus.values();
+    }
+
+    public TeacherAttendanceStatus[] getTeacherAttendanceStatuses() {
+        return TeacherAttendanceStatus.values();
+    }
+
+    public record LessonFilter(
+        LocalDate startDate,
+        LocalDate endDate,
+        LessonStatus status,
+        TeacherAttendanceStatus teacherAttendance,
+        Integer page,
+        Integer size,
+        String sort
+    ) {
+    }
+
+    public record AdminLessonRow(
+        Long id,
+        LocalDate date,
+        Integer period,
+        LocalTime startTime,
+        LocalTime endTime,
+        String teacherName,
+        String subjectName,
+        String status,
+        String statusLabel,
+        String teacherAttendance,
+        String teacherAttendanceLabel
+    ) {
+        private static AdminLessonRow from(Lesson lesson) {
+            return new AdminLessonRow(
+                lesson.getId(),
+                lesson.getDate(),
+                lesson.getPeriod(),
+                lesson.getStartTime(),
+                lesson.getEndTime(),
+                lesson.getTeacher().getName(),
+                lesson.getSubject().getName(),
+                lesson.getStatus().name(),
+                lesson.getStatus().getDisplayName(),
+                lesson.getTeacherAttendance().name(),
+                lesson.getTeacherAttendance().getDisplayName()
+            );
+        }
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/lesson/v1/controller/LessonViewController.java
+++ b/src/main/java/geumjeongyahak/domain/lesson/v1/controller/LessonViewController.java
@@ -1,0 +1,47 @@
+package geumjeongyahak.domain.lesson.v1.controller;
+
+import geumjeongyahak.domain.lesson.enums.LessonStatus;
+import geumjeongyahak.domain.lesson.enums.TeacherAttendanceStatus;
+import geumjeongyahak.domain.lesson.service.LessonAdminViewService;
+import geumjeongyahak.domain.lesson.service.LessonAdminViewService.LessonFilter;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import static org.springframework.format.annotation.DateTimeFormat.ISO.DATE;
+
+@Controller
+@RequestMapping("/admin/lesson/lessons")
+@RequiredArgsConstructor
+public class LessonViewController {
+
+    private final LessonAdminViewService lessonAdminViewService;
+
+    @GetMapping
+    public String lessons(
+        @RequestParam(required = false) @DateTimeFormat(iso = DATE) LocalDate startDate,
+        @RequestParam(required = false) @DateTimeFormat(iso = DATE) LocalDate endDate,
+        @RequestParam(required = false) LessonStatus status,
+        @RequestParam(required = false) TeacherAttendanceStatus teacherAttendance,
+        @RequestParam(required = false) Integer page,
+        @RequestParam(required = false) Integer size,
+        @RequestParam(required = false) String sort,
+        Model model,
+        Authentication authentication
+    ) {
+        LessonFilter filter = new LessonFilter(startDate, endDate, status, teacherAttendance, page, size, sort);
+        model.addAttribute("active", "lessons");
+        model.addAttribute("adminName", authentication.getName());
+        model.addAttribute("filter", filter);
+        model.addAttribute("lessonsPage", lessonAdminViewService.getLessons(filter));
+        model.addAttribute("lessonStatuses", lessonAdminViewService.getStatuses());
+        model.addAttribute("teacherAttendanceStatuses", lessonAdminViewService.getTeacherAttendanceStatuses());
+        return "admin/lesson/lessons";
+    }
+}

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -32,6 +32,18 @@
                 <span>대기 중 구매 요청</span>
                 <strong th:text="${summary.pendingPurchaseRequestCount}">0</strong>
             </a>
+            <a class="metric" th:href="@{/admin/lesson/lessons}">
+                <span>전체 수업</span>
+                <strong th:text="${summary.lessonCount}">0</strong>
+            </a>
+            <a class="metric" th:href="@{/admin/lesson/lessons(startDate=${summary.today},endDate=${summary.today})}">
+                <span>오늘 수업</span>
+                <strong th:text="${summary.todayLessonCount}">0</strong>
+            </a>
+            <a class="metric" th:href="@{/admin/lesson/lessons(startDate=${summary.weekStart},endDate=${summary.weekEnd},status='SCHEDULED')}">
+                <span>이번 주 예정 수업</span>
+                <strong th:text="${summary.weeklyScheduledLessonCount}">0</strong>
+            </a>
         </section>
 
         <div class="dashboard-grid">
@@ -71,6 +83,10 @@
                     <a class="metric" th:href="@{/admin/classroom/classrooms}">
                         <span>분반 관리</span>
                         <p style="font-size: 13px; margin: 4px 0 0;">분반 및 교육 과정 운영</p>
+                    </a>
+                    <a class="metric" th:href="@{/admin/lesson/lessons}">
+                        <span>수업 관리</span>
+                        <p style="font-size: 13px; margin: 4px 0 0;">수업 일정과 운영 상태 조회</p>
                     </a>
                 </div>
             </section>

--- a/src/main/resources/templates/admin/fragments/layout.html
+++ b/src/main/resources/templates/admin/fragments/layout.html
@@ -432,6 +432,7 @@
             <a th:href="@{/admin/post/posts}" th:classappend="${active == 'posts'} ? 'active'">게시글</a>
             <a th:href="@{/admin/department/departments}" th:classappend="${active == 'departments'} ? 'active'">부서</a>
             <a th:href="@{/admin/classroom/classrooms}" th:classappend="${active == 'classrooms'} ? 'active'">분반</a>
+            <a th:href="@{/admin/lesson/lessons}" th:classappend="${active == 'lessons'} ? 'active'">수업</a>
             <a th:href="@{/admin/request/purchase/purchase-requests}" th:classappend="${active == 'purchaseRequests'} ? 'active'">구매 요청</a>
         </nav>
         <div th:if="${#arrays.contains(@environment.getActiveProfiles(), 'dev')}" style="margin-top: 20px;">

--- a/src/main/resources/templates/admin/lesson/lessons.html
+++ b/src/main/resources/templates/admin/lesson/lessons.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/layout :: head('수업 관리')}"></head>
+<body>
+<div th:replace="~{admin/fragments/layout :: shell(~{::main})}">
+    <main class="stack">
+        <div class="page-title">
+            <div>
+                <h1>수업</h1>
+                <p>날짜, 수업 상태, 교사 출석 상태 기준으로 수업 정보를 조회합니다.</p>
+            </div>
+        </div>
+
+        <form class="panel filter-grid" th:action="@{/admin/lesson/lessons}" method="get">
+            <label>시작일
+                <input name="startDate" type="date" th:value="${filter.startDate}">
+            </label>
+            <label>종료일
+                <input name="endDate" type="date" th:value="${filter.endDate}">
+            </label>
+            <label>수업 상태
+                <select name="status">
+                    <option value="">전체</option>
+                    <option th:each="status : ${lessonStatuses}" th:value="${status.name()}" th:text="${status.displayName}" th:selected="${filter.status == status}">예정</option>
+                </select>
+            </label>
+            <label>교사 출석
+                <select name="teacherAttendance">
+                    <option value="">전체</option>
+                    <option th:each="attendance : ${teacherAttendanceStatuses}" th:value="${attendance.name()}" th:text="${attendance.displayName}" th:selected="${filter.teacherAttendance == attendance}">출석</option>
+                </select>
+            </label>
+            <label>페이지 크기
+                <select name="size">
+                    <option value="10" th:selected="${lessonsPage.size == 10}">10</option>
+                    <option value="20" th:selected="${lessonsPage.size == 20}">20</option>
+                    <option value="50" th:selected="${lessonsPage.size == 50}">50</option>
+                    <option value="100" th:selected="${lessonsPage.size == 100}">100</option>
+                </select>
+            </label>
+            <label>정렬
+                <select name="sort">
+                    <option value="date,ASC;period,ASC" th:selected="${filter.sort == null || filter.sort == 'date,ASC;period,ASC'}">날짜 오름차순</option>
+                    <option value="date,DESC;period,ASC" th:selected="${filter.sort == 'date,DESC;period,ASC'}">날짜 내림차순</option>
+                    <option value="teacherName,ASC" th:selected="${filter.sort == 'teacherName,ASC'}">교사 오름차순</option>
+                    <option value="subjectName,ASC" th:selected="${filter.sort == 'subjectName,ASC'}">과목 오름차순</option>
+                    <option value="status,ASC" th:selected="${filter.sort == 'status,ASC'}">수업 상태 오름차순</option>
+                </select>
+            </label>
+            <button class="button" type="submit">조회</button>
+            <a class="reset-link" th:href="@{/admin/lesson/lessons}">초기화</a>
+        </form>
+
+        <section class="panel table-panel">
+            <div class="table-scroll">
+                <table>
+                    <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>날짜</th>
+                        <th>교시</th>
+                        <th>시간</th>
+                        <th>교사</th>
+                        <th>과목</th>
+                        <th>수업 상태</th>
+                        <th>교사 출석</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="lesson : ${lessonsPage.content}">
+                        <td th:text="${lesson.id}">1</td>
+                        <td th:text="${lesson.date}">2026-05-11</td>
+                        <td th:text="${lesson.period}">1</td>
+                        <td th:text="|${lesson.startTime} - ${lesson.endTime}|">19:20 - 20:00</td>
+                        <td th:text="${lesson.teacherName}">홍길동</td>
+                        <td th:text="${lesson.subjectName}">국어</td>
+                        <td><span class="pill" th:text="${lesson.statusLabel}">예정</span></td>
+                        <td><span class="pill" th:text="${lesson.teacherAttendanceLabel}">결석</span></td>
+                    </tr>
+                    <tr th:if="${#lists.isEmpty(lessonsPage.content)}">
+                        <td colspan="8" class="empty">조회된 수업이 없습니다.</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+            <div class="pager">
+                <span th:text="|총 ${lessonsPage.totalElements}건 · ${lessonsPage.page + 1}/${lessonsPage.totalPages == 0 ? 1 : lessonsPage.totalPages} 페이지|">총 0건</span>
+                <div>
+                    <a class="reset-link" th:classappend="${!lessonsPage.hasPrevious()} ? 'disabled'" th:href="@{/admin/lesson/lessons(startDate=${filter.startDate},endDate=${filter.endDate},status=${filter.status},teacherAttendance=${filter.teacherAttendance},size=${lessonsPage.size},sort=${filter.sort},page=${lessonsPage.previousPage()})}">이전</a>
+                    <a class="reset-link" th:classappend="${!lessonsPage.hasNext()} ? 'disabled'" th:href="@{/admin/lesson/lessons(startDate=${filter.startDate},endDate=${filter.endDate},status=${filter.status},teacherAttendance=${filter.teacherAttendance},size=${lessonsPage.size},sort=${filter.sort},page=${lessonsPage.nextPage()})}">다음</a>
+                </div>
+            </div>
+        </section>
+    </main>
+</div>
+</body>
+</html>

--- a/src/test/java/geumjeongyahak/unit/base/AdminDashboardServiceTest.java
+++ b/src/test/java/geumjeongyahak/unit/base/AdminDashboardServiceTest.java
@@ -1,0 +1,78 @@
+package geumjeongyahak.unit.base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import geumjeongyahak.domain.base.service.AdminDashboardService;
+import geumjeongyahak.domain.base.service.AdminDashboardService.AdminDashboardSummary;
+import geumjeongyahak.domain.classroom.repository.ClassroomRepository;
+import geumjeongyahak.domain.department.repository.DepartmentRepository;
+import geumjeongyahak.domain.lesson.enums.LessonStatus;
+import geumjeongyahak.domain.lesson.repository.LessonRepository;
+import geumjeongyahak.domain.purchase_request.enums.PurchaseRequestStatus;
+import geumjeongyahak.domain.purchase_request.repository.PurchaseRequestRepository;
+import geumjeongyahak.domain.student.repository.StudentRepository;
+import geumjeongyahak.domain.users.repository.UserRepository;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminDashboardServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private DepartmentRepository departmentRepository;
+
+    @Mock
+    private ClassroomRepository classroomRepository;
+
+    @Mock
+    private PurchaseRequestRepository purchaseRequestRepository;
+
+    @Mock
+    private StudentRepository studentRepository;
+
+    @Mock
+    private LessonRepository lessonRepository;
+
+    @InjectMocks
+    private AdminDashboardService adminDashboardService;
+
+    @Test
+    void getSummary_includesLessonCounts() {
+        given(userRepository.count()).willReturn(4L);
+        given(departmentRepository.count()).willReturn(6L);
+        given(classroomRepository.count()).willReturn(9L);
+        given(purchaseRequestRepository.countByStatus(PurchaseRequestStatus.PENDING)).willReturn(2L);
+        given(studentRepository.count()).willReturn(11L);
+        given(lessonRepository.countByIsDeletedFalse()).willReturn(20L);
+        given(lessonRepository.countByIsDeletedFalseAndDate(any(LocalDate.class))).willReturn(3L);
+        given(lessonRepository.countByStatusAndIsDeletedFalseAndDateBetween(
+            eq(LessonStatus.SCHEDULED),
+            any(LocalDate.class),
+            any(LocalDate.class)
+        )).willReturn(8L);
+
+        AdminDashboardSummary summary = adminDashboardService.getSummary();
+
+        assertThat(summary.userCount()).isEqualTo(4L);
+        assertThat(summary.departmentCount()).isEqualTo(6L);
+        assertThat(summary.classroomCount()).isEqualTo(9L);
+        assertThat(summary.pendingPurchaseRequestCount()).isEqualTo(2L);
+        assertThat(summary.studentCount()).isEqualTo(11L);
+        assertThat(summary.lessonCount()).isEqualTo(20L);
+        assertThat(summary.todayLessonCount()).isEqualTo(3L);
+        assertThat(summary.weeklyScheduledLessonCount()).isEqualTo(8L);
+        assertThat(summary.today()).isNotNull();
+        assertThat(summary.weekStart()).isNotNull();
+        assertThat(summary.weekEnd()).isNotNull();
+    }
+}

--- a/src/test/java/geumjeongyahak/unit/lesson/LessonAdminViewServiceTest.java
+++ b/src/test/java/geumjeongyahak/unit/lesson/LessonAdminViewServiceTest.java
@@ -1,0 +1,153 @@
+package geumjeongyahak.unit.lesson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import geumjeongyahak.domain.auth.enums.RoleType;
+import geumjeongyahak.domain.base.dto.response.AdminPage;
+import geumjeongyahak.domain.lesson.entity.Lesson;
+import geumjeongyahak.domain.lesson.enums.LessonStatus;
+import geumjeongyahak.domain.lesson.enums.TeacherAttendanceStatus;
+import geumjeongyahak.domain.lesson.repository.LessonRepository;
+import geumjeongyahak.domain.lesson.service.LessonAdminViewService;
+import geumjeongyahak.domain.lesson.service.LessonAdminViewService.AdminLessonRow;
+import geumjeongyahak.domain.lesson.service.LessonAdminViewService.LessonFilter;
+import geumjeongyahak.domain.subject.entity.Subject;
+import geumjeongyahak.domain.users.entity.User;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LessonAdminViewServiceTest {
+
+    @Mock
+    private LessonRepository lessonRepository;
+
+    @InjectMocks
+    private LessonAdminViewService lessonAdminViewService;
+
+    @Test
+    void getLessons_filtersByDateStatusAndTeacherAttendance() {
+        Lesson matchingLesson = lesson(
+            "김교사",
+            "국어",
+            LocalDate.of(2026, 5, 11),
+            1,
+            LessonStatus.SCHEDULED,
+            TeacherAttendanceStatus.ABSENT
+        );
+        Lesson completedLesson = lesson(
+            "박교사",
+            "수학",
+            LocalDate.of(2026, 5, 12),
+            2,
+            LessonStatus.COMPLETED,
+            TeacherAttendanceStatus.PRESENT
+        );
+        Lesson outsideDateLesson = lesson(
+            "이교사",
+            "영어",
+            LocalDate.of(2026, 5, 18),
+            1,
+            LessonStatus.SCHEDULED,
+            TeacherAttendanceStatus.ABSENT
+        );
+        given(lessonRepository.findAllByIsDeletedFalseOrderByDateAscPeriodAsc())
+            .willReturn(List.of(matchingLesson, completedLesson, outsideDateLesson));
+
+        AdminPage<AdminLessonRow> page = lessonAdminViewService.getLessons(new LessonFilter(
+            LocalDate.of(2026, 5, 10),
+            LocalDate.of(2026, 5, 12),
+            LessonStatus.SCHEDULED,
+            TeacherAttendanceStatus.ABSENT,
+            null,
+            null,
+            null
+        ));
+
+        assertThat(page.totalElements()).isEqualTo(1);
+        assertThat(page.content()).extracting(AdminLessonRow::teacherName).containsExactly("김교사");
+        assertThat(page.content()).extracting(AdminLessonRow::subjectName).containsExactly("국어");
+    }
+
+    @Test
+    void getLessons_sortsByTeacherName() {
+        Lesson secondTeacherLesson = lesson(
+            "최교사",
+            "수학",
+            LocalDate.of(2026, 5, 11),
+            1,
+            LessonStatus.SCHEDULED,
+            TeacherAttendanceStatus.ABSENT
+        );
+        Lesson firstTeacherLesson = lesson(
+            "김교사",
+            "국어",
+            LocalDate.of(2026, 5, 12),
+            1,
+            LessonStatus.SCHEDULED,
+            TeacherAttendanceStatus.ABSENT
+        );
+        given(lessonRepository.findAllByIsDeletedFalseOrderByDateAscPeriodAsc())
+            .willReturn(List.of(secondTeacherLesson, firstTeacherLesson));
+
+        AdminPage<AdminLessonRow> page = lessonAdminViewService.getLessons(new LessonFilter(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "teacherName,ASC"
+        ));
+
+        assertThat(page.content()).extracting(AdminLessonRow::teacherName).containsExactly("김교사", "최교사");
+    }
+
+    private Lesson lesson(
+        String teacherName,
+        String subjectName,
+        LocalDate date,
+        int period,
+        LessonStatus status,
+        TeacherAttendanceStatus teacherAttendance
+    ) {
+        User teacher = User.builder()
+            .nickname(teacherName)
+            .name(teacherName)
+            .role(RoleType.VOLUNTEER)
+            .build();
+        Subject subject = new Subject(
+            null,
+            teacher,
+            subjectName,
+            date,
+            date.plusMonths(1),
+            DayOfWeek.MONDAY,
+            LocalTime.of(19, 20),
+            LocalTime.of(20, 0),
+            period,
+            LocalDateTime.now(),
+            null
+        );
+        Lesson lesson = new Lesson(
+            subject,
+            teacher,
+            date,
+            LocalTime.of(19, 20),
+            LocalTime.of(20, 0),
+            period
+        );
+        lesson.updateStatus(status);
+        lesson.updateTeacherAttendance(teacherAttendance);
+        return lesson;
+    }
+}


### PR DESCRIPTION
## 개요

관리자 콘솔에서 수업 현황을 확인하고 수업 목록 화면으로 이동할 수 있도록 수업 관리 UI를 추가했습니다.

## 변경 유형

- [x] 새 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [x] 테스트 (test)
- [ ] 기타 (chore)

## 변경 내용

- 관리자 수업 목록 화면을 추가했습니다.
  - URL: `/admin/lesson/lessons`
  - 날짜 범위, 수업 상태, 교사 출석 상태 필터 지원
  - 날짜, 교시, 교사, 과목, 상태 기준 정렬 지원
  - 수업 상태/교사 출석 상태를 한글 라벨로 표시

- 관리자 대시보드에 수업 현황 지표를 추가했습니다.
  - 전체 수업 수
  - 오늘 수업 수
  - 이번 주 예정 수업 수
  - 각 지표 클릭 시 수업 목록 화면으로 이동

- 관리자 사이드바에 `수업` 메뉴를 추가했습니다.
  - 링크: `/admin/lesson/lessons`
  - 수업 목록 화면에서 active 메뉴 표시

- 관련 테스트를 추가했습니다.
  - `LessonAdminViewServiceTest`
  - `AdminDashboardServiceTest`

## 관련 이슈

Closes #56

## 스크린샷 (선택)

관리자 대시보드와 수업 목록 화면 UI 변경이 포함됩니다.
<img width="1920" height="916" alt="image" src="https://github.com/user-attachments/assets/1cce097d-8cde-4da9-a1da-1efec2e74620" />
<img width="1920" height="919" alt="image" src="https://github.com/user-attachments/assets/0ec48fff-615a-44bc-9674-2101bc0f9f0b" />

## 체크리스트

- [x] 코드 컨벤션을 준수했습니다
- [x] 테스트 코드를 작성/수정했습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)

## 리뷰어에게

이번 PR 범위와 직접 관련된 테스트는 통과했습니다.