### PR TITLE
[FEAT] 하루 일정 관리자 페이지 추가

### DIFF
--- a/src/main/java/geumjeongyahak/domain/classroom/service/ClassroomProxyService.java
+++ b/src/main/java/geumjeongyahak/domain/classroom/service/ClassroomProxyService.java
@@ -1,11 +1,14 @@
 package geumjeongyahak.domain.classroom.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import geumjeongyahak.domain.classroom.entity.Classroom;
 import geumjeongyahak.domain.classroom.exception.ClassroomNotFoundException;
 import geumjeongyahak.domain.classroom.repository.ClassroomRepository;
+
+import java.util.List;
 
 /**
  * Classroom 도메인의 Proxy Service.
@@ -30,5 +33,13 @@ public class ClassroomProxyService {
         }
 
         return classroom;
+    }
+
+    @Transactional(readOnly = true)
+    public List<Classroom> getActiveClassroomsOrderByName() {
+        return classroomRepository.findAll(Sort.by(Sort.Direction.ASC, "name"))
+            .stream()
+            .filter(classroom -> !classroom.isDeleted())
+            .toList();
     }
 }

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/repository/DailyStudentAttendanceRepository.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/repository/DailyStudentAttendanceRepository.java
@@ -12,5 +12,7 @@ public interface DailyStudentAttendanceRepository extends JpaRepository<DailyStu
     @EntityGraph(attributePaths = {"student"})
     List<DailyStudentAttendance> findAllByDailyScheduleIdAndIsDeletedFalse(Long dailyScheduleId);
 
+    List<DailyStudentAttendance> findAllByDailySchedule_IdInAndIsDeletedFalse(List<Long> dailyScheduleIds);
+
     Optional<DailyStudentAttendance> findByDailyScheduleIdAndStudentId(Long dailyScheduleId, Long studentId);
 }

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleAdminViewService.java
@@ -8,11 +8,15 @@ import geumjeongyahak.domain.daily_schedule.enums.DailyStudentAttendanceStatus;
 import geumjeongyahak.domain.daily_schedule.enums.DailyTeacherAttendanceStatus;
 import geumjeongyahak.domain.daily_schedule.repository.DailyStudentAttendanceRepository;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailyScheduleListRequest;
+import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyStudentAttendanceItemRequest;
+import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyStudentAttendancesRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyScheduleStatusRequest;
+import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyTeacherAttendanceRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleDetailResponse;
 import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleSummaryResponse;
 import geumjeongyahak.domain.users.entity.User;
 import geumjeongyahak.domain.users.service.UserProxyService;
+import java.math.BigDecimal;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -33,6 +37,7 @@ public class DailyScheduleAdminViewService {
     private static final int PREVIOUS_WEEK_OFFSET = -1;
     private static final int NEXT_WEEK_OFFSET = 1;
     private static final boolean ADMIN_CAN_VIEW_SENSITIVE_INFO = true;
+    private static final boolean ADMIN_CAN_WRITE_ANY_DAILY_SCHEDULE = true;
 
     private final DailyScheduleService dailyScheduleService;
     private final DailyScheduleAdminService dailyScheduleAdminService;
@@ -104,8 +109,48 @@ public class DailyScheduleAdminViewService {
         );
     }
 
+    @Transactional
+    public void updateTeacherAttendance(
+        Long adminId,
+        Long dailyScheduleId,
+        DailyTeacherAttendanceStatus status,
+        BigDecimal latitude,
+        BigDecimal longitude
+    ) {
+        dailyScheduleService.updateTeacherAttendance(
+            dailyScheduleId,
+            adminId,
+            ADMIN_CAN_WRITE_ANY_DAILY_SCHEDULE,
+            ADMIN_CAN_VIEW_SENSITIVE_INFO,
+            new UpdateDailyTeacherAttendanceRequest(status, latitude, longitude)
+        );
+    }
+
+    @Transactional
+    public void updateStudentAttendances(
+        Long adminId,
+        Long dailyScheduleId,
+        List<UpdateDailyStudentAttendanceItemRequest> attendances
+    ) {
+        dailyScheduleService.updateStudentAttendances(
+            dailyScheduleId,
+            adminId,
+            ADMIN_CAN_WRITE_ANY_DAILY_SCHEDULE,
+            ADMIN_CAN_VIEW_SENSITIVE_INFO,
+            new UpdateDailyStudentAttendancesRequest(attendances)
+        );
+    }
+
     public DailyScheduleStatus[] getStatuses() {
         return DailyScheduleStatus.values();
+    }
+
+    public DailyTeacherAttendanceStatus[] getTeacherAttendanceStatuses() {
+        return DailyTeacherAttendanceStatus.values();
+    }
+
+    public DailyStudentAttendanceStatus[] getStudentAttendanceStatuses() {
+        return DailyStudentAttendanceStatus.values();
     }
 
     public String getScheduleStatusLabel(DailyScheduleStatus status) {

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleAdminViewService.java
@@ -8,6 +8,7 @@ import geumjeongyahak.domain.daily_schedule.enums.DailyStudentAttendanceStatus;
 import geumjeongyahak.domain.daily_schedule.enums.DailyTeacherAttendanceStatus;
 import geumjeongyahak.domain.daily_schedule.repository.DailyStudentAttendanceRepository;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailyScheduleListRequest;
+import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyScheduleJournalRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyStudentAttendanceItemRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyStudentAttendancesRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyScheduleStatusRequest;
@@ -138,6 +139,26 @@ public class DailyScheduleAdminViewService {
             ADMIN_CAN_WRITE_ANY_DAILY_SCHEDULE,
             ADMIN_CAN_VIEW_SENSITIVE_INFO,
             new UpdateDailyStudentAttendancesRequest(attendances)
+        );
+    }
+
+    @Transactional
+    public void updateJournal(
+        Long adminId,
+        Long dailyScheduleId,
+        Boolean personalInfoConsent,
+        String residentRegistrationNumberPrefix,
+        List<UpdateDailyScheduleJournalRequest.LessonJournalRequest> lessonJournals
+    ) {
+        dailyScheduleService.updateJournal(
+            dailyScheduleId,
+            adminId,
+            ADMIN_CAN_WRITE_ANY_DAILY_SCHEDULE,
+            new UpdateDailyScheduleJournalRequest(
+                personalInfoConsent,
+                residentRegistrationNumberPrefix,
+                lessonJournals
+            )
         );
     }
 

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleAdminViewService.java
@@ -1,0 +1,247 @@
+package geumjeongyahak.domain.daily_schedule.service;
+
+import geumjeongyahak.domain.classroom.entity.Classroom;
+import geumjeongyahak.domain.classroom.service.ClassroomProxyService;
+import geumjeongyahak.domain.daily_schedule.entity.DailyStudentAttendance;
+import geumjeongyahak.domain.daily_schedule.enums.DailyScheduleStatus;
+import geumjeongyahak.domain.daily_schedule.enums.DailyStudentAttendanceStatus;
+import geumjeongyahak.domain.daily_schedule.enums.DailyTeacherAttendanceStatus;
+import geumjeongyahak.domain.daily_schedule.repository.DailyStudentAttendanceRepository;
+import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailyScheduleListRequest;
+import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleSummaryResponse;
+import geumjeongyahak.domain.users.entity.User;
+import geumjeongyahak.domain.users.service.UserProxyService;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DailyScheduleAdminViewService {
+
+    private static final int PREVIOUS_WEEK_OFFSET = -1;
+    private static final int NEXT_WEEK_OFFSET = 1;
+
+    private final DailyScheduleService dailyScheduleService;
+    private final DailyStudentAttendanceRepository dailyStudentAttendanceRepository;
+    private final ClassroomProxyService classroomProxyService;
+    private final UserProxyService userProxyService;
+
+    public DailyScheduleAdminPage getDailySchedules(DailyScheduleFilter filter) {
+        DateRange range = resolveDateRange(filter.from(), filter.to());
+        List<DailyScheduleSummaryResponse> summaries = dailyScheduleService.getDailySchedules(
+            new DailyScheduleListRequest(
+                range.from(),
+                range.to(),
+                filter.classroomId(),
+                filter.teacherId(),
+                filter.status()
+            )
+        );
+        Map<Long, StudentAttendanceSummary> attendanceSummaries = getStudentAttendanceSummaries(summaries);
+        List<DailyScheduleRow> rows = summaries.stream()
+            .map(summary -> DailyScheduleRow.from(
+                summary,
+                attendanceSummaries.getOrDefault(
+                    summary.dailyScheduleId(),
+                    StudentAttendanceSummary.empty()
+                )
+            ))
+            .toList();
+
+        return new DailyScheduleAdminPage(
+            range.from(),
+            range.to(),
+            range.shiftWeeks(PREVIOUS_WEEK_OFFSET),
+            range.currentWeek(),
+            range.shiftWeeks(NEXT_WEEK_OFFSET),
+            rows
+        );
+    }
+
+    public List<ClassroomOption> getClassroomOptions() {
+        return classroomProxyService.getActiveClassroomsOrderByName()
+            .stream()
+            .map(ClassroomOption::from)
+            .toList();
+    }
+
+    public List<TeacherOption> getTeacherOptions() {
+        return userProxyService.getTeacherCandidatesOrderByName()
+            .stream()
+            .map(TeacherOption::from)
+            .toList();
+    }
+
+    public DailyScheduleStatus[] getStatuses() {
+        return DailyScheduleStatus.values();
+    }
+
+    public String getScheduleStatusLabel(DailyScheduleStatus status) {
+        return status.getDisplayName();
+    }
+
+    public String getTeacherAttendanceStatusLabel(DailyTeacherAttendanceStatus status) {
+        return status == null ? "미처리" : status.getDisplayName();
+    }
+
+    private DateRange resolveDateRange(LocalDate from, LocalDate to) {
+        if (from != null && to != null) {
+            return new DateRange(from, to);
+        }
+        LocalDate baseDate = from != null ? from : LocalDate.now();
+        LocalDate weekStart = baseDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate weekEnd = baseDate.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+        return new DateRange(weekStart, weekEnd);
+    }
+
+    private Map<Long, StudentAttendanceSummary> getStudentAttendanceSummaries(
+        List<DailyScheduleSummaryResponse> summaries
+    ) {
+        List<Long> dailyScheduleIds = summaries.stream()
+            .map(DailyScheduleSummaryResponse::dailyScheduleId)
+            .toList();
+        if (dailyScheduleIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return dailyStudentAttendanceRepository.findAllByDailySchedule_IdInAndIsDeletedFalse(dailyScheduleIds)
+            .stream()
+            .collect(Collectors.groupingBy(
+                attendance -> attendance.getDailySchedule().getId(),
+                Collectors.collectingAndThen(Collectors.toList(), this::toStudentAttendanceSummary)
+            ));
+    }
+
+    private StudentAttendanceSummary toStudentAttendanceSummary(List<DailyStudentAttendance> attendances) {
+        Map<DailyStudentAttendanceStatus, Long> counts = attendances.stream()
+            .collect(Collectors.groupingBy(
+                DailyStudentAttendance::getStatus,
+                () -> new EnumMap<>(DailyStudentAttendanceStatus.class),
+                Collectors.counting()
+            ));
+        return new StudentAttendanceSummary(
+            counts.getOrDefault(DailyStudentAttendanceStatus.PRESENT, 0L),
+            counts.getOrDefault(DailyStudentAttendanceStatus.LATE, 0L),
+            counts.getOrDefault(DailyStudentAttendanceStatus.ABSENT, 0L),
+            attendances.size()
+        );
+    }
+
+    public record DailyScheduleFilter(
+        LocalDate from,
+        LocalDate to,
+        Long classroomId,
+        Long teacherId,
+        DailyScheduleStatus status
+    ) {
+    }
+
+    public record DailyScheduleAdminPage(
+        LocalDate from,
+        LocalDate to,
+        DateRange previousWeek,
+        DateRange currentWeek,
+        DateRange nextWeek,
+        List<DailyScheduleRow> rows
+    ) {
+    }
+
+    public record DateRange(
+        LocalDate from,
+        LocalDate to
+    ) {
+        private DateRange shiftWeeks(int weekOffset) {
+            return new DateRange(from.plusWeeks(weekOffset), to.plusWeeks(weekOffset));
+        }
+
+        private DateRange currentWeek() {
+            LocalDate today = LocalDate.now();
+            return new DateRange(
+                today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)),
+                today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY))
+            );
+        }
+    }
+
+    public record DailyScheduleRow(
+        Long dailyScheduleId,
+        LocalDate lessonDate,
+        Long classroomId,
+        String classroomName,
+        Long teacherId,
+        String teacherName,
+        LocalTime activityStartTime,
+        LocalTime activityEndTime,
+        Integer volunteerServiceMinutes,
+        DailyScheduleStatus status,
+        String statusLabel,
+        DailyTeacherAttendanceStatus teacherAttendanceStatus,
+        String teacherAttendanceStatusLabel,
+        int lessonCount,
+        StudentAttendanceSummary studentAttendanceSummary
+    ) {
+        private static DailyScheduleRow from(
+            DailyScheduleSummaryResponse summary,
+            StudentAttendanceSummary studentAttendanceSummary
+        ) {
+            return new DailyScheduleRow(
+                summary.dailyScheduleId(),
+                summary.lessonDate(),
+                summary.classroomId(),
+                summary.classroomName(),
+                summary.teacherId(),
+                summary.teacherName(),
+                summary.activityStartTime(),
+                summary.activityEndTime(),
+                summary.volunteerServiceMinutes(),
+                summary.status(),
+                summary.status().getDisplayName(),
+                summary.teacherAttendanceStatus(),
+                summary.teacherAttendanceStatus() == null
+                    ? "미처리"
+                    : summary.teacherAttendanceStatus().getDisplayName(),
+                summary.lessonCount(),
+                studentAttendanceSummary
+            );
+        }
+    }
+
+    public record StudentAttendanceSummary(
+        long presentCount,
+        long lateCount,
+        long absentCount,
+        long totalCount
+    ) {
+        private static StudentAttendanceSummary empty() {
+            return new StudentAttendanceSummary(0L, 0L, 0L, 0L);
+        }
+    }
+
+    public record ClassroomOption(
+        Long id,
+        String name
+    ) {
+        private static ClassroomOption from(Classroom classroom) {
+            return new ClassroomOption(classroom.getId(), classroom.getName());
+        }
+    }
+
+    public record TeacherOption(
+        Long id,
+        String name
+    ) {
+        private static TeacherOption from(User user) {
+            return new TeacherOption(user.getId(), user.getName());
+        }
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleAdminViewService.java
@@ -8,6 +8,7 @@ import geumjeongyahak.domain.daily_schedule.enums.DailyStudentAttendanceStatus;
 import geumjeongyahak.domain.daily_schedule.enums.DailyTeacherAttendanceStatus;
 import geumjeongyahak.domain.daily_schedule.repository.DailyStudentAttendanceRepository;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailyScheduleListRequest;
+import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleDetailResponse;
 import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleSummaryResponse;
 import geumjeongyahak.domain.users.entity.User;
 import geumjeongyahak.domain.users.service.UserProxyService;
@@ -30,6 +31,7 @@ public class DailyScheduleAdminViewService {
 
     private static final int PREVIOUS_WEEK_OFFSET = -1;
     private static final int NEXT_WEEK_OFFSET = 1;
+    private static final boolean ADMIN_CAN_VIEW_SENSITIVE_INFO = true;
 
     private final DailyScheduleService dailyScheduleService;
     private final DailyStudentAttendanceRepository dailyStudentAttendanceRepository;
@@ -80,6 +82,14 @@ public class DailyScheduleAdminViewService {
             .stream()
             .map(TeacherOption::from)
             .toList();
+    }
+
+    public DailyScheduleDetailResponse getDailySchedule(Long viewerId, Long dailyScheduleId) {
+        return dailyScheduleService.getDailySchedule(
+            dailyScheduleId,
+            viewerId,
+            ADMIN_CAN_VIEW_SENSITIVE_INFO
+        );
     }
 
     public DailyScheduleStatus[] getStatuses() {

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleAdminViewService.java
@@ -8,6 +8,7 @@ import geumjeongyahak.domain.daily_schedule.enums.DailyStudentAttendanceStatus;
 import geumjeongyahak.domain.daily_schedule.enums.DailyTeacherAttendanceStatus;
 import geumjeongyahak.domain.daily_schedule.repository.DailyStudentAttendanceRepository;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailyScheduleListRequest;
+import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyScheduleStatusRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleDetailResponse;
 import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleSummaryResponse;
 import geumjeongyahak.domain.users.entity.User;
@@ -34,6 +35,7 @@ public class DailyScheduleAdminViewService {
     private static final boolean ADMIN_CAN_VIEW_SENSITIVE_INFO = true;
 
     private final DailyScheduleService dailyScheduleService;
+    private final DailyScheduleAdminService dailyScheduleAdminService;
     private final DailyStudentAttendanceRepository dailyStudentAttendanceRepository;
     private final ClassroomProxyService classroomProxyService;
     private final UserProxyService userProxyService;
@@ -89,6 +91,16 @@ public class DailyScheduleAdminViewService {
             dailyScheduleId,
             viewerId,
             ADMIN_CAN_VIEW_SENSITIVE_INFO
+        );
+    }
+
+    @Transactional
+    public void updateStatus(Long adminId, Long dailyScheduleId, DailyScheduleStatus status) {
+        dailyScheduleAdminService.updateStatus(
+            dailyScheduleId,
+            adminId,
+            ADMIN_CAN_VIEW_SENSITIVE_INFO,
+            new UpdateDailyScheduleStatusRequest(status)
         );
     }
 

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/DailyScheduleViewController.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/DailyScheduleViewController.java
@@ -4,9 +4,14 @@ import static org.springframework.format.annotation.DateTimeFormat.ISO.DATE;
 
 import geumjeongyahak.common.security.service.CustomUserDetails;
 import geumjeongyahak.domain.daily_schedule.enums.DailyScheduleStatus;
+import geumjeongyahak.domain.daily_schedule.enums.DailyStudentAttendanceStatus;
+import geumjeongyahak.domain.daily_schedule.enums.DailyTeacherAttendanceStatus;
 import geumjeongyahak.domain.daily_schedule.service.DailyScheduleAdminViewService;
 import geumjeongyahak.domain.daily_schedule.service.DailyScheduleAdminViewService.DailyScheduleFilter;
+import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyStudentAttendanceItemRequest;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -77,6 +82,8 @@ public class DailyScheduleViewController {
             dailyScheduleId
         ));
         model.addAttribute("statuses", dailyScheduleAdminViewService.getStatuses());
+        model.addAttribute("teacherAttendanceStatuses", dailyScheduleAdminViewService.getTeacherAttendanceStatuses());
+        model.addAttribute("studentAttendanceStatuses", dailyScheduleAdminViewService.getStudentAttendanceStatuses());
         return "admin/daily-schedule/daily-schedules-detail";
     }
 
@@ -101,6 +108,84 @@ public class DailyScheduleViewController {
         addRedirectAttributeIfPresent(redirectAttributes, "teacherId", teacherId);
         addRedirectAttributeIfPresent(redirectAttributes, "status", filterStatus);
         return "redirect:/admin/daily-schedule/daily-schedules/" + dailyScheduleId;
+    }
+
+    @PreAuthorize(DAILY_SCHEDULE_MANAGE_ACCESS)
+    @PostMapping("/{dailyScheduleId}/teacher-attendance")
+    public String updateTeacherAttendance(
+        @PathVariable Long dailyScheduleId,
+        @RequestParam DailyTeacherAttendanceStatus teacherAttendanceStatus,
+        @RequestParam(required = false) @DateTimeFormat(iso = DATE) LocalDate from,
+        @RequestParam(required = false) @DateTimeFormat(iso = DATE) LocalDate to,
+        @RequestParam(required = false) Long classroomId,
+        @RequestParam(required = false) Long teacherId,
+        @RequestParam(required = false) DailyScheduleStatus filterStatus,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        RedirectAttributes redirectAttributes
+    ) {
+        dailyScheduleAdminViewService.updateTeacherAttendance(
+            userDetails.getUserId(),
+            dailyScheduleId,
+            teacherAttendanceStatus,
+            null,
+            null
+        );
+        redirectAttributes.addFlashAttribute("message", "교사 출석 상태를 변경했습니다.");
+        addListFilterRedirectAttributes(redirectAttributes, from, to, classroomId, teacherId, filterStatus);
+        return "redirect:/admin/daily-schedule/daily-schedules/" + dailyScheduleId;
+    }
+
+    @PreAuthorize(DAILY_SCHEDULE_MANAGE_ACCESS)
+    @PostMapping("/{dailyScheduleId}/student-attendances")
+    public String updateStudentAttendances(
+        @PathVariable Long dailyScheduleId,
+        @RequestParam List<Long> studentIds,
+        @RequestParam List<DailyStudentAttendanceStatus> studentAttendanceStatuses,
+        @RequestParam(required = false) @DateTimeFormat(iso = DATE) LocalDate from,
+        @RequestParam(required = false) @DateTimeFormat(iso = DATE) LocalDate to,
+        @RequestParam(required = false) Long classroomId,
+        @RequestParam(required = false) Long teacherId,
+        @RequestParam(required = false) DailyScheduleStatus filterStatus,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        RedirectAttributes redirectAttributes
+    ) {
+        dailyScheduleAdminViewService.updateStudentAttendances(
+            userDetails.getUserId(),
+            dailyScheduleId,
+            buildStudentAttendanceItems(studentIds, studentAttendanceStatuses)
+        );
+        redirectAttributes.addFlashAttribute("message", "학생 출석 상태를 변경했습니다.");
+        addListFilterRedirectAttributes(redirectAttributes, from, to, classroomId, teacherId, filterStatus);
+        return "redirect:/admin/daily-schedule/daily-schedules/" + dailyScheduleId;
+    }
+
+    private List<UpdateDailyStudentAttendanceItemRequest> buildStudentAttendanceItems(
+        List<Long> studentIds,
+        List<DailyStudentAttendanceStatus> statuses
+    ) {
+        List<UpdateDailyStudentAttendanceItemRequest> items = new ArrayList<>();
+        if (studentIds.size() != statuses.size()) {
+            throw new IllegalArgumentException("학생 출석 요청 값이 올바르지 않습니다.");
+        }
+        for (int i = 0; i < studentIds.size(); i++) {
+            items.add(new UpdateDailyStudentAttendanceItemRequest(studentIds.get(i), statuses.get(i)));
+        }
+        return items;
+    }
+
+    private void addListFilterRedirectAttributes(
+        RedirectAttributes redirectAttributes,
+        LocalDate from,
+        LocalDate to,
+        Long classroomId,
+        Long teacherId,
+        DailyScheduleStatus filterStatus
+    ) {
+        addRedirectAttributeIfPresent(redirectAttributes, "from", from);
+        addRedirectAttributeIfPresent(redirectAttributes, "to", to);
+        addRedirectAttributeIfPresent(redirectAttributes, "classroomId", classroomId);
+        addRedirectAttributeIfPresent(redirectAttributes, "teacherId", teacherId);
+        addRedirectAttributeIfPresent(redirectAttributes, "status", filterStatus);
     }
 
     private void addRedirectAttributeIfPresent(RedirectAttributes redirectAttributes, String name, Object value) {

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/DailyScheduleViewController.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/DailyScheduleViewController.java
@@ -2,6 +2,7 @@ package geumjeongyahak.domain.daily_schedule.v1.controller;
 
 import static org.springframework.format.annotation.DateTimeFormat.ISO.DATE;
 
+import geumjeongyahak.common.security.service.CustomUserDetails;
 import geumjeongyahak.domain.daily_schedule.enums.DailyScheduleStatus;
 import geumjeongyahak.domain.daily_schedule.service.DailyScheduleAdminViewService;
 import geumjeongyahak.domain.daily_schedule.service.DailyScheduleAdminViewService.DailyScheduleFilter;
@@ -10,9 +11,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -46,5 +49,29 @@ public class DailyScheduleViewController {
         model.addAttribute("teachers", dailyScheduleAdminViewService.getTeacherOptions());
         model.addAttribute("statuses", dailyScheduleAdminViewService.getStatuses());
         return "admin/daily-schedule/daily-schedules";
+    }
+
+    @PreAuthorize(DAILY_SCHEDULE_READ_ACCESS)
+    @GetMapping("/{dailyScheduleId}")
+    public String dailyScheduleDetail(
+        @PathVariable Long dailyScheduleId,
+        @RequestParam(required = false) @DateTimeFormat(iso = DATE) LocalDate from,
+        @RequestParam(required = false) @DateTimeFormat(iso = DATE) LocalDate to,
+        @RequestParam(required = false) Long classroomId,
+        @RequestParam(required = false) Long teacherId,
+        @RequestParam(required = false) DailyScheduleStatus status,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        Model model,
+        Authentication authentication
+    ) {
+        DailyScheduleFilter filter = new DailyScheduleFilter(from, to, classroomId, teacherId, status);
+        model.addAttribute("active", "dailySchedules");
+        model.addAttribute("adminName", authentication.getName());
+        model.addAttribute("filter", filter);
+        model.addAttribute("schedule", dailyScheduleAdminViewService.getDailySchedule(
+            userDetails.getUserId(),
+            dailyScheduleId
+        ));
+        return "admin/daily-schedule/daily-schedules-detail";
     }
 }

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/DailyScheduleViewController.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/DailyScheduleViewController.java
@@ -8,6 +8,7 @@ import geumjeongyahak.domain.daily_schedule.enums.DailyStudentAttendanceStatus;
 import geumjeongyahak.domain.daily_schedule.enums.DailyTeacherAttendanceStatus;
 import geumjeongyahak.domain.daily_schedule.service.DailyScheduleAdminViewService;
 import geumjeongyahak.domain.daily_schedule.service.DailyScheduleAdminViewService.DailyScheduleFilter;
+import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyScheduleJournalRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyStudentAttendanceItemRequest;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -159,6 +160,35 @@ public class DailyScheduleViewController {
         return "redirect:/admin/daily-schedule/daily-schedules/" + dailyScheduleId;
     }
 
+    @PreAuthorize(DAILY_SCHEDULE_MANAGE_ACCESS)
+    @PostMapping("/{dailyScheduleId}/journal")
+    public String updateJournal(
+        @PathVariable Long dailyScheduleId,
+        @RequestParam(required = false) Boolean personalInfoConsent,
+        @RequestParam(required = false) String residentRegistrationNumberPrefix,
+        @RequestParam List<Long> lessonIds,
+        @RequestParam List<String> notes,
+        @RequestParam(required = false) @DateTimeFormat(iso = DATE) LocalDate from,
+        @RequestParam(required = false) @DateTimeFormat(iso = DATE) LocalDate to,
+        @RequestParam(required = false) Long classroomId,
+        @RequestParam(required = false) Long teacherId,
+        @RequestParam(required = false) DailyScheduleStatus filterStatus,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        RedirectAttributes redirectAttributes
+    ) {
+        boolean consent = Boolean.TRUE.equals(personalInfoConsent);
+        dailyScheduleAdminViewService.updateJournal(
+            userDetails.getUserId(),
+            dailyScheduleId,
+            consent,
+            normalizeResidentRegistrationNumberPrefix(consent, residentRegistrationNumberPrefix),
+            buildLessonJournals(lessonIds, notes)
+        );
+        redirectAttributes.addFlashAttribute("message", "수업 일지를 저장했습니다.");
+        addListFilterRedirectAttributes(redirectAttributes, from, to, classroomId, teacherId, filterStatus);
+        return "redirect:/admin/daily-schedule/daily-schedules/" + dailyScheduleId;
+    }
+
     private List<UpdateDailyStudentAttendanceItemRequest> buildStudentAttendanceItems(
         List<Long> studentIds,
         List<DailyStudentAttendanceStatus> statuses
@@ -171,6 +201,30 @@ public class DailyScheduleViewController {
             items.add(new UpdateDailyStudentAttendanceItemRequest(studentIds.get(i), statuses.get(i)));
         }
         return items;
+    }
+
+    private List<UpdateDailyScheduleJournalRequest.LessonJournalRequest> buildLessonJournals(
+        List<Long> lessonIds,
+        List<String> notes
+    ) {
+        List<UpdateDailyScheduleJournalRequest.LessonJournalRequest> journals = new ArrayList<>();
+        if (lessonIds.size() != notes.size()) {
+            throw new IllegalArgumentException("수업 일지 요청 값이 올바르지 않습니다.");
+        }
+        for (int i = 0; i < lessonIds.size(); i++) {
+            journals.add(new UpdateDailyScheduleJournalRequest.LessonJournalRequest(lessonIds.get(i), notes.get(i)));
+        }
+        return journals;
+    }
+
+    private String normalizeResidentRegistrationNumberPrefix(
+        boolean personalInfoConsent,
+        String residentRegistrationNumberPrefix
+    ) {
+        if (!personalInfoConsent || residentRegistrationNumberPrefix == null || residentRegistrationNumberPrefix.isBlank()) {
+            return null;
+        }
+        return residentRegistrationNumberPrefix.trim();
     }
 
     private void addListFilterRedirectAttributes(

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/DailyScheduleViewController.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/DailyScheduleViewController.java
@@ -1,0 +1,50 @@
+package geumjeongyahak.domain.daily_schedule.v1.controller;
+
+import static org.springframework.format.annotation.DateTimeFormat.ISO.DATE;
+
+import geumjeongyahak.domain.daily_schedule.enums.DailyScheduleStatus;
+import geumjeongyahak.domain.daily_schedule.service.DailyScheduleAdminViewService;
+import geumjeongyahak.domain.daily_schedule.service.DailyScheduleAdminViewService.DailyScheduleFilter;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequestMapping("/admin/daily-schedule/daily-schedules")
+@RequiredArgsConstructor
+public class DailyScheduleViewController {
+
+    private static final String DAILY_SCHEDULE_READ_ACCESS =
+        "hasRole('ADMIN') or hasAuthority('daily-schedule:read:*') or hasAuthority('daily-schedule:manage:*')";
+
+    private final DailyScheduleAdminViewService dailyScheduleAdminViewService;
+
+    @PreAuthorize(DAILY_SCHEDULE_READ_ACCESS)
+    @GetMapping
+    public String dailySchedules(
+        @RequestParam(required = false) @DateTimeFormat(iso = DATE) LocalDate from,
+        @RequestParam(required = false) @DateTimeFormat(iso = DATE) LocalDate to,
+        @RequestParam(required = false) Long classroomId,
+        @RequestParam(required = false) Long teacherId,
+        @RequestParam(required = false) DailyScheduleStatus status,
+        Model model,
+        Authentication authentication
+    ) {
+        DailyScheduleFilter filter = new DailyScheduleFilter(from, to, classroomId, teacherId, status);
+        model.addAttribute("active", "dailySchedules");
+        model.addAttribute("adminName", authentication.getName());
+        model.addAttribute("filter", filter);
+        model.addAttribute("dailySchedulesPage", dailyScheduleAdminViewService.getDailySchedules(filter));
+        model.addAttribute("classrooms", dailyScheduleAdminViewService.getClassroomOptions());
+        model.addAttribute("teachers", dailyScheduleAdminViewService.getTeacherOptions());
+        model.addAttribute("statuses", dailyScheduleAdminViewService.getStatuses());
+        return "admin/daily-schedule/daily-schedules";
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/DailyScheduleViewController.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/DailyScheduleViewController.java
@@ -16,8 +16,10 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
 @RequestMapping("/admin/daily-schedule/daily-schedules")
@@ -26,6 +28,8 @@ public class DailyScheduleViewController {
 
     private static final String DAILY_SCHEDULE_READ_ACCESS =
         "hasRole('ADMIN') or hasAuthority('daily-schedule:read:*') or hasAuthority('daily-schedule:manage:*')";
+    private static final String DAILY_SCHEDULE_MANAGE_ACCESS =
+        "hasRole('ADMIN') or hasAuthority('daily-schedule:manage:*')";
 
     private final DailyScheduleAdminViewService dailyScheduleAdminViewService;
 
@@ -72,6 +76,36 @@ public class DailyScheduleViewController {
             userDetails.getUserId(),
             dailyScheduleId
         ));
+        model.addAttribute("statuses", dailyScheduleAdminViewService.getStatuses());
         return "admin/daily-schedule/daily-schedules-detail";
+    }
+
+    @PreAuthorize(DAILY_SCHEDULE_MANAGE_ACCESS)
+    @PostMapping("/{dailyScheduleId}/status")
+    public String updateStatus(
+        @PathVariable Long dailyScheduleId,
+        @RequestParam DailyScheduleStatus status,
+        @RequestParam(required = false) @DateTimeFormat(iso = DATE) LocalDate from,
+        @RequestParam(required = false) @DateTimeFormat(iso = DATE) LocalDate to,
+        @RequestParam(required = false) Long classroomId,
+        @RequestParam(required = false) Long teacherId,
+        @RequestParam(required = false) DailyScheduleStatus filterStatus,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        RedirectAttributes redirectAttributes
+    ) {
+        dailyScheduleAdminViewService.updateStatus(userDetails.getUserId(), dailyScheduleId, status);
+        redirectAttributes.addFlashAttribute("message", "하루 일정 상태를 변경했습니다.");
+        addRedirectAttributeIfPresent(redirectAttributes, "from", from);
+        addRedirectAttributeIfPresent(redirectAttributes, "to", to);
+        addRedirectAttributeIfPresent(redirectAttributes, "classroomId", classroomId);
+        addRedirectAttributeIfPresent(redirectAttributes, "teacherId", teacherId);
+        addRedirectAttributeIfPresent(redirectAttributes, "status", filterStatus);
+        return "redirect:/admin/daily-schedule/daily-schedules/" + dailyScheduleId;
+    }
+
+    private void addRedirectAttributeIfPresent(RedirectAttributes redirectAttributes, String name, Object value) {
+        if (value != null) {
+            redirectAttributes.addAttribute(name, value.toString());
+        }
     }
 }

--- a/src/main/java/geumjeongyahak/domain/users/service/UserProxyService.java
+++ b/src/main/java/geumjeongyahak/domain/users/service/UserProxyService.java
@@ -2,18 +2,28 @@ package geumjeongyahak.domain.users.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import geumjeongyahak.domain.auth.enums.RoleType;
 import geumjeongyahak.domain.users.entity.User;
 import geumjeongyahak.domain.users.exception.UserNotFoundException;
 import geumjeongyahak.domain.users.repository.UserRepository;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserProxyService {
+    private static final Set<RoleType> TEACHER_ROLES = Set.of(
+        RoleType.ADMIN,
+        RoleType.MANAGER,
+        RoleType.VOLUNTEER
+    );
+
     private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
@@ -61,6 +71,14 @@ public class UserProxyService {
     @Transactional(readOnly = true)
     public java.util.List<User> getAllByDepartmentId(Long departmentId) {
         return userRepository.findAllByDepartmentId(departmentId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<User> getTeacherCandidatesOrderByName() {
+        return userRepository.findAll(Sort.by(Sort.Direction.ASC, "name"))
+            .stream()
+            .filter(user -> TEACHER_ROLES.contains(user.getRole()))
+            .toList();
     }
 
     @Transactional

--- a/src/main/resources/sql/init_data.sql
+++ b/src/main/resources/sql/init_data.sql
@@ -104,8 +104,14 @@ VALUES
     (3, 1, 2, 3, '2026-06-10', '21:00:00', '21:40:00', 'SCHEDULED'),
     (4, 2, 3, 1, '2026-06-17', '19:20:00', '20:00:00', 'SCHEDULED'),
     (5, 2, 3, 2, '2026-06-17', '20:10:00', '20:50:00', 'SCHEDULED'),
-    (6, 2, 3, 3, '2026-06-17', '21:00:00', '21:40:00', 'SCHEDULED');
-ALTER SEQUENCE lessons_id_seq RESTART WITH 7;
+    (6, 2, 3, 3, '2026-06-17', '21:00:00', '21:40:00', 'SCHEDULED'),
+    (7, 1, 2, 1, '2026-05-13', '19:20:00', '20:00:00', 'COMPLETED'),
+    (8, 1, 2, 2, '2026-05-13', '20:10:00', '20:50:00', 'COMPLETED'),
+    (9, 1, 2, 3, '2026-05-13', '21:00:00', '21:40:00', 'COMPLETED');
+UPDATE lessons SET note = '1교시에는 한글 자음과 모음 복습을 진행했습니다.' WHERE id = 7;
+UPDATE lessons SET note = '2교시에는 짧은 단어 읽기와 받아쓰기를 연습했습니다.' WHERE id = 8;
+UPDATE lessons SET note = '3교시에는 생활 문장 읽기 활동과 개별 피드백을 진행했습니다.' WHERE id = 9;
+ALTER SEQUENCE lessons_id_seq RESTART WITH 10;
 
 -- 10. Daily Schedules
 INSERT INTO daily_schedules (
@@ -117,8 +123,22 @@ VALUES
     (2, 2, 3, '2026-06-17', '19:20:00', '21:40:00', 'SCHEDULED', FALSE, '2026-05-20 00:00:00', '2026-05-20 00:00:00'),
     (3, 1, 2, '2026-06-24', '19:20:00', '21:40:00', 'SCHEDULED', FALSE, '2026-05-20 00:00:00', '2026-05-20 00:00:00'),
     (4, 2, 3, '2026-06-24', '19:20:00', '21:40:00', 'SCHEDULED', FALSE, '2026-05-20 00:00:00', '2026-05-20 00:00:00'),
-    (5, 8, 2, '2026-06-27', '19:20:00', '20:00:00', 'SCHEDULED', FALSE, '2026-05-20 00:00:00', '2026-05-20 00:00:00');
-ALTER SEQUENCE daily_schedules_id_seq RESTART WITH 6;
+    (5, 8, 2, '2026-06-27', '19:20:00', '20:00:00', 'SCHEDULED', FALSE, '2026-05-20 00:00:00', '2026-05-20 00:00:00'),
+    (6, 1, 2, '2026-05-13', '19:20:00', '21:40:00', 'COMPLETED', FALSE, '2026-05-13 18:00:00', '2026-05-13 22:00:00');
+UPDATE daily_schedules
+SET resident_registration_number_prefix = '900101',
+    personal_info_consent = TRUE
+WHERE id = 6;
+ALTER SEQUENCE daily_schedules_id_seq RESTART WITH 7;
+
+-- 10-1. Daily Teacher Attendances
+INSERT INTO daily_teacher_attendances (
+    id, daily_schedule_id, status, volunteer_service_minutes, attended_at, latitude, longitude, is_deleted,
+    created_at, updated_at
+)
+VALUES
+    (1, 6, 'PRESENT', 140, '2026-05-13 19:18:00', NULL, NULL, FALSE, '2026-05-13 19:18:00', '2026-05-13 19:18:00');
+ALTER SEQUENCE daily_teacher_attendances_id_seq RESTART WITH 2;
 
 -- 11. Absence Requests
 INSERT INTO absence_requests (
@@ -181,4 +201,13 @@ VALUES
     (1, 1, '이영희', '010-3333-3333', '기초반', 'ENROLLED'),
     (2, 1, '박민수', '010-4444-4444', '기초반', 'ENROLLED');
 ALTER SEQUENCE students_id_seq RESTART WITH 3;
+
+-- 15. Daily Student Attendances
+INSERT INTO daily_student_attendances (
+    id, daily_schedule_id, student_id, status, is_deleted, created_at, updated_at
+)
+VALUES
+    (1, 6, 1, 'PRESENT', FALSE, '2026-05-13 22:00:00', '2026-05-13 22:00:00'),
+    (2, 6, 2, 'LATE', FALSE, '2026-05-13 22:00:00', '2026-05-13 22:00:00');
+ALTER SEQUENCE daily_student_attendances_id_seq RESTART WITH 3;
 

--- a/src/main/resources/templates/admin/daily-schedule/daily-schedules-detail.html
+++ b/src/main/resources/templates/admin/daily-schedule/daily-schedules-detail.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/layout :: head('하루 일정 상세')}"></head>
+<body>
+<div th:replace="~{admin/fragments/layout :: shell(~{::main})}">
+    <main class="stack">
+        <div class="page-title">
+            <div>
+                <h1>하루 일정 상세</h1>
+                <p th:text="|${schedule.lessonDate} ${schedule.classroomName} 일정과 출석 현황입니다.|">
+                    2026-05-20 벚꽃반 일정과 출석 현황입니다.
+                </p>
+            </div>
+            <a class="reset-link"
+               th:href="@{/admin/daily-schedule/daily-schedules(from=${filter.from},to=${filter.to},classroomId=${filter.classroomId},teacherId=${filter.teacherId},status=${filter.status})}">
+                목록으로
+            </a>
+        </div>
+
+        <section class="panel">
+            <h2>기본 정보</h2>
+            <div class="detail-grid">
+                <div class="detail-item">
+                    <span>ID</span>
+                    <strong th:text="${schedule.dailyScheduleId}">1</strong>
+                </div>
+                <div class="detail-item">
+                    <span>수업일</span>
+                    <strong th:text="${schedule.lessonDate}">2026-05-20</strong>
+                </div>
+                <div class="detail-item">
+                    <span>분반</span>
+                    <strong th:text="|${schedule.classroomName} (#${schedule.classroomId})|">벚꽃반 (#1)</strong>
+                </div>
+                <div class="detail-item">
+                    <span>담당 교사</span>
+                    <strong th:text="|${schedule.teacherName} (#${schedule.teacherId})|">홍길동 (#2)</strong>
+                </div>
+                <div class="detail-item">
+                    <span>교사 연락처</span>
+                    <strong th:text="${schedule.teacherPhoneNumber != null ? schedule.teacherPhoneNumber : '-'}">010-0000-0000</strong>
+                </div>
+                <div class="detail-item">
+                    <span>주민번호 앞자리</span>
+                    <strong th:text="${schedule.residentRegistrationNumberPrefix != null ? schedule.residentRegistrationNumberPrefix : '-'}">900101</strong>
+                </div>
+                <div class="detail-item">
+                    <span>개인정보 활용 동의</span>
+                    <strong th:text="${schedule.personalInfoConsent ? '동의' : '미동의'}">동의</strong>
+                </div>
+                <div class="detail-item">
+                    <span>운영 시간</span>
+                    <strong th:text="${schedule.activityStartTime != null && schedule.activityEndTime != null ? schedule.activityStartTime + ' - ' + schedule.activityEndTime : '-'}">
+                        19:20 - 21:40
+                    </strong>
+                </div>
+                <div class="detail-item">
+                    <span>하루 일정 상태</span>
+                    <strong>
+                        <span class="pill" th:text="${schedule.status.displayName}">예정</span>
+                    </strong>
+                </div>
+            </div>
+        </section>
+
+        <section class="panel">
+            <h2>교사 출석</h2>
+            <div class="detail-grid" th:if="${schedule.teacherAttendance != null}">
+                <div class="detail-item">
+                    <span>출석 ID</span>
+                    <strong th:text="${schedule.teacherAttendance.attendanceId}">1</strong>
+                </div>
+                <div class="detail-item">
+                    <span>출석 상태</span>
+                    <strong>
+                        <span class="pill" th:text="${schedule.teacherAttendance.status.displayName}">출석</span>
+                    </strong>
+                </div>
+                <div class="detail-item">
+                    <span>출석 처리 시각</span>
+                    <strong th:text="${schedule.teacherAttendance.attendedAt != null ? schedule.teacherAttendance.attendedAt : '-'}">
+                        2026-05-20T19:20
+                    </strong>
+                </div>
+                <div class="detail-item">
+                    <span>봉사 인정 시간</span>
+                    <strong th:text="${schedule.teacherAttendance.volunteerServiceMinutes != null ? schedule.teacherAttendance.volunteerServiceMinutes + '분' : '-'}">
+                        120분
+                    </strong>
+                </div>
+                <div class="detail-item">
+                    <span>위도</span>
+                    <strong th:text="${schedule.teacherAttendance.latitude != null ? schedule.teacherAttendance.latitude : '-'}">35.1795543</strong>
+                </div>
+                <div class="detail-item">
+                    <span>경도</span>
+                    <strong th:text="${schedule.teacherAttendance.longitude != null ? schedule.teacherAttendance.longitude : '-'}">129.0756416</strong>
+                </div>
+            </div>
+            <p class="empty" th:if="${schedule.teacherAttendance == null}">교사 출석 정보가 아직 없습니다.</p>
+        </section>
+
+        <section class="panel table-panel">
+            <div style="padding: 22px 22px 0;">
+                <h2>학생 출석</h2>
+            </div>
+            <div class="table-scroll">
+                <table>
+                    <thead>
+                    <tr>
+                        <th>출석 ID</th>
+                        <th>학생 ID</th>
+                        <th>학생명</th>
+                        <th>상태</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="attendance : ${schedule.studentAttendances}">
+                        <td th:text="${attendance.attendanceId}">1</td>
+                        <td th:text="${attendance.studentId}">10</td>
+                        <td th:text="${attendance.studentName}">최양지</td>
+                        <td>
+                            <span class="pill" th:text="${attendance.status.displayName}">출석</span>
+                        </td>
+                    </tr>
+                    <tr th:if="${#lists.isEmpty(schedule.studentAttendances)}">
+                        <td colspan="4" class="empty">학생 출석 정보가 없습니다.</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <section class="panel table-panel">
+            <div style="padding: 22px 22px 0;">
+                <h2>수업 일지</h2>
+            </div>
+            <div class="table-scroll">
+                <table>
+                    <thead>
+                    <tr>
+                        <th>수업 ID</th>
+                        <th>교시</th>
+                        <th>시간</th>
+                        <th>과목</th>
+                        <th>일지</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="lesson : ${schedule.lessons}">
+                        <td th:text="${lesson.lessonId}">1</td>
+                        <td th:text="${lesson.period}">1</td>
+                        <td th:text="${lesson.startTime != null && lesson.endTime != null ? lesson.startTime + ' - ' + lesson.endTime : '-'}">19:20 - 20:00</td>
+                        <td th:text="${lesson.subjectName}">국어</td>
+                        <td th:text="${lesson.note != null && !#strings.isEmpty(lesson.note) ? lesson.note : '-'}">오늘 수업 내용</td>
+                    </tr>
+                    <tr th:if="${#lists.isEmpty(schedule.lessons)}">
+                        <td colspan="5" class="empty">수업 일지 정보가 없습니다.</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/daily-schedule/daily-schedules-detail.html
+++ b/src/main/resources/templates/admin/daily-schedule/daily-schedules-detail.html
@@ -191,9 +191,44 @@
             </div>
         </form>
 
-        <section class="panel table-panel">
+        <form id="journalForm"
+              class="panel table-panel"
+              th:action="@{/admin/daily-schedule/daily-schedules/{dailyScheduleId}/journal(dailyScheduleId=${schedule.dailyScheduleId})}"
+              method="post">
+            <input type="hidden" name="from" th:value="${filter.from != null ? #temporals.format(filter.from, 'yyyy-MM-dd') : ''}">
+            <input type="hidden" name="to" th:value="${filter.to != null ? #temporals.format(filter.to, 'yyyy-MM-dd') : ''}">
+            <input type="hidden" name="classroomId" th:value="${filter.classroomId}">
+            <input type="hidden" name="teacherId" th:value="${filter.teacherId}">
+            <input type="hidden" name="filterStatus" th:value="${filter.status}">
             <div style="padding: 22px 22px 0;">
-                <h2>수업 일지</h2>
+                <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap;">
+                    <h2>수업 일지</h2>
+                    <button class="button" type="submit" th:if="${!#lists.isEmpty(schedule.lessons)}">
+                        수업 일지 저장
+                    </button>
+                </div>
+                <div class="detail-grid" style="margin: 16px 0;">
+                    <label class="check-label">
+                        <input type="checkbox"
+                               id="personalInfoConsent"
+                               name="personalInfoConsent"
+                               value="true"
+                               th:checked="${schedule.personalInfoConsent}">
+                        개인정보 활용 동의
+                    </label>
+                    <label>주민번호 앞자리
+                        <input id="residentRegistrationNumberPrefix"
+                               name="residentRegistrationNumberPrefix"
+                               type="text"
+                               inputmode="numeric"
+                               maxlength="6"
+                               pattern="[0-9]{6}"
+                               th:value="${schedule.residentRegistrationNumberPrefix}">
+                    </label>
+                </div>
+                <p id="journalValidationMessage" style="display: none; color: var(--danger); font-weight: 800;">
+                    개인정보 활용 동의 여부와 주민번호 앞자리 입력값이 일치하지 않습니다.
+                </p>
             </div>
             <div class="table-scroll">
                 <table>
@@ -212,7 +247,12 @@
                         <td th:text="${lesson.period}">1</td>
                         <td th:text="${lesson.startTime != null && lesson.endTime != null ? lesson.startTime + ' - ' + lesson.endTime : '-'}">19:20 - 20:00</td>
                         <td th:text="${lesson.subjectName}">국어</td>
-                        <td th:text="${lesson.note != null && !#strings.isEmpty(lesson.note) ? lesson.note : '-'}">오늘 수업 내용</td>
+                        <td>
+                            <input type="hidden" name="lessonIds" th:value="${lesson.lessonId}">
+                            <textarea name="notes"
+                                      required
+                                      th:text="${lesson.note}">오늘 수업 내용</textarea>
+                        </td>
                     </tr>
                     <tr th:if="${#lists.isEmpty(schedule.lessons)}">
                         <td colspan="5" class="empty">수업 일지 정보가 없습니다.</td>
@@ -220,8 +260,36 @@
                     </tbody>
                 </table>
             </div>
-        </section>
+        </form>
     </main>
 </div>
+<script>
+const journalForm = document.getElementById('journalForm');
+const personalInfoConsent = document.getElementById('personalInfoConsent');
+const residentRegistrationNumberPrefix = document.getElementById('residentRegistrationNumberPrefix');
+const journalValidationMessage = document.getElementById('journalValidationMessage');
+
+if (journalForm && personalInfoConsent && residentRegistrationNumberPrefix && journalValidationMessage) {
+    journalForm.addEventListener('submit', (event) => {
+        const hasConsent = personalInfoConsent.checked;
+        const residentPrefix = residentRegistrationNumberPrefix.value.trim();
+        const valid = hasConsent
+            ? /^\d{6}$/.test(residentPrefix)
+            : residentPrefix.length === 0;
+
+        if (valid) {
+            journalValidationMessage.style.display = 'none';
+            return;
+        }
+
+        event.preventDefault();
+        journalValidationMessage.textContent = hasConsent
+            ? '개인정보 활용에 동의한 경우 주민번호 앞자리 6자리를 입력해야 합니다.'
+            : '개인정보 활용에 동의하지 않은 경우 주민번호 앞자리를 비워주세요.';
+        journalValidationMessage.style.display = 'block';
+        residentRegistrationNumberPrefix.focus();
+    });
+}
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/admin/daily-schedule/daily-schedules-detail.html
+++ b/src/main/resources/templates/admin/daily-schedule/daily-schedules-detail.html
@@ -63,6 +63,25 @@
             </div>
         </section>
 
+        <form class="panel filter-grid"
+              th:action="@{/admin/daily-schedule/daily-schedules/{dailyScheduleId}/status(dailyScheduleId=${schedule.dailyScheduleId})}"
+              method="post">
+            <input type="hidden" name="from" th:value="${filter.from != null ? #temporals.format(filter.from, 'yyyy-MM-dd') : ''}">
+            <input type="hidden" name="to" th:value="${filter.to != null ? #temporals.format(filter.to, 'yyyy-MM-dd') : ''}">
+            <input type="hidden" name="classroomId" th:value="${filter.classroomId}">
+            <input type="hidden" name="teacherId" th:value="${filter.teacherId}">
+            <input type="hidden" name="filterStatus" th:value="${filter.status}">
+            <label>하루 일정 상태
+                <select name="status">
+                    <option th:each="status : ${statuses}"
+                            th:value="${status.name()}"
+                            th:text="${status.displayName}"
+                            th:selected="${schedule.status == status}">예정</option>
+                </select>
+            </label>
+            <button class="button" type="submit">상태 변경</button>
+        </form>
+
         <section class="panel">
             <h2>교사 출석</h2>
             <div class="detail-grid" th:if="${schedule.teacherAttendance != null}">

--- a/src/main/resources/templates/admin/daily-schedule/daily-schedules-detail.html
+++ b/src/main/resources/templates/admin/daily-schedule/daily-schedules-detail.html
@@ -117,11 +117,44 @@
                 </div>
             </div>
             <p class="empty" th:if="${schedule.teacherAttendance == null}">교사 출석 정보가 아직 없습니다.</p>
+            <form class="filter-grid"
+                  style="margin-top: 18px;"
+                  th:action="@{/admin/daily-schedule/daily-schedules/{dailyScheduleId}/teacher-attendance(dailyScheduleId=${schedule.dailyScheduleId})}"
+                  method="post">
+                <input type="hidden" name="from" th:value="${filter.from != null ? #temporals.format(filter.from, 'yyyy-MM-dd') : ''}">
+                <input type="hidden" name="to" th:value="${filter.to != null ? #temporals.format(filter.to, 'yyyy-MM-dd') : ''}">
+                <input type="hidden" name="classroomId" th:value="${filter.classroomId}">
+                <input type="hidden" name="teacherId" th:value="${filter.teacherId}">
+                <input type="hidden" name="filterStatus" th:value="${filter.status}">
+                <label>교사 출석 상태
+                    <select name="teacherAttendanceStatus">
+                        <option th:each="status : ${teacherAttendanceStatuses}"
+                                th:value="${status.name()}"
+                                th:text="${status.displayName}"
+                                th:selected="${schedule.teacherAttendance != null ? schedule.teacherAttendance.status == status : status.name() == 'ABSENT'}">
+                            출석
+                        </option>
+                    </select>
+                </label>
+                <button class="button" type="submit">교사 출석 저장</button>
+            </form>
         </section>
 
-        <section class="panel table-panel">
+        <form class="panel table-panel"
+              th:action="@{/admin/daily-schedule/daily-schedules/{dailyScheduleId}/student-attendances(dailyScheduleId=${schedule.dailyScheduleId})}"
+              method="post">
+            <input type="hidden" name="from" th:value="${filter.from != null ? #temporals.format(filter.from, 'yyyy-MM-dd') : ''}">
+            <input type="hidden" name="to" th:value="${filter.to != null ? #temporals.format(filter.to, 'yyyy-MM-dd') : ''}">
+            <input type="hidden" name="classroomId" th:value="${filter.classroomId}">
+            <input type="hidden" name="teacherId" th:value="${filter.teacherId}">
+            <input type="hidden" name="filterStatus" th:value="${filter.status}">
             <div style="padding: 22px 22px 0;">
-                <h2>학생 출석</h2>
+                <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap;">
+                    <h2>학생 출석</h2>
+                    <button class="button" type="submit" th:if="${!#lists.isEmpty(schedule.studentAttendances)}">
+                        학생 출석 저장
+                    </button>
+                </div>
             </div>
             <div class="table-scroll">
                 <table>
@@ -139,7 +172,15 @@
                         <td th:text="${attendance.studentId}">10</td>
                         <td th:text="${attendance.studentName}">최양지</td>
                         <td>
-                            <span class="pill" th:text="${attendance.status.displayName}">출석</span>
+                            <input type="hidden" name="studentIds" th:value="${attendance.studentId}">
+                            <select name="studentAttendanceStatuses">
+                                <option th:each="status : ${studentAttendanceStatuses}"
+                                        th:value="${status.name()}"
+                                        th:text="${status.displayName}"
+                                        th:selected="${attendance.status == status}">
+                                    출석
+                                </option>
+                            </select>
                         </td>
                     </tr>
                     <tr th:if="${#lists.isEmpty(schedule.studentAttendances)}">
@@ -148,7 +189,7 @@
                     </tbody>
                 </table>
             </div>
-        </section>
+        </form>
 
         <section class="panel table-panel">
             <div style="padding: 22px 22px 0;">

--- a/src/main/resources/templates/admin/daily-schedule/daily-schedules.html
+++ b/src/main/resources/templates/admin/daily-schedule/daily-schedules.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/layout :: head('하루 일정 관리')}"></head>
+<body>
+<div th:replace="~{admin/fragments/layout :: shell(~{::main})}">
+    <main class="stack">
+        <div class="page-title">
+            <div>
+                <h1>하루 일정</h1>
+                <p>주간 단위로 하루 일정과 출석 처리 현황을 확인합니다.</p>
+            </div>
+        </div>
+
+        <section class="panel">
+            <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap;">
+                <div>
+                    <h2 style="margin: 0;" th:text="|${dailySchedulesPage.from} ~ ${dailySchedulesPage.to}|">2026-05-18 ~ 2026-05-24</h2>
+                    <p>기본 조회 범위는 오늘이 포함된 주입니다.</p>
+                </div>
+                <div style="display: flex; gap: 8px; flex-wrap: wrap;">
+                    <a class="reset-link"
+                       th:href="@{/admin/daily-schedule/daily-schedules(from=${dailySchedulesPage.previousWeek.from},to=${dailySchedulesPage.previousWeek.to},classroomId=${filter.classroomId},teacherId=${filter.teacherId},status=${filter.status})}">이전 주</a>
+                    <a class="reset-link"
+                       th:href="@{/admin/daily-schedule/daily-schedules(from=${dailySchedulesPage.currentWeek.from},to=${dailySchedulesPage.currentWeek.to},classroomId=${filter.classroomId},teacherId=${filter.teacherId},status=${filter.status})}">이번 주</a>
+                    <a class="reset-link"
+                       th:href="@{/admin/daily-schedule/daily-schedules(from=${dailySchedulesPage.nextWeek.from},to=${dailySchedulesPage.nextWeek.to},classroomId=${filter.classroomId},teacherId=${filter.teacherId},status=${filter.status})}">다음 주</a>
+                </div>
+            </div>
+        </section>
+
+        <form class="panel filter-grid" th:action="@{/admin/daily-schedule/daily-schedules}" method="get">
+            <label>시작일
+                <input name="from" type="date" th:value="${dailySchedulesPage.from}">
+            </label>
+            <label>종료일
+                <input name="to" type="date" th:value="${dailySchedulesPage.to}">
+            </label>
+            <label>분반
+                <select name="classroomId">
+                    <option value="">전체</option>
+                    <option th:each="classroom : ${classrooms}"
+                            th:value="${classroom.id}"
+                            th:text="${classroom.name}"
+                            th:selected="${filter.classroomId == classroom.id}">벚꽃반</option>
+                </select>
+            </label>
+            <label>교사
+                <select name="teacherId">
+                    <option value="">전체</option>
+                    <option th:each="teacher : ${teachers}"
+                            th:value="${teacher.id}"
+                            th:text="${teacher.name}"
+                            th:selected="${filter.teacherId == teacher.id}">홍길동</option>
+                </select>
+            </label>
+            <label>상태
+                <select name="status">
+                    <option value="">전체</option>
+                    <option th:each="status : ${statuses}"
+                            th:value="${status.name()}"
+                            th:text="${status.displayName}"
+                            th:selected="${filter.status == status}">예정</option>
+                </select>
+            </label>
+            <button class="button" type="submit">조회</button>
+            <a class="reset-link" th:href="@{/admin/daily-schedule/daily-schedules}">초기화</a>
+        </form>
+
+        <section class="panel table-panel">
+            <div class="table-scroll">
+                <table>
+                    <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>수업일</th>
+                        <th>분반</th>
+                        <th>담당 교사</th>
+                        <th>운영 시간</th>
+                        <th>하루 일정 상태</th>
+                        <th>교사 출석</th>
+                        <th>학생 출석</th>
+                        <th>수업 수</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="schedule : ${dailySchedulesPage.rows}">
+                        <td th:text="${schedule.dailyScheduleId}">1</td>
+                        <td th:text="${schedule.lessonDate}">2026-05-20</td>
+                        <td th:text="${schedule.classroomName}">벚꽃반</td>
+                        <td th:text="${schedule.teacherName}">홍길동</td>
+                        <td th:text="${schedule.activityStartTime != null && schedule.activityEndTime != null ? schedule.activityStartTime + ' - ' + schedule.activityEndTime : '-'}">19:20 - 21:40</td>
+                        <td>
+                            <span class="pill" th:text="${schedule.statusLabel}">예정</span>
+                        </td>
+                        <td>
+                            <span class="pill" th:text="${schedule.teacherAttendanceStatusLabel}">미처리</span>
+                        </td>
+                        <td th:text="|출석 ${schedule.studentAttendanceSummary.presentCount} / 지각 ${schedule.studentAttendanceSummary.lateCount} / 결석 ${schedule.studentAttendanceSummary.absentCount} / 전체 ${schedule.studentAttendanceSummary.totalCount}|">
+                            출석 0 / 지각 0 / 결석 0 / 전체 0
+                        </td>
+                        <td th:text="${schedule.lessonCount}">3</td>
+                    </tr>
+                    <tr th:if="${#lists.isEmpty(dailySchedulesPage.rows)}">
+                        <td colspan="9" class="empty">조회된 하루 일정이 없습니다.</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/daily-schedule/daily-schedules.html
+++ b/src/main/resources/templates/admin/daily-schedule/daily-schedules.html
@@ -80,6 +80,7 @@
                         <th>교사 출석</th>
                         <th>학생 출석</th>
                         <th>수업 수</th>
+                        <th>관리</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -99,9 +100,15 @@
                             출석 0 / 지각 0 / 결석 0 / 전체 0
                         </td>
                         <td th:text="${schedule.lessonCount}">3</td>
+                        <td>
+                            <a class="reset-link"
+                               th:href="@{/admin/daily-schedule/daily-schedules/{dailyScheduleId}(dailyScheduleId=${schedule.dailyScheduleId},from=${dailySchedulesPage.from},to=${dailySchedulesPage.to},classroomId=${filter.classroomId},teacherId=${filter.teacherId},status=${filter.status})}">
+                                상세보기
+                            </a>
+                        </td>
                     </tr>
                     <tr th:if="${#lists.isEmpty(dailySchedulesPage.rows)}">
-                        <td colspan="9" class="empty">조회된 하루 일정이 없습니다.</td>
+                        <td colspan="10" class="empty">조회된 하루 일정이 없습니다.</td>
                     </tr>
                     </tbody>
                 </table>

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -92,6 +92,10 @@
                         <span>수업 관리</span>
                         <p style="font-size: 13px; margin: 4px 0 0;">수업 일정과 운영 상태 조회</p>
                     </a>
+                    <a class="metric" th:href="@{/admin/daily-schedule/daily-schedules}">
+                        <span>하루 일정 관리</span>
+                        <p style="font-size: 13px; margin: 4px 0 0;">출석 현황과 수업 일지 관리</p>
+                    </a>
                 </div>
             </section>
         </div>

--- a/src/main/resources/templates/admin/fragments/layout.html
+++ b/src/main/resources/templates/admin/fragments/layout.html
@@ -433,6 +433,7 @@
             <a th:href="@{/admin/department/departments}" th:classappend="${active == 'departments'} ? 'active'">부서</a>
             <a th:href="@{/admin/classroom/classrooms}" th:classappend="${active == 'classrooms'} ? 'active'">분반</a>
             <a th:href="@{/admin/lesson/lessons}" th:classappend="${active == 'lessons'} ? 'active'">수업</a>
+            <a th:href="@{/admin/daily-schedule/daily-schedules}" th:classappend="${active == 'dailySchedules'} ? 'active'">하루 일정</a>
             <a th:href="@{/admin/request/absence/absence-requests}" th:classappend="${active == 'absenceRequests'} ? 'active'">결석 요청</a>
             <a th:href="@{/admin/request/lesson-exchange}" th:classappend="${active == 'lessonExchangeRequests'} ? 'active'">수업 교환</a>
             <a th:href="@{/admin/request/purchase/purchase-requests}" th:classappend="${active == 'purchaseRequests'} ? 'active'">구매 요청</a>


### PR DESCRIPTION
## 개요

하루 일정 관리자 페이지를 추가하여 관리자가 주간 단위로 하루 일정, 교사 출석, 학생 출석, 수업 일지를 조회하고 수정할 수 있도록 했습니다.

## 변경 유형

- [x] 새 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 테스트 (test)
- [x] 기타 (chore)

## 변경 내용

- 하루 일정 관리자 주간 목록 및 상세 화면 추가
- 날짜 범위, 분반, 교사, 일정 상태 필터 추가
- 하루 일정 상태 변경 기능 추가
- 교사 출석 상태 및 학생 출석 상태 수정 기능 추가
- 교시별 수업 일지 수정 기능 추가
- 개인정보 동의/주민번호 앞자리 입력값 페이지 내 검증 추가
- 관리자 사이드바 및 대시보드 진입점 추가
- 관리자 화면 확인용 과거 하루 일정 초기 데이터 추가

## 관련 이슈

Closes #72

## 스크린샷 (선택)

관리자 하루 일정 목록 화면
<img width="1920" height="926" alt="image" src="https://github.com/user-attachments/assets/c5bbeadf-3bed-4571-bbef-12698360f51e" />
<img width="1920" height="923" alt="image" src="https://github.com/user-attachments/assets/84ea66ba-36dc-49bc-a96b-190d4b26df2c" />

관리자 하루 일정 상세 화면 - 완료된 하루 일정
<img width="1920" height="915" alt="image" src="https://github.com/user-attachments/assets/8418d1fc-46d0-4bc2-b9e8-651b8a4cec75" />
<img width="1920" height="921" alt="image" src="https://github.com/user-attachments/assets/742e5240-1299-4b32-8300-22f287c7471f" />
<img width="1920" height="520" alt="image" src="https://github.com/user-attachments/assets/a995723a-f2fe-409b-bd09-d8a0dc87b073" />

관리자 하루 일정 상세 화면 - 예정된 하루 일정
<img width="1920" height="919" alt="image" src="https://github.com/user-attachments/assets/247f3d98-9e3b-46a9-a7dc-7366da5be214" />
<img width="1920" height="916" alt="image" src="https://github.com/user-attachments/assets/050b2c2b-0a1a-410b-a20f-8f7f2e27894d" />

## 체크리스트

- [x] 코드 컨벤션을 준수했습니다
- [ ] 테스트 코드를 작성/수정했습니다
- [x] 모든 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)

## 리뷰어에게

기존 `daily_schedule` 도메인 서비스 로직을 관리자 화면에서 재사용하는 구조입니다.