### PR TITLE
[FEAT] 수업 교환 요청 관리자 대시보드 추가

### DIFF
--- a/docs/Domain/User/Permissions.md
+++ b/docs/Domain/User/Permissions.md
@@ -176,6 +176,9 @@ permission code로는 표현되지 않습니다.
 | `PATCH /api/v1/lesson-exchange-requests/{requestId}/approve` | `ADMIN` \| `lesson-exchange-request:manage:*` |
 | `PATCH /api/v1/lesson-exchange-requests/{requestId}/reject` | `ADMIN` \| `lesson-exchange-request:manage:*` |
 | `POST /api/v1/lesson-exchange-requests/{requestId}/proposals` | 인증만 |
+| `GET /admin/request/lesson-exchange` | 관리자 콘솔 접근 가능 사용자 |
+| `POST /admin/request/lesson-exchange/{requestId}/approve` | `ADMIN` \| `lesson-exchange-request:manage:*` |
+| `POST /admin/request/lesson-exchange/{requestId}/reject` | `ADMIN` \| `lesson-exchange-request:manage:*` |
 | `POST /api/v1/purchase-requests` | 인증만 |
 | `GET /api/v1/admin/purchase-requests` | `ADMIN` \| `purchase-request:read:*` |
 | `GET /api/v1/admin/purchase-requests/{requestId}` | `ADMIN` \| `MANAGER` \| `purchase-request:read:*` |

--- a/docs/api/Requests.md
+++ b/docs/api/Requests.md
@@ -89,9 +89,40 @@
 | 제안 목록 조회 | 교사 이상 권한 |
 | 제안 수락 | 교사 이상 권한 + 요청자 본인 조건 |
 
-## 4. 결석 요청 API
+## 4. 관리자 콘솔
 
-## 4.1 결석 요청 생성
+### 4.1 수업 교환 요청 관리자 대시보드
+
+- **URL**: `/admin/request/lesson-exchange`
+- **Method**: `GET`
+- **Description**: 관리자 콘솔에서 수업 교환 요청과 제안의 처리 현황을 조회합니다.
+
+### 표시 항목
+
+- 수업 교환 요청 상태별 건수
+  - `PENDING`, `APPROVED`, `REJECTED`, `COMPLETED`, `EXPIRED`, `CANCELLED`
+- 수업 교환 제안 상태별 건수
+  - `ACTIVE`, `WITHDRAWN`, `ACCEPTED`, `CLOSED`
+- 승인 검토가 필요한 `PENDING` 요청 목록
+  - 오래된 요청부터 최대 10건
+  - 요청 ID, 제목, 반 이름, 요청자, 수업일, 만료 시각, 제안 수, 상태, 생성일 표시
+
+### 관리자 액션
+
+| 화면 액션 | URL | Method | 권한 | 설명 |
+|---|---|---|---|---|
+| 수업 교환 요청 승인 | `/admin/request/lesson-exchange/{requestId}/approve` | `POST` | `ADMIN` 또는 `lesson-exchange-request:manage:*` | `PENDING` 요청을 `APPROVED`로 변경 |
+| 수업 교환 요청 반려 | `/admin/request/lesson-exchange/{requestId}/reject` | `POST` | `ADMIN` 또는 `lesson-exchange-request:manage:*` | `PENDING` 요청을 `REJECTED`로 변경하고 반려 사유 저장 |
+
+### 구현 기준 동작
+
+- 관리자 콘솔 액션은 기존 `LessonExchangeRequestService`의 승인/반려 로직을 재사용합니다.
+- 승인/반려 후 `/admin/request/lesson-exchange`로 리다이렉트하고 처리 결과 메시지를 표시합니다.
+- 제안은 승인된 요청에 대해서만 생성할 수 있으므로, 관리자 대시보드의 검토 필요 목록은 제안 수가 0일 수 있습니다.
+
+## 5. 결석 요청 API
+
+## 5.1 결석 요청 생성
 
 - **URL**: `/api/v1/absence-requests`
 - **Method**: `POST`
@@ -141,7 +172,7 @@
 | 같은 수업에 진행 중인 결석 요청 존재 | 409 |
 | 이미 만료된 수업에 대한 요청 | 400 |
 
-## 4.2 결석 요청 목록 조회
+## 5.2 결석 요청 목록 조회
 
 - **URL**: `/api/v1/absence-requests`
 - **Method**: `GET`
@@ -187,7 +218,7 @@
 }
 ```
 
-## 4.3 결석 요청 상세 조회
+## 5.3 결석 요청 상세 조회
 
 - **URL**: `/api/v1/absence-requests/{requestId}`
 - **Method**: `GET`
@@ -198,7 +229,7 @@
 - `ADMIN` 또는 `absence-request:read:*` 권한 사용자는 모든 요청을 조회할 수 있습니다.
 - 그 외 `VOLUNTEER`, `MANAGER` 사용자는 본인이 요청한 결석 요청만 조회할 수 있습니다.
 
-## 4.4 결석 요청 승인
+## 5.4 결석 요청 승인
 
 - **URL**: `/api/v1/absence-requests/{requestId}/approve`
 - **Method**: `PATCH`
@@ -211,7 +242,7 @@
 - `AbsenceApprovedEvent`가 발행되고, 대상 수업의 `teacherAttendance`가 `EXCUSED`로 변경됩니다.
 - 이미 `APPROVED`, `REJECTED`, `CANCELLED`, `EXPIRED` 상태인 요청은 재처리할 수 없습니다.
 
-## 4.5 결석 요청 반려
+## 5.5 결석 요청 반려
 
 - **URL**: `/api/v1/absence-requests/{requestId}/reject`
 - **Method**: `PATCH`
@@ -231,7 +262,7 @@
 - `approvalAt`, `approvalBy`, `note`가 기록됩니다.
 - 이미 `APPROVED`, `REJECTED`, `CANCELLED`, `EXPIRED` 상태인 요청은 재처리할 수 없습니다.
 
-## 4.6 결석 요청 취소
+## 5.6 결석 요청 취소
 
 - **URL**: `/api/v1/absence-requests/{requestId}`
 - **Method**: `DELETE`
@@ -243,15 +274,15 @@
 - 수업 출석 상태를 변경하지 않습니다.
 - 본인 요청이 아니거나 이미 처리된 요청이면 취소할 수 없습니다.
 
-## 4.7 결석 요청 자동 만료
+## 5.7 결석 요청 자동 만료
 
 - `PENDING` 상태의 결석 요청 중 `expiresAt`이 지난 요청은 스케줄러가 자동으로 `EXPIRED` 처리합니다.
 - `expiresAt`은 수업 하루 전까지 처리를 유도하기 위해 대상 수업일의 00:00으로 자동 설정됩니다.
 - 만료된 요청은 승인, 반려, 취소할 수 없습니다.
 
-## 5. 수업 교환 요청 API
+## 6. 수업 교환 요청 API
 
-## 5.1 요청 생성
+## 6.1 요청 생성
 
 - **URL**: `/api/v1/lesson-exchange-requests`
 - **Method**: `POST`
@@ -282,7 +313,7 @@
 | 교환 요청 가능 기간(현재+4일) 이전 수업 | 400 |
 | 만료 시각 정책 위반 | 400 |
 
-## 5.2 요청 목록 조회
+## 6.2 요청 목록 조회
 
 - **URL**: `/api/v1/lesson-exchange-requests`
 - **Method**: `GET`
@@ -295,13 +326,13 @@
 | `status` | 특정 상태만 조회 |
 | `mine` | `true`면 본인 요청만 조회 |
 
-## 5.3 요청 상세 조회
+## 6.3 요청 상세 조회
 
 - **URL**: `/api/v1/lesson-exchange-requests/{requestId}`
 - **Method**: `GET`
 - **Description**: 교사 이상 권한 사용자가 수업 교환 요청 단건 상세를 조회합니다.
 
-## 5.4 요청 수정
+## 6.4 요청 수정
 
 - **URL**: `/api/v1/lesson-exchange-requests/{requestId}`
 - **Method**: `PATCH`
@@ -313,7 +344,7 @@
 - 수정 후 반 이름 snapshot도 함께 갱신됩니다.
 - 요청 날짜를 변경하면 변경된 날짜의 요청자 수업 전체를 하루 단위로 다시 검증합니다.
 
-## 5.5 요청 취소
+## 6.5 요청 취소
 
 - **URL**: `/api/v1/lesson-exchange-requests/{requestId}/cancel`
 - **Method**: `PATCH`
@@ -324,7 +355,7 @@
 - 요청 상태가 `CANCELLED`로 변경됩니다.
 - `cancelledAt`이 기록됩니다.
 
-## 5.6 요청 승인
+## 6.6 요청 승인
 
 - **URL**: `/api/v1/lesson-exchange-requests/{requestId}/approve`
 - **Method**: `PATCH`
@@ -335,7 +366,7 @@
 - 요청 상태가 `APPROVED`로 변경됩니다.
 - `processedAt`, `processedBy`가 기록됩니다.
 
-## 5.7 요청 반려
+## 6.7 요청 반려
 
 - **URL**: `/api/v1/lesson-exchange-requests/{requestId}/reject`
 - **Method**: `PATCH`
@@ -354,9 +385,9 @@
 - 요청 상태가 `REJECTED`로 변경됩니다.
 - `processedAt`, `processedBy`, `rejectionNote`가 기록됩니다.
 
-## 6. 수업 교환 제안 API
+## 7. 수업 교환 제안 API
 
-## 6.1 제안 생성
+## 7.1 제안 생성
 
 - **URL**: `/api/v1/lesson-exchange-requests/{requestId}/proposals`
 - **Method**: `POST`
@@ -386,13 +417,13 @@
 - `EXCHANGE` 제안은 제안 날짜에 제안자의 수업이 있어야 하며, 해당 날짜 수업 전체가 교환 대상입니다.
 - `SUBSTITUTION` 제안은 요청 수업 시간대에 제안자의 기존 수업이 충돌하면 생성할 수 없습니다.
 
-## 6.2 제안 목록 조회
+## 7.2 제안 목록 조회
 
 - **URL**: `/api/v1/lesson-exchange-requests/{requestId}/proposals`
 - **Method**: `GET`
 - **Description**: 교사 이상 권한 사용자가 특정 요청에 등록된 제안 목록을 최신순으로 조회합니다.
 
-## 6.3 제안 수정
+## 7.3 제안 수정
 
 - **URL**: `/api/v1/lesson-exchange-requests/{requestId}/proposals/{proposalId}`
 - **Method**: `PATCH`
@@ -404,7 +435,7 @@
 - `EXCHANGE <-> SUBSTITUTION` 전환이 가능합니다.
 - 교환형으로 수정될 때는 제안 날짜의 제안자 수업 전체를 기준으로 반 이름 snapshot을 다시 계산합니다.
 
-## 6.4 제안 철회
+## 7.4 제안 철회
 
 - **URL**: `/api/v1/lesson-exchange-requests/{requestId}/proposals/{proposalId}/withdraw`
 - **Method**: `PATCH`
@@ -415,7 +446,7 @@
 - 제안 상태가 `WITHDRAWN`으로 변경됩니다.
 - `withdrawnAt`이 기록됩니다.
 
-## 6.5 제안 수락
+## 7.5 제안 수락
 
 - **URL**: `/api/v1/lesson-exchange-requests/{requestId}/proposals/{proposalId}/accept`
 - **Method**: `PATCH`
@@ -436,9 +467,9 @@
 - `SUBSTITUTION`
   - 요청 날짜의 요청자 수업 전체 teacher를 제안자로 변경
 
-## 7. 대표 시퀀스
+## 8. 대표 시퀀스
 
-### 7.1 요청 생성 → 승인 → 제안 생성 → 수락
+### 8.1 요청 생성 → 승인 → 제안 생성 → 수락
 
 ```mermaid
 sequenceDiagram
@@ -471,7 +502,7 @@ sequenceDiagram
     ProposalService-->>Requester: 요청 COMPLETED, 제안 ACCEPTED
 ```
 
-### 7.2 자동 만료
+### 8.2 자동 만료
 
 ```mermaid
 sequenceDiagram

--- a/src/main/java/geumjeongyahak/domain/request/repository/LessonExchangeProposalRepository.java
+++ b/src/main/java/geumjeongyahak/domain/request/repository/LessonExchangeProposalRepository.java
@@ -29,4 +29,10 @@ public interface LessonExchangeProposalRepository
         Long requestId,
         LessonExchangeProposalStatus status
     );
+
+    long countByStatus(LessonExchangeProposalStatus status);
+
+    long countByRequest_Id(Long requestId);
+
+    long countByRequest_IdAndStatus(Long requestId, LessonExchangeProposalStatus status);
 }

--- a/src/main/java/geumjeongyahak/domain/request/repository/LessonExchangeRequestRepository.java
+++ b/src/main/java/geumjeongyahak/domain/request/repository/LessonExchangeRequestRepository.java
@@ -51,4 +51,10 @@ public interface LessonExchangeRequestRepository extends JpaRepository<LessonExc
         Collection<LessonExchangeRequestStatus> statuses,
         LocalDateTime expiresAt
     );
+
+    long countByStatus(LessonExchangeRequestStatus status);
+
+    List<LessonExchangeRequest> findTop10ByStatusOrderByCreatedAtAsc(
+        LessonExchangeRequestStatus status
+    );
 }

--- a/src/main/java/geumjeongyahak/domain/request/service/LessonExchangeRequestAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/request/service/LessonExchangeRequestAdminViewService.java
@@ -1,0 +1,151 @@
+package geumjeongyahak.domain.request.service;
+
+import geumjeongyahak.domain.request.entity.LessonExchangeRequest;
+import geumjeongyahak.domain.request.enums.LessonExchangeProposalStatus;
+import geumjeongyahak.domain.request.enums.LessonExchangeRequestStatus;
+import geumjeongyahak.domain.request.repository.LessonExchangeProposalRepository;
+import geumjeongyahak.domain.request.repository.LessonExchangeRequestRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LessonExchangeRequestAdminViewService {
+
+    private final LessonExchangeRequestRepository lessonExchangeRequestRepository;
+    private final LessonExchangeProposalRepository lessonExchangeProposalRepository;
+
+    public LessonExchangeDashboard getDashboard() {
+        List<StatusCount<LessonExchangeRequestStatus>> requestStatusCounts = Arrays.stream(LessonExchangeRequestStatus.values())
+            .map(status -> new StatusCount<>(
+                status,
+                requestStatusLabel(status),
+                lessonExchangeRequestRepository.countByStatus(status)
+            ))
+            .toList();
+        List<StatusCount<LessonExchangeProposalStatus>> proposalStatusCounts = Arrays.stream(LessonExchangeProposalStatus.values())
+            .map(status -> new StatusCount<>(
+                status,
+                proposalStatusLabel(status),
+                lessonExchangeProposalRepository.countByStatus(status)
+            ))
+            .toList();
+
+        return new LessonExchangeDashboard(
+            requestStatusCounts,
+            proposalStatusCounts,
+            countRequestStatus(requestStatusCounts, LessonExchangeRequestStatus.PENDING),
+            countProposalStatus(proposalStatusCounts, LessonExchangeProposalStatus.ACTIVE),
+            getReviewRequiredRequests()
+        );
+    }
+
+    private List<ReviewRequiredRequestRow> getReviewRequiredRequests() {
+        return lessonExchangeRequestRepository
+            .findTop10ByStatusOrderByCreatedAtAsc(LessonExchangeRequestStatus.PENDING)
+            .stream()
+            .map(this::toReviewRequiredRequestRow)
+            .toList();
+    }
+
+    private ReviewRequiredRequestRow toReviewRequiredRequestRow(LessonExchangeRequest request) {
+        long proposalCount = lessonExchangeProposalRepository.countByRequest_Id(request.getId());
+        long activeProposalCount = lessonExchangeProposalRepository.countByRequest_IdAndStatus(
+            request.getId(),
+            LessonExchangeProposalStatus.ACTIVE
+        );
+
+        return new ReviewRequiredRequestRow(
+            request.getId(),
+            request.getClassroomNameSnapshot(),
+            request.getRequestedBy().getName(),
+            request.getTitle(),
+            request.getLessonDate(),
+            request.getExpiresAt(),
+            request.getCreatedAt(),
+            request.getStatus(),
+            requestStatusLabel(request.getStatus()),
+            proposalCount,
+            activeProposalCount
+        );
+    }
+
+    private long countRequestStatus(
+        List<StatusCount<LessonExchangeRequestStatus>> statusCounts,
+        LessonExchangeRequestStatus status
+    ) {
+        return statusCounts.stream()
+            .filter(statusCount -> statusCount.status() == status)
+            .findFirst()
+            .map(StatusCount::count)
+            .orElse(0L);
+    }
+
+    private long countProposalStatus(
+        List<StatusCount<LessonExchangeProposalStatus>> statusCounts,
+        LessonExchangeProposalStatus status
+    ) {
+        return statusCounts.stream()
+            .filter(statusCount -> statusCount.status() == status)
+            .findFirst()
+            .map(StatusCount::count)
+            .orElse(0L);
+    }
+
+    private String requestStatusLabel(LessonExchangeRequestStatus status) {
+        return switch (status) {
+            case PENDING -> "승인 대기";
+            case APPROVED -> "승인";
+            case REJECTED -> "반려";
+            case COMPLETED -> "교환 완료";
+            case EXPIRED -> "만료";
+            case CANCELLED -> "취소";
+        };
+    }
+
+    private String proposalStatusLabel(LessonExchangeProposalStatus status) {
+        return switch (status) {
+            case ACTIVE -> "진행 중";
+            case WITHDRAWN -> "철회";
+            case ACCEPTED -> "수락";
+            case CLOSED -> "종료";
+        };
+    }
+
+    public record LessonExchangeDashboard(
+        List<StatusCount<LessonExchangeRequestStatus>> requestStatusCounts,
+        List<StatusCount<LessonExchangeProposalStatus>> proposalStatusCounts,
+        long pendingRequestCount,
+        long activeProposalCount,
+        List<ReviewRequiredRequestRow> reviewRequiredRequests
+    ) {
+    }
+
+    public record StatusCount<T extends Enum<T>>(
+        T status,
+        String label,
+        long count
+    ) {
+    }
+
+    public record ReviewRequiredRequestRow(
+        Long id,
+        String classroomName,
+        String requestedByName,
+        String title,
+        LocalDate lessonDate,
+        LocalDateTime expiresAt,
+        LocalDateTime createdAt,
+        LessonExchangeRequestStatus status,
+        String statusLabel,
+        long proposalCount,
+        long activeProposalCount
+    ) {
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/request/service/LessonExchangeRequestAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/request/service/LessonExchangeRequestAdminViewService.java
@@ -20,6 +20,7 @@ public class LessonExchangeRequestAdminViewService {
 
     private final LessonExchangeRequestRepository lessonExchangeRequestRepository;
     private final LessonExchangeProposalRepository lessonExchangeProposalRepository;
+    private final LessonExchangeRequestService lessonExchangeRequestService;
 
     public LessonExchangeDashboard getDashboard() {
         List<StatusCount<LessonExchangeRequestStatus>> requestStatusCounts = Arrays.stream(LessonExchangeRequestStatus.values())
@@ -116,6 +117,16 @@ public class LessonExchangeRequestAdminViewService {
             case ACCEPTED -> "수락";
             case CLOSED -> "종료";
         };
+    }
+
+    @Transactional
+    public void approve(Long approverId, Long requestId) {
+        lessonExchangeRequestService.approveLessonExchangeRequest(approverId, requestId);
+    }
+
+    @Transactional
+    public void reject(Long approverId, Long requestId, String note) {
+        lessonExchangeRequestService.rejectLessonExchangeRequest(approverId, requestId, note);
     }
 
     public record LessonExchangeDashboard(

--- a/src/main/java/geumjeongyahak/domain/request/v1/controller/LessonExchangeRequestViewController.java
+++ b/src/main/java/geumjeongyahak/domain/request/v1/controller/LessonExchangeRequestViewController.java
@@ -1,0 +1,25 @@
+package geumjeongyahak.domain.request.v1.controller;
+
+import geumjeongyahak.domain.request.service.LessonExchangeRequestAdminViewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/admin/request/lesson-exchange")
+@RequiredArgsConstructor
+public class LessonExchangeRequestViewController {
+
+    private final LessonExchangeRequestAdminViewService lessonExchangeRequestAdminViewService;
+
+    @GetMapping
+    public String dashboard(Model model, Authentication authentication) {
+        model.addAttribute("active", "lessonExchangeRequests");
+        model.addAttribute("adminName", authentication.getName());
+        model.addAttribute("dashboard", lessonExchangeRequestAdminViewService.getDashboard());
+        return "admin/request/lesson-exchange/dashboard";
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/request/v1/controller/LessonExchangeRequestViewController.java
+++ b/src/main/java/geumjeongyahak/domain/request/v1/controller/LessonExchangeRequestViewController.java
@@ -1,17 +1,27 @@
 package geumjeongyahak.domain.request.v1.controller;
 
+import geumjeongyahak.common.security.service.CustomUserDetails;
 import geumjeongyahak.domain.request.service.LessonExchangeRequestAdminViewService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
 @RequestMapping("/admin/request/lesson-exchange")
 @RequiredArgsConstructor
 public class LessonExchangeRequestViewController {
+
+    private static final String LESSON_EXCHANGE_MANAGE_ACCESS =
+        "hasRole('ADMIN') or hasAuthority('lesson-exchange-request:manage:*')";
 
     private final LessonExchangeRequestAdminViewService lessonExchangeRequestAdminViewService;
 
@@ -21,5 +31,30 @@ public class LessonExchangeRequestViewController {
         model.addAttribute("adminName", authentication.getName());
         model.addAttribute("dashboard", lessonExchangeRequestAdminViewService.getDashboard());
         return "admin/request/lesson-exchange/dashboard";
+    }
+
+    @PreAuthorize(LESSON_EXCHANGE_MANAGE_ACCESS)
+    @PostMapping("/{requestId}/approve")
+    public String approve(
+        @PathVariable Long requestId,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        RedirectAttributes redirectAttributes
+    ) {
+        lessonExchangeRequestAdminViewService.approve(userDetails.getUserId(), requestId);
+        redirectAttributes.addFlashAttribute("message", "수업 교환 요청을 승인했습니다.");
+        return "redirect:/admin/request/lesson-exchange";
+    }
+
+    @PreAuthorize(LESSON_EXCHANGE_MANAGE_ACCESS)
+    @PostMapping("/{requestId}/reject")
+    public String reject(
+        @PathVariable Long requestId,
+        @RequestParam String note,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        RedirectAttributes redirectAttributes
+    ) {
+        lessonExchangeRequestAdminViewService.reject(userDetails.getUserId(), requestId, note);
+        redirectAttributes.addFlashAttribute("message", "수업 교환 요청을 반려했습니다.");
+        return "redirect:/admin/request/lesson-exchange";
     }
 }

--- a/src/main/resources/sql/init_data.sql
+++ b/src/main/resources/sql/init_data.sql
@@ -107,14 +107,55 @@ VALUES
     (6, 2, 3, 3, '2026-06-17', '21:00:00', '21:40:00', 'SCHEDULED', 'ABSENT');
 ALTER SEQUENCE lessons_id_seq RESTART WITH 7;
 
--- 10. Students
+-- 10. Lesson Exchange Requests
+INSERT INTO lesson_exchange_requests (
+    id, lesson_date, requested_by, title, classroom_name_snapshot, content, status,
+    expires_at, processed_at, processed_by, completed_at, cancelled_at, rejection_note,
+    created_at, updated_at
+)
+VALUES
+    (1, '2026-06-10', 2, '6월 10일 한글 기초 수업 교환 요청', '벚꽃반', '개인 일정으로 6월 10일 한글 기초 수업 교환을 요청합니다.', 'PENDING',
+     '2026-06-07 23:59:00', NULL, NULL, NULL, NULL, NULL, '2026-05-20 10:00:00', '2026-05-20 10:00:00'),
+    (2, '2026-06-17', 3, '6월 17일 수학 기초 수업 교환 요청', '개나리반', '해당 날짜 수학 기초 수업을 다른 선생님과 교환하고 싶습니다.', 'PENDING',
+     '2026-06-14 23:59:00', NULL, NULL, NULL, NULL, NULL, '2026-05-21 09:30:00', '2026-05-21 09:30:00'),
+    (3, '2026-06-10', 2, '승인된 한글 기초 수업 교환 요청', '벚꽃반', '관리자가 승인해 제안을 받을 수 있는 수업 교환 요청입니다.', 'APPROVED',
+     '2026-06-07 23:59:00', '2026-05-22 11:00:00', 1, NULL, NULL, NULL, '2026-05-21 13:10:00', '2026-05-22 11:00:00'),
+    (4, '2026-06-17', 3, '반려된 수학 기초 수업 교환 요청', '개나리반', '일정상 교환 요청을 제출했으나 반려된 예시입니다.', 'REJECTED',
+     '2026-06-14 23:59:00', '2026-05-23 14:20:00', 1, NULL, NULL, '대체 수업 일정이 충분하지 않습니다.', '2026-05-22 15:00:00', '2026-05-23 14:20:00'),
+    (5, '2026-06-10', 2, '완료된 한글 기초 수업 교환 요청', '벚꽃반', '제안 수락까지 완료된 수업 교환 요청입니다.', 'COMPLETED',
+     '2026-06-07 23:59:00', '2026-05-24 10:00:00', 1, '2026-05-25 16:00:00', NULL, NULL, '2026-05-23 08:40:00', '2026-05-25 16:00:00'),
+    (6, '2026-06-17', 3, '만료된 수학 기초 수업 교환 요청', '개나리반', '만료 처리된 수업 교환 요청입니다.', 'EXPIRED',
+     '2026-05-24 23:59:00', NULL, NULL, NULL, NULL, NULL, '2026-05-20 16:20:00', '2026-05-25 00:10:00'),
+    (7, '2026-06-10', 2, '취소된 한글 기초 수업 교환 요청', '벚꽃반', '요청자가 직접 취소한 수업 교환 요청입니다.', 'CANCELLED',
+     '2026-06-07 23:59:00', NULL, NULL, NULL, '2026-05-24 18:00:00', NULL, '2026-05-24 12:00:00', '2026-05-24 18:00:00');
+ALTER SEQUENCE lesson_exchange_requests_id_seq RESTART WITH 8;
+
+-- 11. Lesson Exchange Proposals
+INSERT INTO lesson_exchange_proposals (
+    id, request_id, proposed_by, proposal_type, lesson_date, content, classroom_name_snapshot,
+    status, accepted_at, withdrawn_at, closed_at, created_at, updated_at
+)
+VALUES
+    (1, 3, 3, 'EXCHANGE', '2026-06-17', '6월 17일 수학 기초 수업과 교환 가능합니다.', '개나리반',
+     'ACTIVE', NULL, NULL, NULL, '2026-05-22 13:00:00', '2026-05-22 13:00:00'),
+    (2, 3, 3, 'SUBSTITUTION', NULL, '교환 대신 6월 10일 한글 기초 수업을 대체할 수 있습니다.', '개나리반',
+     'ACTIVE', NULL, NULL, NULL, '2026-05-23 08:30:00', '2026-05-23 08:30:00'),
+    (3, 3, 3, 'EXCHANGE', '2026-06-17', '한 번 제안했다가 철회한 교환 제안입니다.', '개나리반',
+     'WITHDRAWN', NULL, '2026-05-24 09:00:00', NULL, '2026-05-23 12:40:00', '2026-05-24 09:00:00'),
+    (4, 5, 3, 'EXCHANGE', '2026-06-17', '완료된 요청에서 수락된 교환 제안입니다.', '개나리반',
+     'ACCEPTED', '2026-05-25 16:00:00', NULL, NULL, '2026-05-24 09:00:00', '2026-05-25 16:00:00'),
+    (5, 5, 3, 'SUBSTITUTION', NULL, '다른 제안이 수락되어 종료된 대체 제안입니다.', '개나리반',
+     'CLOSED', NULL, NULL, '2026-05-25 16:00:00', '2026-05-24 10:30:00', '2026-05-25 16:00:00');
+ALTER SEQUENCE lesson_exchange_proposals_id_seq RESTART WITH 6;
+
+-- 12. Students
 INSERT INTO students (id, class_id, name, phone_number, description, status)
 VALUES
     (1, 1, '이영희', '010-3333-3333', '기초반', 'ENROLLED'),
     (2, 1, '박민수', '010-4444-4444', '기초반', 'ENROLLED');
 ALTER SEQUENCE students_id_seq RESTART WITH 3;
 
--- 11. Student Attendances
+-- 13. Student Attendances
 INSERT INTO student_attendances (lesson_id, student_id, status, memo)
 VALUES
     (1, 1, 'ABSENT', NULL),

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -105,6 +105,10 @@
                     <span style="color: var(--warning);">승인 대기 중</span>
                     <p style="font-size: 13px; margin: 4px 0 0;">검토가 필요한 신규 구매 요청</p>
                 </a>
+                <a class="metric" th:href="@{/admin/request/lesson-exchange}">
+                    <span>수업 교환 요청</span>
+                    <p style="font-size: 13px; margin: 4px 0 0;">교환 요청과 제안 처리 현황 확인</p>
+                </a>
             </div>
         </section>
     </main>

--- a/src/main/resources/templates/admin/fragments/layout.html
+++ b/src/main/resources/templates/admin/fragments/layout.html
@@ -433,6 +433,7 @@
             <a th:href="@{/admin/department/departments}" th:classappend="${active == 'departments'} ? 'active'">부서</a>
             <a th:href="@{/admin/classroom/classrooms}" th:classappend="${active == 'classrooms'} ? 'active'">분반</a>
             <a th:href="@{/admin/lesson/lessons}" th:classappend="${active == 'lessons'} ? 'active'">수업</a>
+            <a th:href="@{/admin/request/lesson-exchange}" th:classappend="${active == 'lessonExchangeRequests'} ? 'active'">수업 교환</a>
             <a th:href="@{/admin/request/purchase/purchase-requests}" th:classappend="${active == 'purchaseRequests'} ? 'active'">구매 요청</a>
         </nav>
         <div th:if="${#arrays.contains(@environment.getActiveProfiles(), 'dev')}" style="margin-top: 20px;">

--- a/src/main/resources/templates/admin/request/lesson-exchange/dashboard.html
+++ b/src/main/resources/templates/admin/request/lesson-exchange/dashboard.html
@@ -62,6 +62,7 @@
                         <th>제안</th>
                         <th>상태</th>
                         <th>생성일</th>
+                        <th>처리</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -75,9 +76,18 @@
                         <td th:text="|전체 ${request.proposalCount}건 / 진행 ${request.activeProposalCount}건|">전체 0건 / 진행 0건</td>
                         <td><span class="pill status-PENDING" th:text="${request.statusLabel}">승인 대기</span></td>
                         <td th:text="${#temporals.format(request.createdAt, 'yyyy.MM.dd')}">2026.05.20</td>
+                        <td>
+                            <form class="inline-form" th:action="@{/admin/request/lesson-exchange/{requestId}/approve(requestId=${request.id})}" method="post">
+                                <button class="button" type="submit">승인</button>
+                            </form>
+                            <form class="inline-form" th:action="@{/admin/request/lesson-exchange/{requestId}/reject(requestId=${request.id})}" method="post">
+                                <input name="note" placeholder="반려 사유" required>
+                                <button class="button danger" type="submit">반려</button>
+                            </form>
+                        </td>
                     </tr>
                     <tr th:if="${#lists.isEmpty(dashboard.reviewRequiredRequests)}">
-                        <td colspan="9" class="empty">검토가 필요한 수업 교환 요청이 없습니다.</td>
+                        <td colspan="10" class="empty">검토가 필요한 수업 교환 요청이 없습니다.</td>
                     </tr>
                     </tbody>
                 </table>

--- a/src/main/resources/templates/admin/request/lesson-exchange/dashboard.html
+++ b/src/main/resources/templates/admin/request/lesson-exchange/dashboard.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/layout :: head('수업 교환 요청 관리')}"></head>
+<body>
+<div th:replace="~{admin/fragments/layout :: shell(~{::main})}">
+    <main class="stack">
+        <div class="page-title">
+            <div>
+                <h1>수업 교환 요청</h1>
+                <p>수업 교환 요청과 제안의 처리 현황을 확인합니다.</p>
+            </div>
+        </div>
+
+        <section class="metric-grid dashboard-swipe swipe-grid">
+            <div class="metric">
+                <span>승인 대기 요청</span>
+                <strong th:text="${dashboard.pendingRequestCount}">0</strong>
+            </div>
+            <div class="metric">
+                <span>진행 중 제안</span>
+                <strong th:text="${dashboard.activeProposalCount}">0</strong>
+            </div>
+        </section>
+
+        <div class="dashboard-grid">
+            <section class="panel">
+                <h2>요청 상태</h2>
+                <div class="detail-grid">
+                    <div class="detail-item" th:each="statusCount : ${dashboard.requestStatusCounts}">
+                        <span th:text="${statusCount.label}">승인 대기</span>
+                        <strong th:text="|${statusCount.count}건|">0건</strong>
+                    </div>
+                </div>
+            </section>
+
+            <section class="panel">
+                <h2>제안 상태</h2>
+                <div class="detail-grid">
+                    <div class="detail-item" th:each="statusCount : ${dashboard.proposalStatusCounts}">
+                        <span th:text="${statusCount.label}">진행 중</span>
+                        <strong th:text="|${statusCount.count}건|">0건</strong>
+                    </div>
+                </div>
+            </section>
+        </div>
+
+        <section class="panel table-panel">
+            <div style="padding: 22px 22px 4px;">
+                <h2>검토 필요 요청</h2>
+                <p>오래된 승인 대기 요청부터 최대 10건을 표시합니다.</p>
+            </div>
+            <div class="table-scroll">
+                <table>
+                    <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>제목</th>
+                        <th>분반</th>
+                        <th>요청자</th>
+                        <th>수업일</th>
+                        <th>만료 시각</th>
+                        <th>제안</th>
+                        <th>상태</th>
+                        <th>생성일</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="request : ${dashboard.reviewRequiredRequests}">
+                        <td th:text="${request.id}">1</td>
+                        <td th:text="${request.title}">수업 교환 요청</td>
+                        <td th:text="${request.classroomName}">벚꽃반</td>
+                        <td th:text="${request.requestedByName}">홍길동</td>
+                        <td th:text="${request.lessonDate}">2026-06-10</td>
+                        <td th:text="${#temporals.format(request.expiresAt, 'yyyy.MM.dd HH:mm')}">2026.06.07 23:59</td>
+                        <td th:text="|전체 ${request.proposalCount}건 / 진행 ${request.activeProposalCount}건|">전체 0건 / 진행 0건</td>
+                        <td><span class="pill status-PENDING" th:text="${request.statusLabel}">승인 대기</span></td>
+                        <td th:text="${#temporals.format(request.createdAt, 'yyyy.MM.dd')}">2026.05.20</td>
+                    </tr>
+                    <tr th:if="${#lists.isEmpty(dashboard.reviewRequiredRequests)}">
+                        <td colspan="9" class="empty">검토가 필요한 수업 교환 요청이 없습니다.</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    </main>
+</div>
+</body>
+</html>

--- a/src/test/java/geumjeongyahak/unit/request/LessonExchangeRequestAdminViewServiceTest.java
+++ b/src/test/java/geumjeongyahak/unit/request/LessonExchangeRequestAdminViewServiceTest.java
@@ -1,0 +1,144 @@
+package geumjeongyahak.unit.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import geumjeongyahak.domain.auth.enums.RoleType;
+import geumjeongyahak.domain.request.entity.LessonExchangeRequest;
+import geumjeongyahak.domain.request.enums.LessonExchangeProposalStatus;
+import geumjeongyahak.domain.request.enums.LessonExchangeRequestStatus;
+import geumjeongyahak.domain.request.repository.LessonExchangeProposalRepository;
+import geumjeongyahak.domain.request.repository.LessonExchangeRequestRepository;
+import geumjeongyahak.domain.request.service.LessonExchangeRequestAdminViewService;
+import geumjeongyahak.domain.request.service.LessonExchangeRequestAdminViewService.LessonExchangeDashboard;
+import geumjeongyahak.domain.request.service.LessonExchangeRequestAdminViewService.ReviewRequiredRequestRow;
+import geumjeongyahak.domain.request.service.LessonExchangeRequestAdminViewService.StatusCount;
+import geumjeongyahak.domain.users.entity.User;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class LessonExchangeRequestAdminViewServiceTest {
+
+    @Mock
+    private LessonExchangeRequestRepository lessonExchangeRequestRepository;
+
+    @Mock
+    private LessonExchangeProposalRepository lessonExchangeProposalRepository;
+
+    @InjectMocks
+    private LessonExchangeRequestAdminViewService lessonExchangeRequestAdminViewService;
+
+    @Test
+    void getDashboard_countsRequestAndProposalStatuses() {
+        for (LessonExchangeRequestStatus status : LessonExchangeRequestStatus.values()) {
+            given(lessonExchangeRequestRepository.countByStatus(status)).willReturn(0L);
+        }
+        for (LessonExchangeProposalStatus status : LessonExchangeProposalStatus.values()) {
+            given(lessonExchangeProposalRepository.countByStatus(status)).willReturn(0L);
+        }
+        given(lessonExchangeRequestRepository.countByStatus(LessonExchangeRequestStatus.PENDING))
+            .willReturn(3L);
+        given(lessonExchangeRequestRepository.countByStatus(LessonExchangeRequestStatus.APPROVED))
+            .willReturn(2L);
+        given(lessonExchangeProposalRepository.countByStatus(LessonExchangeProposalStatus.ACTIVE))
+            .willReturn(5L);
+        given(lessonExchangeProposalRepository.countByStatus(LessonExchangeProposalStatus.ACCEPTED))
+            .willReturn(1L);
+        given(lessonExchangeRequestRepository.findTop10ByStatusOrderByCreatedAtAsc(LessonExchangeRequestStatus.PENDING))
+            .willReturn(List.of());
+
+        LessonExchangeDashboard dashboard = lessonExchangeRequestAdminViewService.getDashboard();
+
+        assertThat(dashboard.pendingRequestCount()).isEqualTo(3L);
+        assertThat(dashboard.activeProposalCount()).isEqualTo(5L);
+        assertThat(findRequestStatusCount(dashboard, LessonExchangeRequestStatus.APPROVED).count())
+            .isEqualTo(2L);
+        assertThat(findProposalStatusCount(dashboard, LessonExchangeProposalStatus.ACCEPTED).count())
+            .isEqualTo(1L);
+    }
+
+    @Test
+    void getDashboard_includesReviewRequiredRequestsWithProposalCounts() {
+        LessonExchangeRequest request = lessonExchangeRequest(
+            10L,
+            "벚꽃반",
+            "김교사",
+            "6월 10일 수업 교환 요청",
+            LocalDate.of(2026, 6, 10),
+            LocalDateTime.of(2026, 6, 7, 23, 59),
+            LocalDateTime.of(2026, 5, 20, 10, 0)
+        );
+        given(lessonExchangeRequestRepository.findTop10ByStatusOrderByCreatedAtAsc(LessonExchangeRequestStatus.PENDING))
+            .willReturn(List.of(request));
+        given(lessonExchangeProposalRepository.countByRequest_Id(10L)).willReturn(4L);
+        given(lessonExchangeProposalRepository.countByRequest_IdAndStatus(10L, LessonExchangeProposalStatus.ACTIVE))
+            .willReturn(2L);
+
+        LessonExchangeDashboard dashboard = lessonExchangeRequestAdminViewService.getDashboard();
+
+        assertThat(dashboard.reviewRequiredRequests()).hasSize(1);
+        ReviewRequiredRequestRow row = dashboard.reviewRequiredRequests().getFirst();
+        assertThat(row.id()).isEqualTo(10L);
+        assertThat(row.classroomName()).isEqualTo("벚꽃반");
+        assertThat(row.requestedByName()).isEqualTo("김교사");
+        assertThat(row.status()).isEqualTo(LessonExchangeRequestStatus.PENDING);
+        assertThat(row.statusLabel()).isEqualTo("승인 대기");
+        assertThat(row.proposalCount()).isEqualTo(4L);
+        assertThat(row.activeProposalCount()).isEqualTo(2L);
+    }
+
+    private StatusCount<LessonExchangeRequestStatus> findRequestStatusCount(
+        LessonExchangeDashboard dashboard,
+        LessonExchangeRequestStatus status
+    ) {
+        return dashboard.requestStatusCounts().stream()
+            .filter(statusCount -> statusCount.status() == status)
+            .findFirst()
+            .orElseThrow();
+    }
+
+    private StatusCount<LessonExchangeProposalStatus> findProposalStatusCount(
+        LessonExchangeDashboard dashboard,
+        LessonExchangeProposalStatus status
+    ) {
+        return dashboard.proposalStatusCounts().stream()
+            .filter(statusCount -> statusCount.status() == status)
+            .findFirst()
+            .orElseThrow();
+    }
+
+    private LessonExchangeRequest lessonExchangeRequest(
+        Long id,
+        String classroomName,
+        String requestedByName,
+        String title,
+        LocalDate lessonDate,
+        LocalDateTime expiresAt,
+        LocalDateTime createdAt
+    ) {
+        User requestedBy = User.builder()
+            .nickname(requestedByName)
+            .name(requestedByName)
+            .role(RoleType.VOLUNTEER)
+            .build();
+        LessonExchangeRequest request = new LessonExchangeRequest(
+            requestedBy,
+            lessonDate,
+            title,
+            classroomName,
+            "수업 교환을 요청합니다.",
+            expiresAt
+        );
+        ReflectionTestUtils.setField(request, "id", id);
+        ReflectionTestUtils.setField(request, "createdAt", createdAt);
+        return request;
+    }
+}

--- a/src/test/java/geumjeongyahak/unit/request/LessonExchangeRequestAdminViewServiceTest.java
+++ b/src/test/java/geumjeongyahak/unit/request/LessonExchangeRequestAdminViewServiceTest.java
@@ -2,6 +2,7 @@ package geumjeongyahak.unit.request;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 import geumjeongyahak.domain.auth.enums.RoleType;
 import geumjeongyahak.domain.request.entity.LessonExchangeRequest;
@@ -10,6 +11,7 @@ import geumjeongyahak.domain.request.enums.LessonExchangeRequestStatus;
 import geumjeongyahak.domain.request.repository.LessonExchangeProposalRepository;
 import geumjeongyahak.domain.request.repository.LessonExchangeRequestRepository;
 import geumjeongyahak.domain.request.service.LessonExchangeRequestAdminViewService;
+import geumjeongyahak.domain.request.service.LessonExchangeRequestService;
 import geumjeongyahak.domain.request.service.LessonExchangeRequestAdminViewService.LessonExchangeDashboard;
 import geumjeongyahak.domain.request.service.LessonExchangeRequestAdminViewService.ReviewRequiredRequestRow;
 import geumjeongyahak.domain.request.service.LessonExchangeRequestAdminViewService.StatusCount;
@@ -32,6 +34,9 @@ class LessonExchangeRequestAdminViewServiceTest {
 
     @Mock
     private LessonExchangeProposalRepository lessonExchangeProposalRepository;
+
+    @Mock
+    private LessonExchangeRequestService lessonExchangeRequestService;
 
     @InjectMocks
     private LessonExchangeRequestAdminViewService lessonExchangeRequestAdminViewService;
@@ -93,6 +98,22 @@ class LessonExchangeRequestAdminViewServiceTest {
         assertThat(row.statusLabel()).isEqualTo("승인 대기");
         assertThat(row.proposalCount()).isEqualTo(4L);
         assertThat(row.activeProposalCount()).isEqualTo(2L);
+    }
+
+    @Test
+    void approve_delegatesToLessonExchangeRequestService() {
+        lessonExchangeRequestAdminViewService.approve(1L, 10L);
+
+        then(lessonExchangeRequestService).should()
+            .approveLessonExchangeRequest(1L, 10L);
+    }
+
+    @Test
+    void reject_delegatesToLessonExchangeRequestService() {
+        lessonExchangeRequestAdminViewService.reject(1L, 10L, "일정 확인이 필요합니다.");
+
+        then(lessonExchangeRequestService).should()
+            .rejectLessonExchangeRequest(1L, 10L, "일정 확인이 필요합니다.");
     }
 
     private StatusCount<LessonExchangeRequestStatus> findRequestStatusCount(


### PR DESCRIPTION
## 개요

수업 교환 요청/제안 현황을 확인하고 승인/반려까지 처리할 수 있는 관리자 대시보드를 추가했습니다.

## 변경 유형

- [x] 새 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 문서 수정 (docs)
- [x] 테스트 (test)
- [x] 기타 (chore)

## 변경 내용

- 수업 교환 요청/제안 상태별 집계 조회를 위한 관리자 View Service를 추가했습니다.
- `/admin/request/lesson-exchange` 관리자 대시보드 화면을 추가했습니다.
- 관리자 사이드바와 메인 대시보드에서 수업 교환 대시보드로 이동할 수 있도록 연결했습니다.
- 관리자 화면에서 `PENDING` 수업 교환 요청을 승인/반려할 수 있도록 POST 액션을 추가했습니다.
- 관리자 화면 확인용 수업 교환 요청/제안 초기 데이터를 추가했습니다.
- 수업 교환 관리자 대시보드 관련 문서와 권한 문서를 업데이트했습니다.

## 관련 이슈

Closes #62

## 스크린샷 (선택)

<img width="1920" height="915" alt="image" src="https://github.com/user-attachments/assets/b384c1cd-7b4e-40e0-9d94-1b9b7282b550" />
<img width="1920" height="919" alt="image" src="https://github.com/user-attachments/assets/2ecd8ddb-eb75-4f34-8da3-34e829c2c5e8" />

## 체크리스트

- [x] 코드 컨벤션을 준수했습니다
- [x] 테스트 코드를 작성/수정했습니다
- [x] 모든 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요한 경우)

## 리뷰어에게

수업 교환 제안은 승인된 요청 이후에만 가능하므로, 초기 데이터도 `APPROVED` 또는 `COMPLETED` 요청에만 제안이 연결되도록 구성했습니다.
관리자 승인/반려 화면 액션은 기존 `LessonExchangeRequestService`의 API 승인/반려 로직을 재사용합니다.
