### PR TITLE
[FEAT] 결석 요청 관리자 페이지 추가

### DIFF
--- a/src/main/java/geumjeongyahak/domain/base/dto/response/AdminPage.java
+++ b/src/main/java/geumjeongyahak/domain/base/dto/response/AdminPage.java
@@ -25,6 +25,16 @@ public record AdminPage<T>(
         );
     }
 
+    public static <T> AdminPage<T> from(PaginationResponse<T> response) {
+        return new AdminPage<>(
+            response.getContent(),
+            response.getPage(),
+            response.getSize(),
+            response.getTotalElements(),
+            response.getTotalPages()
+        );
+    }
+
     public boolean hasPrevious() {
         return page > 0;
     }

--- a/src/main/java/geumjeongyahak/domain/base/service/AdminDashboardService.java
+++ b/src/main/java/geumjeongyahak/domain/base/service/AdminDashboardService.java
@@ -6,6 +6,8 @@ import geumjeongyahak.domain.classroom.repository.ClassroomRepository;
 import geumjeongyahak.domain.department.repository.DepartmentRepository;
 import geumjeongyahak.domain.purchase_request.enums.PurchaseRequestStatus;
 import geumjeongyahak.domain.purchase_request.repository.PurchaseRequestRepository;
+import geumjeongyahak.domain.request.enums.RequestStatus;
+import geumjeongyahak.domain.request.repository.AbsenceRequestRepository;
 import geumjeongyahak.domain.student.repository.StudentRepository;
 import geumjeongyahak.domain.users.repository.UserRepository;
 import java.time.DayOfWeek;
@@ -24,6 +26,7 @@ public class AdminDashboardService {
     private final DepartmentRepository departmentRepository;
     private final ClassroomRepository classroomRepository;
     private final PurchaseRequestRepository purchaseRequestRepository;
+    private final AbsenceRequestRepository absenceRequestRepository;
     private final StudentRepository studentRepository;
     private final LessonRepository lessonRepository;
 
@@ -37,6 +40,7 @@ public class AdminDashboardService {
             departmentRepository.count(),
             classroomRepository.count(),
             purchaseRequestRepository.countByStatus(PurchaseRequestStatus.PENDING),
+            absenceRequestRepository.countByStatus(RequestStatus.PENDING),
             studentRepository.count(),
             lessonRepository.countByIsDeletedFalse(),
             lessonRepository.countByIsDeletedFalseAndDate(today),
@@ -52,6 +56,7 @@ public class AdminDashboardService {
         long departmentCount,
         long classroomCount,
         long pendingPurchaseRequestCount,
+        long pendingAbsenceRequestCount,
         long studentCount,
         long lessonCount,
         long todayLessonCount,

--- a/src/main/java/geumjeongyahak/domain/request/repository/AbsenceRequestRepository.java
+++ b/src/main/java/geumjeongyahak/domain/request/repository/AbsenceRequestRepository.java
@@ -14,6 +14,8 @@ import geumjeongyahak.domain.request.enums.RequestStatus;
 
 public interface AbsenceRequestRepository extends JpaRepository<AbsenceRequest, Long>, JpaSpecificationExecutor<AbsenceRequest> {
 
+    long countByStatus(RequestStatus status);
+
     Page<AbsenceRequest> findAll(Pageable pageable);
 
     Page<AbsenceRequest> findAllByRequestedBy_Id(Long requestedById, Pageable pageable);

--- a/src/main/java/geumjeongyahak/domain/request/service/AbsenceRequestAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/request/service/AbsenceRequestAdminViewService.java
@@ -54,6 +54,16 @@ public class AbsenceRequestAdminViewService {
         };
     }
 
+    @Transactional
+    public void approve(Long approverId, Long requestId) {
+        absenceRequestService.approveAbsenceRequest(approverId, requestId);
+    }
+
+    @Transactional
+    public void reject(Long approverId, Long requestId, String note) {
+        absenceRequestService.rejectAbsenceRequest(approverId, requestId, note);
+    }
+
     public record AbsenceRequestFilter(
         RequestStatus status,
         String keyword,

--- a/src/main/java/geumjeongyahak/domain/request/service/AbsenceRequestAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/request/service/AbsenceRequestAdminViewService.java
@@ -1,0 +1,64 @@
+package geumjeongyahak.domain.request.service;
+
+import geumjeongyahak.domain.base.dto.response.AdminPage;
+import geumjeongyahak.domain.base.dto.response.PaginationResponse;
+import geumjeongyahak.domain.request.enums.RequestStatus;
+import geumjeongyahak.domain.request.v1.dto.request.AbsenceRequestPaginationRequest;
+import geumjeongyahak.domain.request.v1.dto.response.AbsenceRequestResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AbsenceRequestAdminViewService {
+
+    private static final boolean ADMIN_CAN_READ_ALL = true;
+    private static final int FIRST_PAGE = 0;
+    private static final int MIN_PAGE_SIZE = 1;
+    private static final int DEFAULT_PAGE_SIZE = 10;
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final AbsenceRequestService absenceRequestService;
+
+    public AdminPage<AbsenceRequestResponse> getAbsenceRequests(Long requesterId, AbsenceRequestFilter filter) {
+        AbsenceRequestPaginationRequest pageRequest = new AbsenceRequestPaginationRequest();
+        pageRequest.setKeyword(filter.keyword());
+        pageRequest.setPage(filter.page() == null || filter.page() < FIRST_PAGE ? FIRST_PAGE : filter.page());
+        pageRequest.setSize(filter.size() == null || filter.size() < MIN_PAGE_SIZE
+            ? DEFAULT_PAGE_SIZE
+            : Math.min(filter.size(), MAX_PAGE_SIZE));
+
+        PaginationResponse<AbsenceRequestResponse> response = absenceRequestService.getAbsenceRequests(
+            requesterId,
+            ADMIN_CAN_READ_ALL,
+            filter.status(),
+            pageRequest
+        );
+
+        return AdminPage.from(response);
+    }
+
+    public RequestStatus[] getStatuses() {
+        return RequestStatus.values();
+    }
+
+    public String getStatusLabel(RequestStatus status) {
+        return switch (status) {
+            case PENDING -> "승인 대기";
+            case APPROVED -> "승인";
+            case REJECTED -> "반려";
+            case CANCELLED -> "취소";
+            case EXPIRED -> "만료";
+        };
+    }
+
+    public record AbsenceRequestFilter(
+        RequestStatus status,
+        String keyword,
+        Integer page,
+        Integer size
+    ) {
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/request/v1/controller/AbsenceRequestViewController.java
+++ b/src/main/java/geumjeongyahak/domain/request/v1/controller/AbsenceRequestViewController.java
@@ -1,0 +1,48 @@
+package geumjeongyahak.domain.request.v1.controller;
+
+import geumjeongyahak.common.security.service.CustomUserDetails;
+import geumjeongyahak.domain.request.enums.RequestStatus;
+import geumjeongyahak.domain.request.service.AbsenceRequestAdminViewService;
+import geumjeongyahak.domain.request.service.AbsenceRequestAdminViewService.AbsenceRequestFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequestMapping("/admin/request/absence/absence-requests")
+@RequiredArgsConstructor
+public class AbsenceRequestViewController {
+
+    private static final String ABSENCE_REQUEST_READ_ACCESS =
+        "hasRole('ADMIN') or hasAuthority('absence-request:read:*')";
+
+    private final AbsenceRequestAdminViewService absenceRequestAdminViewService;
+
+    @PreAuthorize(ABSENCE_REQUEST_READ_ACCESS)
+    @GetMapping
+    public String absenceRequests(
+        @RequestParam(required = false) RequestStatus status,
+        @RequestParam(required = false) String keyword,
+        @RequestParam(required = false) Integer page,
+        @RequestParam(required = false) Integer size,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        Model model,
+        Authentication authentication
+    ) {
+        AbsenceRequestFilter filter = new AbsenceRequestFilter(status, keyword, page, size);
+        model.addAttribute("active", "absenceRequests");
+        model.addAttribute("adminName", authentication.getName());
+        model.addAttribute("filter", filter);
+        model.addAttribute("selectedStatus", status);
+        model.addAttribute("statuses", absenceRequestAdminViewService.getStatuses());
+        model.addAttribute("absenceRequestsPage", absenceRequestAdminViewService.getAbsenceRequests(userDetails.getUserId(), filter));
+        model.addAttribute("absenceRequestAdminViewService", absenceRequestAdminViewService);
+        return "admin/request/absence/absence-requests";
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/request/v1/controller/AbsenceRequestViewController.java
+++ b/src/main/java/geumjeongyahak/domain/request/v1/controller/AbsenceRequestViewController.java
@@ -11,8 +11,11 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
 @RequestMapping("/admin/request/absence/absence-requests")
@@ -21,6 +24,8 @@ public class AbsenceRequestViewController {
 
     private static final String ABSENCE_REQUEST_READ_ACCESS =
         "hasRole('ADMIN') or hasAuthority('absence-request:read:*')";
+    private static final String ABSENCE_REQUEST_MANAGE_ACCESS =
+        "hasRole('ADMIN') or hasAuthority('absence-request:manage:*')";
 
     private final AbsenceRequestAdminViewService absenceRequestAdminViewService;
 
@@ -44,5 +49,30 @@ public class AbsenceRequestViewController {
         model.addAttribute("absenceRequestsPage", absenceRequestAdminViewService.getAbsenceRequests(userDetails.getUserId(), filter));
         model.addAttribute("absenceRequestAdminViewService", absenceRequestAdminViewService);
         return "admin/request/absence/absence-requests";
+    }
+
+    @PreAuthorize(ABSENCE_REQUEST_MANAGE_ACCESS)
+    @PostMapping("/{requestId}/approve")
+    public String approve(
+        @PathVariable Long requestId,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        RedirectAttributes redirectAttributes
+    ) {
+        absenceRequestAdminViewService.approve(userDetails.getUserId(), requestId);
+        redirectAttributes.addFlashAttribute("message", "결석 요청을 승인했습니다.");
+        return "redirect:/admin/request/absence/absence-requests";
+    }
+
+    @PreAuthorize(ABSENCE_REQUEST_MANAGE_ACCESS)
+    @PostMapping("/{requestId}/reject")
+    public String reject(
+        @PathVariable Long requestId,
+        @RequestParam String note,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        RedirectAttributes redirectAttributes
+    ) {
+        absenceRequestAdminViewService.reject(userDetails.getUserId(), requestId, note);
+        redirectAttributes.addFlashAttribute("message", "결석 요청을 반려했습니다.");
+        return "redirect:/admin/request/absence/absence-requests";
     }
 }

--- a/src/main/resources/sql/init_data.sql
+++ b/src/main/resources/sql/init_data.sql
@@ -114,10 +114,27 @@ INSERT INTO daily_schedules (
 )
 VALUES
     (1, 1, 2, '2026-06-10', '19:20:00', '21:40:00', 'SCHEDULED', FALSE, '2026-05-20 00:00:00', '2026-05-20 00:00:00'),
-    (2, 2, 3, '2026-06-17', '19:20:00', '21:40:00', 'SCHEDULED', FALSE, '2026-05-20 00:00:00', '2026-05-20 00:00:00');
-ALTER SEQUENCE daily_schedules_id_seq RESTART WITH 3;
+    (2, 2, 3, '2026-06-17', '19:20:00', '21:40:00', 'SCHEDULED', FALSE, '2026-05-20 00:00:00', '2026-05-20 00:00:00'),
+    (3, 1, 2, '2026-06-24', '19:20:00', '21:40:00', 'SCHEDULED', FALSE, '2026-05-20 00:00:00', '2026-05-20 00:00:00'),
+    (4, 2, 3, '2026-06-24', '19:20:00', '21:40:00', 'SCHEDULED', FALSE, '2026-05-20 00:00:00', '2026-05-20 00:00:00'),
+    (5, 8, 2, '2026-06-27', '19:20:00', '20:00:00', 'SCHEDULED', FALSE, '2026-05-20 00:00:00', '2026-05-20 00:00:00');
+ALTER SEQUENCE daily_schedules_id_seq RESTART WITH 6;
 
--- 11. Lesson Exchange Requests
+-- 11. Absence Requests
+INSERT INTO absence_requests (
+    id, daily_schedule_id, requested_by, title, reason, expires_at, status,
+    approval_at, approval_by, note, created_at, updated_at
+)
+VALUES
+    (1, 3, 2, '6월 24일 한글 기초 결석 요청', '개인 일정으로 6월 24일 한글 기초 수업에 참석하기 어렵습니다.',
+     '2026-06-24 00:00:00', 'PENDING', NULL, NULL, NULL, '2026-05-26 09:00:00', '2026-05-26 09:00:00'),
+    (2, 4, 3, '승인된 수학 기초 결석 요청', '병원 진료 일정으로 수업 참석이 어려워 결석을 요청했습니다.',
+     '2026-06-24 00:00:00', 'APPROVED', '2026-05-27 10:30:00', 1, NULL, '2026-05-26 13:20:00', '2026-05-27 10:30:00'),
+    (3, 5, 2, '반려된 스마트폰 활용 결석 요청', '일정 조정 가능성이 있어 결석 요청을 제출했습니다.',
+     '2026-06-27 00:00:00', 'REJECTED', '2026-05-28 14:10:00', 1, '수업 대체 운영 계획 확인 후 다시 요청해주세요.', '2026-05-27 16:40:00', '2026-05-28 14:10:00');
+ALTER SEQUENCE absence_requests_id_seq RESTART WITH 4;
+
+-- 12. Lesson Exchange Requests
 INSERT INTO lesson_exchange_requests (
     id, daily_schedule_id, lesson_date, requested_by, title, classroom_name_snapshot, content, status,
     expires_at, processed_at, processed_by, completed_at, cancelled_at, rejection_note,
@@ -140,7 +157,7 @@ VALUES
      '2026-06-07 23:59:00', NULL, NULL, NULL, '2026-05-24 18:00:00', NULL, '2026-05-24 12:00:00', '2026-05-24 18:00:00');
 ALTER SEQUENCE lesson_exchange_requests_id_seq RESTART WITH 8;
 
--- 12. Lesson Exchange Proposals
+-- 13. Lesson Exchange Proposals
 INSERT INTO lesson_exchange_proposals (
     id, request_id, proposed_by, proposal_type, daily_schedule_id, lesson_date, content, classroom_name_snapshot,
     status, accepted_at, withdrawn_at, closed_at, created_at, updated_at
@@ -158,7 +175,7 @@ VALUES
      'CLOSED', NULL, NULL, '2026-05-25 16:00:00', '2026-05-24 10:30:00', '2026-05-25 16:00:00');
 ALTER SEQUENCE lesson_exchange_proposals_id_seq RESTART WITH 6;
 
--- 13. Students
+-- 14. Students
 INSERT INTO students (id, class_id, name, phone_number, description, status)
 VALUES
     (1, 1, '이영희', '010-3333-3333', '기초반', 'ENROLLED'),

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -32,6 +32,10 @@
                 <span>대기 중 구매 요청</span>
                 <strong th:text="${summary.pendingPurchaseRequestCount}">0</strong>
             </a>
+            <a class="metric" th:href="@{/admin/request/absence/absence-requests(status='PENDING')}">
+                <span>대기 중 결석 요청</span>
+                <strong th:text="${summary.pendingAbsenceRequestCount}">0</strong>
+            </a>
             <a class="metric" th:href="@{/admin/lesson/lessons}">
                 <span>전체 수업</span>
                 <strong th:text="${summary.lessonCount}">0</strong>
@@ -108,6 +112,10 @@
                 <a class="metric" th:href="@{/admin/request/lesson-exchange}">
                     <span>수업 교환 요청</span>
                     <p style="font-size: 13px; margin: 4px 0 0;">교환 요청과 제안 처리 현황 확인</p>
+                </a>
+                <a class="metric" th:href="@{/admin/request/absence/absence-requests}">
+                    <span>결석 요청</span>
+                    <p style="font-size: 13px; margin: 4px 0 0;">교사 결석 요청 처리 현황 확인</p>
                 </a>
             </div>
         </section>

--- a/src/main/resources/templates/admin/fragments/layout.html
+++ b/src/main/resources/templates/admin/fragments/layout.html
@@ -433,6 +433,7 @@
             <a th:href="@{/admin/department/departments}" th:classappend="${active == 'departments'} ? 'active'">부서</a>
             <a th:href="@{/admin/classroom/classrooms}" th:classappend="${active == 'classrooms'} ? 'active'">분반</a>
             <a th:href="@{/admin/lesson/lessons}" th:classappend="${active == 'lessons'} ? 'active'">수업</a>
+            <a th:href="@{/admin/request/absence/absence-requests}" th:classappend="${active == 'absenceRequests'} ? 'active'">결석 요청</a>
             <a th:href="@{/admin/request/lesson-exchange}" th:classappend="${active == 'lessonExchangeRequests'} ? 'active'">수업 교환</a>
             <a th:href="@{/admin/request/purchase/purchase-requests}" th:classappend="${active == 'purchaseRequests'} ? 'active'">구매 요청</a>
         </nav>

--- a/src/main/resources/templates/admin/request/absence/absence-requests.html
+++ b/src/main/resources/templates/admin/request/absence/absence-requests.html
@@ -51,6 +51,7 @@
                         <th>만료 시각</th>
                         <th>생성일</th>
                         <th>처리일</th>
+                        <th>처리</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -69,9 +70,25 @@
                         <td th:text="${#temporals.format(request.expiresAt, 'yyyy.MM.dd HH:mm')}">2026.05.20 00:00</td>
                         <td th:text="${#temporals.format(request.createdAt, 'yyyy.MM.dd')}">2026.05.18</td>
                         <td th:text="${request.approvalAt != null ? #temporals.format(request.approvalAt, 'yyyy.MM.dd HH:mm') : '-'}">-</td>
+                        <td>
+                            <form class="inline-form"
+                                  th:if="${request.status.name() == 'PENDING'}"
+                                  th:action="@{/admin/request/absence/absence-requests/{requestId}/approve(requestId=${request.id})}"
+                                  method="post">
+                                <button class="button" type="submit">승인</button>
+                            </form>
+                            <form class="inline-form"
+                                  th:if="${request.status.name() == 'PENDING'}"
+                                  th:action="@{/admin/request/absence/absence-requests/{requestId}/reject(requestId=${request.id})}"
+                                  method="post">
+                                <input name="note" placeholder="반려 사유" required>
+                                <button class="button danger" type="submit">반려</button>
+                            </form>
+                            <span th:unless="${request.status.name() == 'PENDING'}">처리 완료</span>
+                        </td>
                     </tr>
                     <tr th:if="${#lists.isEmpty(absenceRequestsPage.content)}">
-                        <td colspan="10" class="empty">결석 요청이 없습니다.</td>
+                        <td colspan="11" class="empty">결석 요청이 없습니다.</td>
                     </tr>
                     </tbody>
                 </table>

--- a/src/main/resources/templates/admin/request/absence/absence-requests.html
+++ b/src/main/resources/templates/admin/request/absence/absence-requests.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/layout :: head('결석 요청 관리')}"></head>
+<body>
+<div th:replace="~{admin/fragments/layout :: shell(~{::main})}">
+    <main class="stack">
+        <div class="page-title">
+            <div>
+                <h1>결석 요청</h1>
+                <p>교사 결석 요청을 상태와 검색어 기준으로 조회합니다.</p>
+            </div>
+        </div>
+
+        <form class="panel filter-grid" th:action="@{/admin/request/absence/absence-requests}" method="get">
+            <label>검색어
+                <input name="keyword" th:value="${filter.keyword}" placeholder="제목, 사유, 요청자, 분반">
+            </label>
+            <label>상태
+                <select name="status">
+                    <option value="">전체</option>
+                    <option th:each="status : ${statuses}"
+                            th:value="${status.name()}"
+                            th:text="${absenceRequestAdminViewService.getStatusLabel(status)}"
+                            th:selected="${selectedStatus == status}">승인 대기</option>
+                </select>
+            </label>
+            <label>페이지 크기
+                <select name="size">
+                    <option value="10" th:selected="${absenceRequestsPage.size == 10}">10</option>
+                    <option value="20" th:selected="${absenceRequestsPage.size == 20}">20</option>
+                    <option value="50" th:selected="${absenceRequestsPage.size == 50}">50</option>
+                    <option value="100" th:selected="${absenceRequestsPage.size == 100}">100</option>
+                </select>
+            </label>
+            <button class="button" type="submit">조회</button>
+            <a class="reset-link" th:href="@{/admin/request/absence/absence-requests}">초기화</a>
+        </form>
+
+        <section class="panel table-panel">
+            <div class="table-scroll">
+                <table>
+                    <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>제목</th>
+                        <th>분반</th>
+                        <th>수업일</th>
+                        <th>요청자</th>
+                        <th>사유</th>
+                        <th>상태</th>
+                        <th>만료 시각</th>
+                        <th>생성일</th>
+                        <th>처리일</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="request : ${absenceRequestsPage.content}">
+                        <td th:text="${request.id}">1</td>
+                        <td th:text="${request.title}">결석 요청</td>
+                        <td th:text="${request.classroomName}">벚꽃반</td>
+                        <td th:text="${request.lessonDate}">2026-05-20</td>
+                        <td th:text="${request.requestedByName}">홍길동</td>
+                        <td th:text="${request.reason}">개인 사정</td>
+                        <td>
+                            <span class="pill"
+                                  th:classappend="'status-' + ${request.status.name()}"
+                                  th:text="${absenceRequestAdminViewService.getStatusLabel(request.status)}">승인 대기</span>
+                        </td>
+                        <td th:text="${#temporals.format(request.expiresAt, 'yyyy.MM.dd HH:mm')}">2026.05.20 00:00</td>
+                        <td th:text="${#temporals.format(request.createdAt, 'yyyy.MM.dd')}">2026.05.18</td>
+                        <td th:text="${request.approvalAt != null ? #temporals.format(request.approvalAt, 'yyyy.MM.dd HH:mm') : '-'}">-</td>
+                    </tr>
+                    <tr th:if="${#lists.isEmpty(absenceRequestsPage.content)}">
+                        <td colspan="10" class="empty">결석 요청이 없습니다.</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+            <div class="pager">
+                <span th:text="|총 ${absenceRequestsPage.totalElements}건 · ${absenceRequestsPage.page + 1}/${absenceRequestsPage.totalPages == 0 ? 1 : absenceRequestsPage.totalPages} 페이지|">총 0건</span>
+                <div>
+                    <a class="reset-link"
+                       th:classappend="${!absenceRequestsPage.hasPrevious()} ? 'disabled'"
+                       th:href="@{/admin/request/absence/absence-requests(status=${filter.status},keyword=${filter.keyword},size=${absenceRequestsPage.size},page=${absenceRequestsPage.previousPage()})}">이전</a>
+                    <a class="reset-link"
+                       th:classappend="${!absenceRequestsPage.hasNext()} ? 'disabled'"
+                       th:href="@{/admin/request/absence/absence-requests(status=${filter.status},keyword=${filter.keyword},size=${absenceRequestsPage.size},page=${absenceRequestsPage.nextPage()})}">다음</a>
+                </div>
+            </div>
+        </section>
+    </main>
+</div>
+</body>
+</html>

--- a/src/test/java/geumjeongyahak/unit/base/AdminDashboardServiceTest.java
+++ b/src/test/java/geumjeongyahak/unit/base/AdminDashboardServiceTest.java
@@ -13,6 +13,8 @@ import geumjeongyahak.domain.lesson.enums.LessonStatus;
 import geumjeongyahak.domain.lesson.repository.LessonRepository;
 import geumjeongyahak.domain.purchase_request.enums.PurchaseRequestStatus;
 import geumjeongyahak.domain.purchase_request.repository.PurchaseRequestRepository;
+import geumjeongyahak.domain.request.enums.RequestStatus;
+import geumjeongyahak.domain.request.repository.AbsenceRequestRepository;
 import geumjeongyahak.domain.student.repository.StudentRepository;
 import geumjeongyahak.domain.users.repository.UserRepository;
 import java.time.LocalDate;
@@ -38,6 +40,9 @@ class AdminDashboardServiceTest {
     private PurchaseRequestRepository purchaseRequestRepository;
 
     @Mock
+    private AbsenceRequestRepository absenceRequestRepository;
+
+    @Mock
     private StudentRepository studentRepository;
 
     @Mock
@@ -52,6 +57,7 @@ class AdminDashboardServiceTest {
         given(departmentRepository.count()).willReturn(6L);
         given(classroomRepository.count()).willReturn(9L);
         given(purchaseRequestRepository.countByStatus(PurchaseRequestStatus.PENDING)).willReturn(2L);
+        given(absenceRequestRepository.countByStatus(RequestStatus.PENDING)).willReturn(5L);
         given(studentRepository.count()).willReturn(11L);
         given(lessonRepository.countByIsDeletedFalse()).willReturn(20L);
         given(lessonRepository.countByIsDeletedFalseAndDate(any(LocalDate.class))).willReturn(3L);
@@ -67,6 +73,7 @@ class AdminDashboardServiceTest {
         assertThat(summary.departmentCount()).isEqualTo(6L);
         assertThat(summary.classroomCount()).isEqualTo(9L);
         assertThat(summary.pendingPurchaseRequestCount()).isEqualTo(2L);
+        assertThat(summary.pendingAbsenceRequestCount()).isEqualTo(5L);
         assertThat(summary.studentCount()).isEqualTo(11L);
         assertThat(summary.lessonCount()).isEqualTo(20L);
         assertThat(summary.todayLessonCount()).isEqualTo(3L);

--- a/src/test/java/geumjeongyahak/unit/request/AbsenceRequestAdminViewServiceTest.java
+++ b/src/test/java/geumjeongyahak/unit/request/AbsenceRequestAdminViewServiceTest.java
@@ -1,0 +1,136 @@
+package geumjeongyahak.unit.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import geumjeongyahak.domain.base.dto.response.AdminPage;
+import geumjeongyahak.domain.base.dto.response.PaginationResponse;
+import geumjeongyahak.domain.request.enums.RequestStatus;
+import geumjeongyahak.domain.request.service.AbsenceRequestAdminViewService;
+import geumjeongyahak.domain.request.service.AbsenceRequestAdminViewService.AbsenceRequestFilter;
+import geumjeongyahak.domain.request.service.AbsenceRequestService;
+import geumjeongyahak.domain.request.v1.dto.request.AbsenceRequestPaginationRequest;
+import geumjeongyahak.domain.request.v1.dto.response.AbsenceRequestResponse;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+class AbsenceRequestAdminViewServiceTest {
+
+    @Mock
+    private AbsenceRequestService absenceRequestService;
+
+    @InjectMocks
+    private AbsenceRequestAdminViewService absenceRequestAdminViewService;
+
+    @Test
+    void getAbsenceRequests_returnsAdminPageFromPagedServiceResponse() {
+        AbsenceRequestResponse response = absenceRequestResponse(10L, RequestStatus.PENDING);
+        given(absenceRequestService.getAbsenceRequests(
+            eq(1L),
+            eq(true),
+            eq(RequestStatus.PENDING),
+            any(AbsenceRequestPaginationRequest.class)
+        )).willReturn(new PaginationResponse<>(new PageImpl<>(
+            List.of(response),
+            PageRequest.of(0, 20),
+            35
+        )));
+
+        AdminPage<AbsenceRequestResponse> page = absenceRequestAdminViewService.getAbsenceRequests(
+            1L,
+            new AbsenceRequestFilter(RequestStatus.PENDING, "개인 사정", 0, 20)
+        );
+
+        assertThat(page.content()).containsExactly(response);
+        assertThat(page.page()).isZero();
+        assertThat(page.size()).isEqualTo(20);
+        assertThat(page.totalElements()).isEqualTo(35);
+        assertThat(page.totalPages()).isEqualTo(2);
+    }
+
+    @Test
+    void getAbsenceRequests_normalizesInvalidPageAndSize() {
+        given(absenceRequestService.getAbsenceRequests(
+            eq(1L),
+            eq(true),
+            eq(null),
+            any(AbsenceRequestPaginationRequest.class)
+        )).willReturn(new PaginationResponse<>(new PageImpl<>(
+            List.of(),
+            PageRequest.of(0, 10),
+            0
+        )));
+        ArgumentCaptor<AbsenceRequestPaginationRequest> captor =
+            ArgumentCaptor.forClass(AbsenceRequestPaginationRequest.class);
+
+        absenceRequestAdminViewService.getAbsenceRequests(
+            1L,
+            new AbsenceRequestFilter(null, "검색어", -1, 0)
+        );
+
+        then(absenceRequestService).should()
+            .getAbsenceRequests(eq(1L), eq(true), eq(null), captor.capture());
+        AbsenceRequestPaginationRequest pageRequest = captor.getValue();
+        assertThat(pageRequest.getPage()).isZero();
+        assertThat(pageRequest.getSize()).isEqualTo(10);
+        assertThat(pageRequest.getKeyword()).isEqualTo("검색어");
+    }
+
+    @Test
+    void getStatusLabel_returnsKoreanLabel() {
+        assertThat(absenceRequestAdminViewService.getStatusLabel(RequestStatus.PENDING)).isEqualTo("승인 대기");
+        assertThat(absenceRequestAdminViewService.getStatusLabel(RequestStatus.APPROVED)).isEqualTo("승인");
+        assertThat(absenceRequestAdminViewService.getStatusLabel(RequestStatus.REJECTED)).isEqualTo("반려");
+        assertThat(absenceRequestAdminViewService.getStatusLabel(RequestStatus.CANCELLED)).isEqualTo("취소");
+        assertThat(absenceRequestAdminViewService.getStatusLabel(RequestStatus.EXPIRED)).isEqualTo("만료");
+    }
+
+    @Test
+    void approve_delegatesToAbsenceRequestService() {
+        absenceRequestAdminViewService.approve(1L, 10L);
+
+        then(absenceRequestService).should()
+            .approveAbsenceRequest(1L, 10L);
+    }
+
+    @Test
+    void reject_delegatesToAbsenceRequestService() {
+        absenceRequestAdminViewService.reject(1L, 10L, "사유가 충분하지 않습니다.");
+
+        then(absenceRequestService).should()
+            .rejectAbsenceRequest(1L, 10L, "사유가 충분하지 않습니다.");
+    }
+
+    private AbsenceRequestResponse absenceRequestResponse(Long id, RequestStatus status) {
+        return new AbsenceRequestResponse(
+            id,
+            20L,
+            LocalDate.of(2026, 5, 20),
+            30L,
+            "벚꽃반",
+            40L,
+            "김교사",
+            "결석 요청",
+            "개인 사정",
+            LocalDateTime.of(2026, 5, 20, 0, 0),
+            status,
+            null,
+            null,
+            null,
+            LocalDateTime.of(2026, 5, 18, 10, 0)
+        );
+    }
+}


### PR DESCRIPTION
## 개요

결석 요청을 관리자 콘솔에서 조회하고 승인/반려할 수 있는 관리자 페이지를 추가했습니다.

## 변경 유형

- [x] 새 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [x] 테스트 (test)
- [x] 기타 (chore)

## 변경 내용

- 결석 요청 관리자 목록 화면을 추가했습니다.
- 상태/검색어/페이지 크기 기반 조회를 지원합니다.
- `PENDING` 결석 요청에 대해 승인/반려 액션을 추가했습니다.
- 관리자 사이드바와 대시보드에 결석 요청 진입점을 추가했습니다.
- 대시보드에 대기 중 결석 요청 수를 표시하도록 추가했습니다.
- 결석 요청 관리자 ViewService 단위 테스트를 추가했습니다.
- 관리자 화면 확인용 결석 요청 초기 데이터를 추가했습니다.

## 관련 이슈

Closes #70

## 스크린샷 (선택)

<!-- 관리자 결석 요청 목록, 대시보드 지표 화면을 첨부해주세요 -->
<img width="1919" height="918" alt="image" src="https://github.com/user-attachments/assets/7850bb0e-d453-4eba-9088-dc349189eb23" />
<img width="1920" height="919" alt="image" src="https://github.com/user-attachments/assets/496d6a9b-eeb6-4db9-a160-8b1b2e8ae6ea" />

## 체크리스트

- [x] 코드 컨벤션을 준수했습니다
- [x] 테스트 코드를 작성/수정했습니다
- [x] 모든 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)

## 리뷰어에게

기존 관리자 페이지 구조와 동일하게 `ViewController`, `AdminViewService`, Thymeleaf 템플릿 흐름으로 구현했습니다.

결석 요청 생성 기능은 관리자 페이지에 포함하지 않았고, 관리자는 생성된 결석 요청을 조회/처리하는 역할로 유지했습니다.