### PR TITLE
[FEAT] 과목 관리자 페이지 추가

### DIFF
--- a/src/main/java/geumjeongyahak/domain/base/model/PermissionRegistry.java
+++ b/src/main/java/geumjeongyahak/domain/base/model/PermissionRegistry.java
@@ -29,7 +29,7 @@ public class PermissionRegistry {
         allow(ResourceType.STUDENT, PermissionScope.GLOBAL_ONLY,
             ActionType.WRITE, ActionType.MANAGE);
         allow(ResourceType.SUBJECT, PermissionScope.GLOBAL_ONLY,
-            ActionType.WRITE, ActionType.MANAGE);
+            ActionType.READ, ActionType.WRITE, ActionType.MANAGE);
         allow(ResourceType.LESSON, PermissionScope.GLOBAL_ONLY,
             ActionType.READ, ActionType.WRITE, ActionType.MANAGE);
         allow(ResourceType.DAILY_SCHEDULE, PermissionScope.GLOBAL_ONLY,

--- a/src/main/java/geumjeongyahak/domain/base/service/AdminDashboardService.java
+++ b/src/main/java/geumjeongyahak/domain/base/service/AdminDashboardService.java
@@ -9,6 +9,7 @@ import geumjeongyahak.domain.purchase_request.repository.PurchaseRequestReposito
 import geumjeongyahak.domain.request.enums.RequestStatus;
 import geumjeongyahak.domain.request.repository.AbsenceRequestRepository;
 import geumjeongyahak.domain.student.repository.StudentRepository;
+import geumjeongyahak.domain.subject.repository.SubjectRepository;
 import geumjeongyahak.domain.users.repository.UserRepository;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -29,6 +30,7 @@ public class AdminDashboardService {
     private final AbsenceRequestRepository absenceRequestRepository;
     private final StudentRepository studentRepository;
     private final LessonRepository lessonRepository;
+    private final SubjectRepository subjectRepository;
 
     public AdminDashboardSummary getSummary() {
         LocalDate today = LocalDate.now();
@@ -42,6 +44,7 @@ public class AdminDashboardService {
             purchaseRequestRepository.countByStatus(PurchaseRequestStatus.PENDING),
             absenceRequestRepository.countByStatus(RequestStatus.PENDING),
             studentRepository.count(),
+            subjectRepository.countByIsActiveTrue(),
             lessonRepository.countByIsDeletedFalse(),
             lessonRepository.countByIsDeletedFalseAndDate(today),
             lessonRepository.countByStatusAndIsDeletedFalseAndDateBetween(LessonStatus.SCHEDULED, weekStart, weekEnd),
@@ -58,6 +61,7 @@ public class AdminDashboardService {
         long pendingPurchaseRequestCount,
         long pendingAbsenceRequestCount,
         long studentCount,
+        long subjectCount,
         long lessonCount,
         long todayLessonCount,
         long weeklyScheduledLessonCount,

--- a/src/main/java/geumjeongyahak/domain/subject/repository/SubjectRepository.java
+++ b/src/main/java/geumjeongyahak/domain/subject/repository/SubjectRepository.java
@@ -36,6 +36,8 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
     @EntityGraph(attributePaths = {"classroom", "teacher"})
     List<Subject> findByClassroomId(Long classroomId);
 
+    long countByIsActiveTrue();
+
     boolean existsByClassroomIdAndTeacherId(Long classroomId, Long teacherId);
 
     @Override

--- a/src/main/java/geumjeongyahak/domain/subject/service/SubjectAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/subject/service/SubjectAdminViewService.java
@@ -2,6 +2,7 @@ package geumjeongyahak.domain.subject.service;
 
 import geumjeongyahak.domain.classroom.entity.Classroom;
 import geumjeongyahak.domain.classroom.service.ClassroomProxyService;
+import geumjeongyahak.domain.subject.v1.dto.request.AssignSubjectTeacherRequest;
 import geumjeongyahak.domain.subject.v1.dto.request.CreateSubjectRequest;
 import geumjeongyahak.domain.subject.v1.dto.request.UpdateSubjectBasicRequest;
 import geumjeongyahak.domain.subject.v1.dto.response.SubjectDetailResponse;
@@ -100,6 +101,11 @@ public class SubjectAdminViewService {
             subjectId,
             new UpdateSubjectBasicRequest(name, normalizeDescription(description))
         );
+    }
+
+    @Transactional
+    public void assignTeacher(Long subjectId, Long teacherId) {
+        subjectService.assignTeacher(subjectId, new AssignSubjectTeacherRequest(teacherId));
     }
 
     private Comparator<SubjectDetailResponse> subjectComparator() {

--- a/src/main/java/geumjeongyahak/domain/subject/service/SubjectAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/subject/service/SubjectAdminViewService.java
@@ -125,6 +125,11 @@ public class SubjectAdminViewService {
         );
     }
 
+    @Transactional
+    public void deactivateSubject(Long subjectId) {
+        subjectService.deleteSubject(subjectId);
+    }
+
     private Comparator<SubjectDetailResponse> subjectComparator() {
         return Comparator
             .comparing(SubjectDetailResponse::classroomName, Comparator.nullsLast(String::compareTo))

--- a/src/main/java/geumjeongyahak/domain/subject/service/SubjectAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/subject/service/SubjectAdminViewService.java
@@ -2,11 +2,15 @@ package geumjeongyahak.domain.subject.service;
 
 import geumjeongyahak.domain.classroom.entity.Classroom;
 import geumjeongyahak.domain.classroom.service.ClassroomProxyService;
+import geumjeongyahak.domain.subject.v1.dto.request.CreateSubjectRequest;
 import geumjeongyahak.domain.subject.v1.dto.response.SubjectDetailResponse;
+import geumjeongyahak.domain.users.entity.User;
+import geumjeongyahak.domain.users.service.UserProxyService;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +28,7 @@ public class SubjectAdminViewService {
 
     private final SubjectService subjectService;
     private final ClassroomProxyService classroomProxyService;
+    private final UserProxyService userProxyService;
 
     public SubjectAdminPage getSubjects(SubjectFilter filter) {
         List<SubjectRow> rows = subjectService.getAllSubjects(filter.classroomId())
@@ -45,6 +50,47 @@ public class SubjectAdminViewService {
             .stream()
             .map(ClassroomOption::from)
             .toList();
+    }
+
+    public List<TeacherOption> getTeacherOptions() {
+        return userProxyService.getTeacherCandidatesOrderByName()
+            .stream()
+            .map(TeacherOption::from)
+            .toList();
+    }
+
+    public List<DayOfWeekOption> getDayOfWeekOptions() {
+        return Arrays.stream(DayOfWeek.values())
+            .map(dayOfWeek -> new DayOfWeekOption(dayOfWeek, getDayOfWeekLabel(dayOfWeek)))
+            .toList();
+    }
+
+    @Transactional
+    public Long createSubject(
+        Long classroomId,
+        Long teacherId,
+        String name,
+        LocalDate startAt,
+        LocalDate endAt,
+        DayOfWeek dayOfWeek,
+        LocalTime startTime,
+        LocalTime endTime,
+        Integer period,
+        String description
+    ) {
+        SubjectDetailResponse response = subjectService.createSubject(new CreateSubjectRequest(
+            classroomId,
+            teacherId,
+            name,
+            startAt,
+            endAt,
+            dayOfWeek,
+            startTime,
+            endTime,
+            period,
+            normalizeDescription(description)
+        ));
+        return response.id();
     }
 
     private Comparator<SubjectDetailResponse> subjectComparator() {
@@ -80,6 +126,13 @@ public class SubjectAdminViewService {
             case SATURDAY -> "토요일";
             case SUNDAY -> "일요일";
         };
+    }
+
+    private static String normalizeDescription(String description) {
+        if (description == null || description.isBlank()) {
+            return null;
+        }
+        return description.trim();
     }
 
     public record SubjectFilter(
@@ -190,5 +243,20 @@ public class SubjectAdminViewService {
         private static ClassroomOption from(Classroom classroom) {
             return new ClassroomOption(classroom.getId(), classroom.getName());
         }
+    }
+
+    public record TeacherOption(
+        Long id,
+        String name
+    ) {
+        private static TeacherOption from(User user) {
+            return new TeacherOption(user.getId(), user.getName());
+        }
+    }
+
+    public record DayOfWeekOption(
+        DayOfWeek value,
+        String label
+    ) {
     }
 }

--- a/src/main/java/geumjeongyahak/domain/subject/service/SubjectAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/subject/service/SubjectAdminViewService.java
@@ -3,6 +3,7 @@ package geumjeongyahak.domain.subject.service;
 import geumjeongyahak.domain.classroom.entity.Classroom;
 import geumjeongyahak.domain.classroom.service.ClassroomProxyService;
 import geumjeongyahak.domain.subject.v1.dto.request.CreateSubjectRequest;
+import geumjeongyahak.domain.subject.v1.dto.request.UpdateSubjectBasicRequest;
 import geumjeongyahak.domain.subject.v1.dto.response.SubjectDetailResponse;
 import geumjeongyahak.domain.users.entity.User;
 import geumjeongyahak.domain.users.service.UserProxyService;
@@ -91,6 +92,14 @@ public class SubjectAdminViewService {
             normalizeDescription(description)
         ));
         return response.id();
+    }
+
+    @Transactional
+    public void updateSubject(Long subjectId, String name, String description) {
+        subjectService.updateSubject(
+            subjectId,
+            new UpdateSubjectBasicRequest(name, normalizeDescription(description))
+        );
     }
 
     private Comparator<SubjectDetailResponse> subjectComparator() {

--- a/src/main/java/geumjeongyahak/domain/subject/service/SubjectAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/subject/service/SubjectAdminViewService.java
@@ -5,6 +5,7 @@ import geumjeongyahak.domain.classroom.service.ClassroomProxyService;
 import geumjeongyahak.domain.subject.v1.dto.request.AssignSubjectTeacherRequest;
 import geumjeongyahak.domain.subject.v1.dto.request.CreateSubjectRequest;
 import geumjeongyahak.domain.subject.v1.dto.request.UpdateSubjectBasicRequest;
+import geumjeongyahak.domain.subject.v1.dto.request.UpdateSubjectScheduleRequest;
 import geumjeongyahak.domain.subject.v1.dto.response.SubjectDetailResponse;
 import geumjeongyahak.domain.users.entity.User;
 import geumjeongyahak.domain.users.service.UserProxyService;
@@ -106,6 +107,22 @@ public class SubjectAdminViewService {
     @Transactional
     public void assignTeacher(Long subjectId, Long teacherId) {
         subjectService.assignTeacher(subjectId, new AssignSubjectTeacherRequest(teacherId));
+    }
+
+    @Transactional
+    public void updateSchedule(
+        Long subjectId,
+        LocalDate startAt,
+        LocalDate endAt,
+        DayOfWeek dayOfWeek,
+        LocalTime startTime,
+        LocalTime endTime,
+        Integer period
+    ) {
+        subjectService.updateSchedule(
+            subjectId,
+            new UpdateSubjectScheduleRequest(startAt, endAt, dayOfWeek, startTime, endTime, period)
+        );
     }
 
     private Comparator<SubjectDetailResponse> subjectComparator() {

--- a/src/main/java/geumjeongyahak/domain/subject/service/SubjectAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/subject/service/SubjectAdminViewService.java
@@ -1,0 +1,194 @@
+package geumjeongyahak.domain.subject.service;
+
+import geumjeongyahak.domain.classroom.entity.Classroom;
+import geumjeongyahak.domain.classroom.service.ClassroomProxyService;
+import geumjeongyahak.domain.subject.v1.dto.response.SubjectDetailResponse;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SubjectAdminViewService {
+
+    private static final String UNASSIGNED_TEACHER_LABEL = "미배정";
+    private static final String ACTIVE_LABEL = "활성";
+    private static final String INACTIVE_LABEL = "비활성";
+
+    private final SubjectService subjectService;
+    private final ClassroomProxyService classroomProxyService;
+
+    public SubjectAdminPage getSubjects(SubjectFilter filter) {
+        List<SubjectRow> rows = subjectService.getAllSubjects(filter.classroomId())
+            .stream()
+            .filter(subject -> filter.active() == null || filter.active().equals(subject.isActive()))
+            .sorted(subjectComparator())
+            .map(SubjectRow::from)
+            .toList();
+
+        return new SubjectAdminPage(rows);
+    }
+
+    public SubjectDetail getSubject(Long subjectId) {
+        return SubjectDetail.from(subjectService.getSubject(subjectId));
+    }
+
+    public List<ClassroomOption> getClassroomOptions() {
+        return classroomProxyService.getActiveClassroomsOrderByName()
+            .stream()
+            .map(ClassroomOption::from)
+            .toList();
+    }
+
+    private Comparator<SubjectDetailResponse> subjectComparator() {
+        return Comparator
+            .comparing(SubjectDetailResponse::classroomName, Comparator.nullsLast(String::compareTo))
+            .thenComparing(SubjectDetailResponse::dayOfWeek, Comparator.nullsLast(Comparator.naturalOrder()))
+            .thenComparing(SubjectDetailResponse::period, Comparator.nullsLast(Integer::compareTo))
+            .thenComparing(SubjectDetailResponse::startAt, Comparator.nullsLast(LocalDate::compareTo))
+            .thenComparing(SubjectDetailResponse::id, Comparator.nullsLast(Long::compareTo));
+    }
+
+    private static String getTeacherLabel(Long teacherId, String teacherName) {
+        if (teacherId == null) {
+            return UNASSIGNED_TEACHER_LABEL;
+        }
+        return teacherName;
+    }
+
+    private static String getActiveLabel(Boolean isActive) {
+        return Boolean.TRUE.equals(isActive) ? ACTIVE_LABEL : INACTIVE_LABEL;
+    }
+
+    private static String getDayOfWeekLabel(DayOfWeek dayOfWeek) {
+        if (dayOfWeek == null) {
+            return "-";
+        }
+        return switch (dayOfWeek) {
+            case MONDAY -> "월요일";
+            case TUESDAY -> "화요일";
+            case WEDNESDAY -> "수요일";
+            case THURSDAY -> "목요일";
+            case FRIDAY -> "금요일";
+            case SATURDAY -> "토요일";
+            case SUNDAY -> "일요일";
+        };
+    }
+
+    public record SubjectFilter(
+        Long classroomId,
+        Boolean active
+    ) {
+    }
+
+    public record SubjectAdminPage(
+        List<SubjectRow> rows
+    ) {
+    }
+
+    public record SubjectRow(
+        Long id,
+        Long classroomId,
+        String classroomName,
+        Long teacherId,
+        String teacherName,
+        String teacherLabel,
+        String name,
+        LocalDate startAt,
+        LocalDate endAt,
+        Integer times,
+        DayOfWeek dayOfWeek,
+        String dayOfWeekLabel,
+        LocalTime startTime,
+        LocalTime endTime,
+        Integer period,
+        LocalDateTime teacherAssignedAt,
+        Boolean isActive,
+        String activeLabel
+    ) {
+        private static SubjectRow from(SubjectDetailResponse response) {
+            return new SubjectRow(
+                response.id(),
+                response.classroomId(),
+                response.classroomName(),
+                response.teacherId(),
+                response.teacherName(),
+                getTeacherLabel(response.teacherId(), response.teacherName()),
+                response.name(),
+                response.startAt(),
+                response.endAt(),
+                response.times(),
+                response.dayOfWeek(),
+                getDayOfWeekLabel(response.dayOfWeek()),
+                response.startTime(),
+                response.endTime(),
+                response.period(),
+                response.teacherAssignedAt(),
+                response.isActive(),
+                getActiveLabel(response.isActive())
+            );
+        }
+    }
+
+    public record SubjectDetail(
+        Long id,
+        Long classroomId,
+        String classroomName,
+        Long teacherId,
+        String teacherName,
+        String teacherLabel,
+        String name,
+        LocalDate startAt,
+        LocalDate endAt,
+        Integer times,
+        DayOfWeek dayOfWeek,
+        String dayOfWeekLabel,
+        LocalTime startTime,
+        LocalTime endTime,
+        Integer period,
+        LocalDateTime teacherAssignedAt,
+        String description,
+        Boolean isActive,
+        String activeLabel
+    ) {
+        private static SubjectDetail from(SubjectDetailResponse response) {
+            return new SubjectDetail(
+                response.id(),
+                response.classroomId(),
+                response.classroomName(),
+                response.teacherId(),
+                response.teacherName(),
+                getTeacherLabel(response.teacherId(), response.teacherName()),
+                response.name(),
+                response.startAt(),
+                response.endAt(),
+                response.times(),
+                response.dayOfWeek(),
+                getDayOfWeekLabel(response.dayOfWeek()),
+                response.startTime(),
+                response.endTime(),
+                response.period(),
+                response.teacherAssignedAt(),
+                response.description(),
+                response.isActive(),
+                getActiveLabel(response.isActive())
+            );
+        }
+    }
+
+    public record ClassroomOption(
+        Long id,
+        String name
+    ) {
+        private static ClassroomOption from(Classroom classroom) {
+            return new ClassroomOption(classroom.getId(), classroom.getName());
+        }
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/subject/v1/controller/SubjectViewController.java
+++ b/src/main/java/geumjeongyahak/domain/subject/v1/controller/SubjectViewController.java
@@ -1,5 +1,6 @@
 package geumjeongyahak.domain.subject.v1.controller;
 
+import geumjeongyahak.common.exception.BusinessException;
 import geumjeongyahak.domain.subject.service.SubjectAdminViewService;
 import geumjeongyahak.domain.subject.service.SubjectAdminViewService.SubjectFilter;
 import java.time.DayOfWeek;
@@ -62,6 +63,7 @@ public class SubjectViewController {
         model.addAttribute("adminName", authentication.getName());
         model.addAttribute("filter", filter);
         model.addAttribute("subject", subjectAdminViewService.getSubject(subjectId));
+        model.addAttribute("teachers", subjectAdminViewService.getTeacherOptions());
         return "admin/subject/subjects-detail";
     }
 
@@ -132,6 +134,26 @@ public class SubjectViewController {
     ) {
         subjectAdminViewService.updateSubject(subjectId, name, description);
         redirectAttributes.addFlashAttribute("message", "과목 기본 정보를 수정했습니다.");
+        addRedirectAttributeIfPresent(redirectAttributes, "classroomId", classroomId);
+        addRedirectAttributeIfPresent(redirectAttributes, "active", active);
+        return "redirect:/admin/subject/subjects/" + subjectId;
+    }
+
+    @PreAuthorize(SUBJECT_MANAGE_ACCESS)
+    @PostMapping("/{subjectId}/teacher")
+    public String assignTeacher(
+        @PathVariable Long subjectId,
+        @RequestParam(required = false) Long teacherId,
+        @RequestParam(required = false) Long classroomId,
+        @RequestParam(required = false) Boolean active,
+        RedirectAttributes redirectAttributes
+    ) {
+        try {
+            subjectAdminViewService.assignTeacher(subjectId, teacherId);
+            redirectAttributes.addFlashAttribute("message", "담당 교사를 변경했습니다.");
+        } catch (BusinessException exception) {
+            redirectAttributes.addFlashAttribute("errorMessage", exception.getMessage());
+        }
         addRedirectAttributeIfPresent(redirectAttributes, "classroomId", classroomId);
         addRedirectAttributeIfPresent(redirectAttributes, "active", active);
         return "redirect:/admin/subject/subjects/" + subjectId;

--- a/src/main/java/geumjeongyahak/domain/subject/v1/controller/SubjectViewController.java
+++ b/src/main/java/geumjeongyahak/domain/subject/v1/controller/SubjectViewController.java
@@ -26,6 +26,8 @@ public class SubjectViewController {
         "hasRole('ADMIN') or hasAuthority('subject:read:*')";
     private static final String SUBJECT_WRITE_ACCESS =
         "hasRole('ADMIN') or hasAuthority('subject:write:*')";
+    private static final String SUBJECT_MANAGE_ACCESS =
+        "hasRole('ADMIN') or hasAuthority('subject:manage:*')";
 
     private final SubjectAdminViewService subjectAdminViewService;
 
@@ -101,11 +103,51 @@ public class SubjectViewController {
         return "redirect:/admin/subject/subjects/" + subjectId;
     }
 
+    @PreAuthorize(SUBJECT_MANAGE_ACCESS)
+    @GetMapping("/{subjectId}/edit")
+    public String editSubject(
+            @PathVariable Long subjectId,
+            @RequestParam(required = false) Long classroomId,
+            @RequestParam(required = false) Boolean active,
+            Model model,
+            Authentication authentication
+    ) {
+        SubjectFilter filter = new SubjectFilter(classroomId, active);
+        model.addAttribute("active", "subjects");
+        model.addAttribute("adminName", authentication.getName());
+        model.addAttribute("filter", filter);
+        model.addAttribute("subject", subjectAdminViewService.getSubject(subjectId));
+        return "admin/subject/subjects-edit";
+    }
+
+    @PreAuthorize(SUBJECT_MANAGE_ACCESS)
+    @PostMapping("/{subjectId}")
+    public String updateSubject(
+        @PathVariable Long subjectId,
+        @RequestParam String name,
+        @RequestParam(required = false) String description,
+        @RequestParam(required = false) Long classroomId,
+        @RequestParam(required = false) Boolean active,
+        RedirectAttributes redirectAttributes
+    ) {
+        subjectAdminViewService.updateSubject(subjectId, name, description);
+        redirectAttributes.addFlashAttribute("message", "과목 기본 정보를 수정했습니다.");
+        addRedirectAttributeIfPresent(redirectAttributes, "classroomId", classroomId);
+        addRedirectAttributeIfPresent(redirectAttributes, "active", active);
+        return "redirect:/admin/subject/subjects/" + subjectId;
+    }
+
     private void addSubjectFormAttributes(Model model, Authentication authentication) {
         model.addAttribute("active", "subjects");
         model.addAttribute("adminName", authentication.getName());
         model.addAttribute("classrooms", subjectAdminViewService.getClassroomOptions());
         model.addAttribute("teachers", subjectAdminViewService.getTeacherOptions());
         model.addAttribute("dayOfWeeks", subjectAdminViewService.getDayOfWeekOptions());
+    }
+
+    private void addRedirectAttributeIfPresent(RedirectAttributes redirectAttributes, String name, Object value) {
+        if (value != null) {
+            redirectAttributes.addAttribute(name, value.toString());
+        }
     }
 }

--- a/src/main/java/geumjeongyahak/domain/subject/v1/controller/SubjectViewController.java
+++ b/src/main/java/geumjeongyahak/domain/subject/v1/controller/SubjectViewController.java
@@ -2,6 +2,9 @@ package geumjeongyahak.domain.subject.v1.controller;
 
 import geumjeongyahak.domain.subject.service.SubjectAdminViewService;
 import geumjeongyahak.domain.subject.service.SubjectAdminViewService.SubjectFilter;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -9,8 +12,10 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
 @RequestMapping("/admin/subject/subjects")
@@ -19,6 +24,8 @@ public class SubjectViewController {
 
     private static final String SUBJECT_READ_ACCESS =
         "hasRole('ADMIN') or hasAuthority('subject:read:*')";
+    private static final String SUBJECT_WRITE_ACCESS =
+        "hasRole('ADMIN') or hasAuthority('subject:write:*')";
 
     private final SubjectAdminViewService subjectAdminViewService;
 
@@ -54,5 +61,51 @@ public class SubjectViewController {
         model.addAttribute("filter", filter);
         model.addAttribute("subject", subjectAdminViewService.getSubject(subjectId));
         return "admin/subject/subjects-detail";
+    }
+
+    @PreAuthorize(SUBJECT_WRITE_ACCESS)
+    @GetMapping("/new")
+    public String newSubject(Model model, Authentication authentication) {
+        addSubjectFormAttributes(model, authentication);
+        return "admin/subject/subjects-form";
+    }
+
+    @PreAuthorize(SUBJECT_WRITE_ACCESS)
+    @PostMapping
+    public String createSubject(
+            @RequestParam Long classroomId,
+            @RequestParam(required = false) Long teacherId,
+            @RequestParam String name,
+            @RequestParam LocalDate startAt,
+            @RequestParam LocalDate endAt,
+            @RequestParam DayOfWeek dayOfWeek,
+            @RequestParam LocalTime startTime,
+            @RequestParam LocalTime endTime,
+            @RequestParam Integer period,
+            @RequestParam(required = false) String description,
+            RedirectAttributes redirectAttributes
+    ) {
+        Long subjectId = subjectAdminViewService.createSubject(
+                classroomId,
+                teacherId,
+                name,
+                startAt,
+                endAt,
+                dayOfWeek,
+                startTime,
+                endTime,
+                period,
+                description
+        );
+        redirectAttributes.addFlashAttribute("message", "과목을 등록했습니다.");
+        return "redirect:/admin/subject/subjects/" + subjectId;
+    }
+
+    private void addSubjectFormAttributes(Model model, Authentication authentication) {
+        model.addAttribute("active", "subjects");
+        model.addAttribute("adminName", authentication.getName());
+        model.addAttribute("classrooms", subjectAdminViewService.getClassroomOptions());
+        model.addAttribute("teachers", subjectAdminViewService.getTeacherOptions());
+        model.addAttribute("dayOfWeeks", subjectAdminViewService.getDayOfWeekOptions());
     }
 }

--- a/src/main/java/geumjeongyahak/domain/subject/v1/controller/SubjectViewController.java
+++ b/src/main/java/geumjeongyahak/domain/subject/v1/controller/SubjectViewController.java
@@ -193,6 +193,21 @@ public class SubjectViewController {
         return "redirect:/admin/subject/subjects/" + subjectId;
     }
 
+    @PreAuthorize(SUBJECT_MANAGE_ACCESS)
+    @PostMapping("/{subjectId}/deactivate")
+    public String deactivateSubject(
+        @PathVariable Long subjectId,
+        @RequestParam(required = false) Long classroomId,
+        @RequestParam(required = false) Boolean active,
+        RedirectAttributes redirectAttributes
+    ) {
+        subjectAdminViewService.deactivateSubject(subjectId);
+        redirectAttributes.addFlashAttribute("message", "과목을 비활성화했습니다.");
+        addRedirectAttributeIfPresent(redirectAttributes, "classroomId", classroomId);
+        addRedirectAttributeIfPresent(redirectAttributes, "active", active);
+        return "redirect:/admin/subject/subjects/" + subjectId;
+    }
+
     private void addSubjectFormAttributes(Model model, Authentication authentication) {
         model.addAttribute("active", "subjects");
         model.addAttribute("adminName", authentication.getName());

--- a/src/main/java/geumjeongyahak/domain/subject/v1/controller/SubjectViewController.java
+++ b/src/main/java/geumjeongyahak/domain/subject/v1/controller/SubjectViewController.java
@@ -64,6 +64,7 @@ public class SubjectViewController {
         model.addAttribute("filter", filter);
         model.addAttribute("subject", subjectAdminViewService.getSubject(subjectId));
         model.addAttribute("teachers", subjectAdminViewService.getTeacherOptions());
+        model.addAttribute("dayOfWeeks", subjectAdminViewService.getDayOfWeekOptions());
         return "admin/subject/subjects-detail";
     }
 
@@ -151,6 +152,39 @@ public class SubjectViewController {
         try {
             subjectAdminViewService.assignTeacher(subjectId, teacherId);
             redirectAttributes.addFlashAttribute("message", "담당 교사를 변경했습니다.");
+        } catch (BusinessException exception) {
+            redirectAttributes.addFlashAttribute("errorMessage", exception.getMessage());
+        }
+        addRedirectAttributeIfPresent(redirectAttributes, "classroomId", classroomId);
+        addRedirectAttributeIfPresent(redirectAttributes, "active", active);
+        return "redirect:/admin/subject/subjects/" + subjectId;
+    }
+
+    @PreAuthorize(SUBJECT_MANAGE_ACCESS)
+    @PostMapping("/{subjectId}/schedule")
+    public String updateSchedule(
+        @PathVariable Long subjectId,
+        @RequestParam LocalDate startAt,
+        @RequestParam LocalDate endAt,
+        @RequestParam DayOfWeek dayOfWeek,
+        @RequestParam LocalTime startTime,
+        @RequestParam LocalTime endTime,
+        @RequestParam Integer period,
+        @RequestParam(required = false) Long classroomId,
+        @RequestParam(required = false) Boolean active,
+        RedirectAttributes redirectAttributes
+    ) {
+        try {
+            subjectAdminViewService.updateSchedule(
+                subjectId,
+                startAt,
+                endAt,
+                dayOfWeek,
+                startTime,
+                endTime,
+                period
+            );
+            redirectAttributes.addFlashAttribute("message", "과목 일정을 수정했습니다.");
         } catch (BusinessException exception) {
             redirectAttributes.addFlashAttribute("errorMessage", exception.getMessage());
         }

--- a/src/main/java/geumjeongyahak/domain/subject/v1/controller/SubjectViewController.java
+++ b/src/main/java/geumjeongyahak/domain/subject/v1/controller/SubjectViewController.java
@@ -1,0 +1,58 @@
+package geumjeongyahak.domain.subject.v1.controller;
+
+import geumjeongyahak.domain.subject.service.SubjectAdminViewService;
+import geumjeongyahak.domain.subject.service.SubjectAdminViewService.SubjectFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequestMapping("/admin/subject/subjects")
+@RequiredArgsConstructor
+public class SubjectViewController {
+
+    private static final String SUBJECT_READ_ACCESS =
+        "hasRole('ADMIN') or hasAuthority('subject:read:*')";
+
+    private final SubjectAdminViewService subjectAdminViewService;
+
+    @PreAuthorize(SUBJECT_READ_ACCESS)
+    @GetMapping
+    public String subjects(
+        @RequestParam(required = false) Long classroomId,
+        @RequestParam(required = false) Boolean active,
+        Model model,
+        Authentication authentication
+    ) {
+        SubjectFilter filter = new SubjectFilter(classroomId, active);
+        model.addAttribute("active", "subjects");
+        model.addAttribute("adminName", authentication.getName());
+        model.addAttribute("filter", filter);
+        model.addAttribute("subjectsPage", subjectAdminViewService.getSubjects(filter));
+        model.addAttribute("classrooms", subjectAdminViewService.getClassroomOptions());
+        return "admin/subject/subjects";
+    }
+
+    @PreAuthorize(SUBJECT_READ_ACCESS)
+    @GetMapping("/{subjectId}")
+    public String subjectDetail(
+        @PathVariable Long subjectId,
+        @RequestParam(required = false) Long classroomId,
+        @RequestParam(required = false) Boolean active,
+        Model model,
+        Authentication authentication
+    ) {
+        SubjectFilter filter = new SubjectFilter(classroomId, active);
+        model.addAttribute("active", "subjects");
+        model.addAttribute("adminName", authentication.getName());
+        model.addAttribute("filter", filter);
+        model.addAttribute("subject", subjectAdminViewService.getSubject(subjectId));
+        return "admin/subject/subjects-detail";
+    }
+}

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -28,6 +28,10 @@
                 <span>분반</span>
                 <strong th:text="${summary.classroomCount}">0</strong>
             </a>
+            <a class="metric" th:href="@{/admin/subject/subjects(active=true)}">
+                <span>활성 과목</span>
+                <strong th:text="${summary.subjectCount}">0</strong>
+            </a>
             <a class="metric" th:href="@{/admin/request/purchase/purchase-requests(status='PENDING')}">
                 <span>대기 중 구매 요청</span>
                 <strong th:text="${summary.pendingPurchaseRequestCount}">0</strong>
@@ -87,6 +91,10 @@
                     <a class="metric" th:href="@{/admin/classroom/classrooms}">
                         <span>분반 관리</span>
                         <p style="font-size: 13px; margin: 4px 0 0;">분반 및 교육 과정 운영</p>
+                    </a>
+                    <a class="metric" th:href="@{/admin/subject/subjects}">
+                        <span>과목 관리</span>
+                        <p style="font-size: 13px; margin: 4px 0 0;">정기 수업 편성과 담당 교사 관리</p>
                     </a>
                     <a class="metric" th:href="@{/admin/lesson/lessons}">
                         <span>수업 관리</span>

--- a/src/main/resources/templates/admin/fragments/layout.html
+++ b/src/main/resources/templates/admin/fragments/layout.html
@@ -495,6 +495,7 @@
             <a th:href="@{/admin/post/posts}" th:classappend="${active == 'posts'} ? 'active'">게시글</a>
             <a th:href="@{/admin/department/departments}" th:classappend="${active == 'departments'} ? 'active'">부서</a>
             <a th:href="@{/admin/classroom/classrooms}" th:classappend="${active == 'classrooms'} ? 'active'">분반</a>
+            <a th:href="@{/admin/subject/subjects}" th:classappend="${active == 'subjects'} ? 'active'">과목</a>
             <a th:href="@{/admin/lesson/lessons}" th:classappend="${active == 'lessons'} ? 'active'">수업</a>
             <a th:href="@{/admin/daily-schedule/daily-schedules}" th:classappend="${active == 'dailySchedules'} ? 'active'">하루 일정</a>
             <a th:href="@{/admin/request/absence/absence-requests}" th:classappend="${active == 'absenceRequests'} ? 'active'">결석 요청</a>

--- a/src/main/resources/templates/admin/subject/subjects-detail.html
+++ b/src/main/resources/templates/admin/subject/subjects-detail.html
@@ -145,6 +145,19 @@
                 <button class="button" type="submit">일정 저장</button>
             </form>
         </section>
+
+        <section class="panel">
+            <h2>운영 상태</h2>
+            <form th:if="${subject.isActive}"
+                  th:action="@{/admin/subject/subjects/{subjectId}/deactivate(subjectId=${subject.id})}"
+                  method="post"
+                  onsubmit="return confirm('이 과목을 비활성화할까요?');">
+                <input type="hidden" name="classroomId" th:value="${filter.classroomId}">
+                <input type="hidden" name="active" th:value="${filter.active}">
+                <button class="button danger" type="submit">과목 비활성화</button>
+            </form>
+            <p th:unless="${subject.isActive}">이미 비활성화된 과목입니다.</p>
+        </section>
     </main>
 </div>
 </body>

--- a/src/main/resources/templates/admin/subject/subjects-detail.html
+++ b/src/main/resources/templates/admin/subject/subjects-detail.html
@@ -21,6 +21,13 @@
             </a>
         </div>
 
+        <p class="flash"
+           style="margin: 0; background: #fff0ed; color: var(--danger);"
+           th:if="${errorMessage}"
+           th:text="${errorMessage}">
+            요청을 처리할 수 없습니다.
+        </p>
+
         <section class="panel">
             <h2>기본 정보</h2>
             <div class="detail-grid">
@@ -87,12 +94,6 @@
 
         <section class="panel">
             <h2>담당 교사</h2>
-            <p class="flash"
-               style="margin: 0 0 16px; background: #fff0ed; color: var(--danger);"
-               th:if="${errorMessage}"
-               th:text="${errorMessage}">
-                담당 교사를 변경할 수 없습니다.
-            </p>
             <form class="filter-grid"
                   th:action="@{/admin/subject/subjects/{subjectId}/teacher(subjectId=${subject.id})}"
                   method="post">
@@ -108,6 +109,40 @@
                     </select>
                 </label>
                 <button class="button" type="submit">담당 교사 저장</button>
+            </form>
+        </section>
+
+        <section class="panel">
+            <h2>일정</h2>
+            <form class="filter-grid"
+                  th:action="@{/admin/subject/subjects/{subjectId}/schedule(subjectId=${subject.id})}"
+                  method="post">
+                <input type="hidden" name="classroomId" th:value="${filter.classroomId}">
+                <input type="hidden" name="active" th:value="${filter.active}">
+                <label>운영 시작일
+                    <input name="startAt" type="date" required th:value="${subject.startAt}">
+                </label>
+                <label>운영 종료일
+                    <input name="endAt" type="date" required th:value="${subject.endAt}">
+                </label>
+                <label>요일
+                    <select name="dayOfWeek" required>
+                        <option th:each="dayOfWeek : ${dayOfWeeks}"
+                                th:value="${dayOfWeek.value.name()}"
+                                th:text="${dayOfWeek.label}"
+                                th:selected="${subject.dayOfWeek == dayOfWeek.value}">월요일</option>
+                    </select>
+                </label>
+                <label>교시
+                    <input name="period" type="number" min="1" required th:value="${subject.period}">
+                </label>
+                <label>시작 시간
+                    <input name="startTime" type="time" required th:value="${subject.startTime}">
+                </label>
+                <label>종료 시간
+                    <input name="endTime" type="time" required th:value="${subject.endTime}">
+                </label>
+                <button class="button" type="submit">일정 저장</button>
             </form>
         </section>
     </main>

--- a/src/main/resources/templates/admin/subject/subjects-detail.html
+++ b/src/main/resources/templates/admin/subject/subjects-detail.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/layout :: head('과목 상세')}"></head>
+<body>
+<div th:replace="~{admin/fragments/layout :: shell(~{::main})}">
+    <main class="stack">
+        <div class="page-title">
+            <div>
+                <h1>과목 상세</h1>
+                <p th:text="|${subject.classroomName} ${subject.name} 편성 정보입니다.|">
+                    벚꽃반 한글 기초 편성 정보입니다.
+                </p>
+            </div>
+            <a class="reset-link"
+               th:href="@{/admin/subject/subjects(classroomId=${filter.classroomId},active=${filter.active})}">
+                목록으로
+            </a>
+        </div>
+
+        <section class="panel">
+            <h2>기본 정보</h2>
+            <div class="detail-grid">
+                <div class="detail-item">
+                    <span>ID</span>
+                    <strong th:text="${subject.id}">1</strong>
+                </div>
+                <div class="detail-item">
+                    <span>상태</span>
+                    <strong>
+                        <span class="pill" th:text="${subject.activeLabel}">활성</span>
+                    </strong>
+                </div>
+                <div class="detail-item">
+                    <span>과목명</span>
+                    <strong th:text="${subject.name}">한글 기초</strong>
+                </div>
+                <div class="detail-item">
+                    <span>분반</span>
+                    <strong th:text="|${subject.classroomName} (#${subject.classroomId})|">벚꽃반 (#1)</strong>
+                </div>
+                <div class="detail-item">
+                    <span>담당 교사</span>
+                    <strong th:text="${subject.teacherId != null ? subject.teacherLabel + ' (#' + subject.teacherId + ')' : subject.teacherLabel}">
+                        홍길동 (#2)
+                    </strong>
+                </div>
+                <div class="detail-item">
+                    <span>교사 배정 시각</span>
+                    <strong th:text="${subject.teacherAssignedAt != null ? subject.teacherAssignedAt : '-'}">
+                        2026-05-01T10:00
+                    </strong>
+                </div>
+                <div class="detail-item">
+                    <span>운영 기간</span>
+                    <strong th:text="|${subject.startAt} ~ ${subject.endAt}|">2026-03-01 ~ 2026-08-31</strong>
+                </div>
+                <div class="detail-item">
+                    <span>요일</span>
+                    <strong th:text="${subject.dayOfWeekLabel}">월요일</strong>
+                </div>
+                <div class="detail-item">
+                    <span>교시</span>
+                    <strong th:text="${subject.period}">1</strong>
+                </div>
+                <div class="detail-item">
+                    <span>수업 시간</span>
+                    <strong th:text="${subject.startTime != null && subject.endTime != null ? subject.startTime + ' - ' + subject.endTime : '-'}">
+                        19:20 - 20:00
+                    </strong>
+                </div>
+                <div class="detail-item">
+                    <span>수업 횟수</span>
+                    <strong th:text="${subject.times}">12</strong>
+                </div>
+                <div class="detail-item">
+                    <span>설명</span>
+                    <strong th:text="${subject.description != null && !subject.description.isBlank() ? subject.description : '-'}">
+                        과목 설명
+                    </strong>
+                </div>
+            </div>
+        </section>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/subject/subjects-detail.html
+++ b/src/main/resources/templates/admin/subject/subjects-detail.html
@@ -15,6 +15,10 @@
                th:href="@{/admin/subject/subjects(classroomId=${filter.classroomId},active=${filter.active})}">
                 목록으로
             </a>
+            <a class="button"
+               th:href="@{/admin/subject/subjects/{subjectId}/edit(subjectId=${subject.id},classroomId=${filter.classroomId},active=${filter.active})}">
+                기본 정보 수정
+            </a>
         </div>
 
         <section class="panel">

--- a/src/main/resources/templates/admin/subject/subjects-detail.html
+++ b/src/main/resources/templates/admin/subject/subjects-detail.html
@@ -84,6 +84,32 @@
                 </div>
             </div>
         </section>
+
+        <section class="panel">
+            <h2>담당 교사</h2>
+            <p class="flash"
+               style="margin: 0 0 16px; background: #fff0ed; color: var(--danger);"
+               th:if="${errorMessage}"
+               th:text="${errorMessage}">
+                담당 교사를 변경할 수 없습니다.
+            </p>
+            <form class="filter-grid"
+                  th:action="@{/admin/subject/subjects/{subjectId}/teacher(subjectId=${subject.id})}"
+                  method="post">
+                <input type="hidden" name="classroomId" th:value="${filter.classroomId}">
+                <input type="hidden" name="active" th:value="${filter.active}">
+                <label>담당 교사
+                    <select name="teacherId">
+                        <option value="" th:selected="${subject.teacherId == null}">미배정</option>
+                        <option th:each="teacher : ${teachers}"
+                                th:value="${teacher.id}"
+                                th:text="${teacher.name}"
+                                th:selected="${subject.teacherId == teacher.id}">홍길동</option>
+                    </select>
+                </label>
+                <button class="button" type="submit">담당 교사 저장</button>
+            </form>
+        </section>
     </main>
 </div>
 </body>

--- a/src/main/resources/templates/admin/subject/subjects-edit.html
+++ b/src/main/resources/templates/admin/subject/subjects-edit.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/layout :: head('과목 기본 정보 수정')}"></head>
+<body>
+<div th:replace="~{admin/fragments/layout :: shell(~{::main})}">
+    <main class="stack">
+        <div class="page-title">
+            <div>
+                <h1>과목 기본 정보 수정</h1>
+                <p th:text="|${subject.classroomName} ${subject.name}의 이름과 설명을 수정합니다.|">
+                    벚꽃반 한글 기초의 이름과 설명을 수정합니다.
+                </p>
+            </div>
+            <a class="reset-link"
+               th:href="@{/admin/subject/subjects/{subjectId}(subjectId=${subject.id},classroomId=${filter.classroomId},active=${filter.active})}">
+                상세로
+            </a>
+        </div>
+
+        <form class="panel form-grid"
+              th:action="@{/admin/subject/subjects/{subjectId}(subjectId=${subject.id})}"
+              method="post">
+            <input type="hidden" name="classroomId" th:value="${filter.classroomId}">
+            <input type="hidden" name="active" th:value="${filter.active}">
+            <label>과목명
+                <input name="name" maxlength="50" required th:value="${subject.name}">
+            </label>
+            <label>설명
+                <textarea name="description" th:text="${subject.description}"></textarea>
+            </label>
+            <button class="button" type="submit">기본 정보 저장</button>
+        </form>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/subject/subjects-form.html
+++ b/src/main/resources/templates/admin/subject/subjects-form.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/layout :: head('과목 등록')}"></head>
+<body>
+<div th:replace="~{admin/fragments/layout :: shell(~{::main})}">
+    <main class="stack">
+        <div class="page-title">
+            <div>
+                <h1>과목 등록</h1>
+                <p>분반의 정기 수업 편성과 담당 교사를 등록합니다.</p>
+            </div>
+            <a class="reset-link" th:href="@{/admin/subject/subjects}">목록으로</a>
+        </div>
+
+        <form class="panel form-grid" th:action="@{/admin/subject/subjects}" method="post">
+            <label>분반
+                <select name="classroomId" required>
+                    <option value="">선택</option>
+                    <option th:each="classroom : ${classrooms}"
+                            th:value="${classroom.id}"
+                            th:text="${classroom.name}">벚꽃반</option>
+                </select>
+            </label>
+            <label>담당 교사
+                <select name="teacherId">
+                    <option value="">미배정</option>
+                    <option th:each="teacher : ${teachers}"
+                            th:value="${teacher.id}"
+                            th:text="${teacher.name}">홍길동</option>
+                </select>
+            </label>
+            <label>과목명
+                <input name="name" maxlength="50" required>
+            </label>
+            <label>운영 시작일
+                <input name="startAt" type="date" required>
+            </label>
+            <label>운영 종료일
+                <input name="endAt" type="date" required>
+            </label>
+            <label>요일
+                <select name="dayOfWeek" required>
+                    <option th:each="dayOfWeek : ${dayOfWeeks}"
+                            th:value="${dayOfWeek.value.name()}"
+                            th:text="${dayOfWeek.label}">월요일</option>
+                </select>
+            </label>
+            <label>교시
+                <input name="period" type="number" min="1" required>
+            </label>
+            <label>시작 시간
+                <input name="startTime" type="time" required>
+            </label>
+            <label>종료 시간
+                <input name="endTime" type="time" required>
+            </label>
+            <label>설명
+                <textarea name="description"></textarea>
+            </label>
+            <button class="button" type="submit">등록</button>
+        </form>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/subject/subjects.html
+++ b/src/main/resources/templates/admin/subject/subjects.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/layout :: head('과목 관리')}"></head>
+<body>
+<div th:replace="~{admin/fragments/layout :: shell(~{::main})}">
+    <main class="stack">
+        <div class="page-title">
+            <div>
+                <h1>과목</h1>
+                <p>분반별 정기 수업 편성과 담당 교사 배정 상태를 조회합니다.</p>
+            </div>
+        </div>
+
+        <form class="panel filter-grid" th:action="@{/admin/subject/subjects}" method="get">
+            <label>분반
+                <select name="classroomId">
+                    <option value="">전체</option>
+                    <option th:each="classroom : ${classrooms}"
+                            th:value="${classroom.id}"
+                            th:text="${classroom.name}"
+                            th:selected="${filter.classroomId == classroom.id}">벚꽃반</option>
+                </select>
+            </label>
+            <label>상태
+                <select name="active">
+                    <option value="">전체</option>
+                    <option value="true" th:selected="${filter.active != null && filter.active}">활성</option>
+                    <option value="false" th:selected="${filter.active != null && !filter.active}">비활성</option>
+                </select>
+            </label>
+            <button class="button" type="submit">조회</button>
+            <a class="reset-link" th:href="@{/admin/subject/subjects}">초기화</a>
+        </form>
+
+        <section class="panel table-panel">
+            <div class="table-scroll">
+                <table>
+                    <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>과목명</th>
+                        <th>분반</th>
+                        <th>담당 교사</th>
+                        <th>운영 기간</th>
+                        <th>요일</th>
+                        <th>교시</th>
+                        <th>수업 시간</th>
+                        <th>수업 횟수</th>
+                        <th>상태</th>
+                        <th>관리</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="subject : ${subjectsPage.rows}">
+                        <td th:text="${subject.id}">1</td>
+                        <td th:text="${subject.name}">한글 기초</td>
+                        <td th:text="${subject.classroomName}">벚꽃반</td>
+                        <td th:text="${subject.teacherLabel}">홍길동</td>
+                        <td th:text="|${subject.startAt} ~ ${subject.endAt}|">2026-03-01 ~ 2026-08-31</td>
+                        <td th:text="${subject.dayOfWeekLabel}">월요일</td>
+                        <td th:text="${subject.period}">1</td>
+                        <td th:text="${subject.startTime != null && subject.endTime != null ? subject.startTime + ' - ' + subject.endTime : '-'}">19:20 - 20:00</td>
+                        <td th:text="${subject.times}">12</td>
+                        <td>
+                            <span class="pill" th:text="${subject.activeLabel}">활성</span>
+                        </td>
+                        <td>
+                            <a class="reset-link"
+                               th:href="@{/admin/subject/subjects/{subjectId}(subjectId=${subject.id},classroomId=${filter.classroomId},active=${filter.active})}">
+                                상세보기
+                            </a>
+                        </td>
+                    </tr>
+                    <tr th:if="${#lists.isEmpty(subjectsPage.rows)}">
+                        <td colspan="11" class="empty">조회된 과목이 없습니다.</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/subject/subjects.html
+++ b/src/main/resources/templates/admin/subject/subjects.html
@@ -9,6 +9,7 @@
                 <h1>과목</h1>
                 <p>분반별 정기 수업 편성과 담당 교사 배정 상태를 조회합니다.</p>
             </div>
+            <a class="button" th:href="@{/admin/subject/subjects/new}">과목 등록</a>
         </div>
 
         <form class="panel filter-grid" th:action="@{/admin/subject/subjects}" method="get">

--- a/src/test/java/geumjeongyahak/unit/base/AdminDashboardServiceTest.java
+++ b/src/test/java/geumjeongyahak/unit/base/AdminDashboardServiceTest.java
@@ -16,6 +16,7 @@ import geumjeongyahak.domain.purchase_request.repository.PurchaseRequestReposito
 import geumjeongyahak.domain.request.enums.RequestStatus;
 import geumjeongyahak.domain.request.repository.AbsenceRequestRepository;
 import geumjeongyahak.domain.student.repository.StudentRepository;
+import geumjeongyahak.domain.subject.repository.SubjectRepository;
 import geumjeongyahak.domain.users.repository.UserRepository;
 import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
@@ -48,6 +49,9 @@ class AdminDashboardServiceTest {
     @Mock
     private LessonRepository lessonRepository;
 
+    @Mock
+    private SubjectRepository subjectRepository;
+
     @InjectMocks
     private AdminDashboardService adminDashboardService;
 
@@ -59,6 +63,7 @@ class AdminDashboardServiceTest {
         given(purchaseRequestRepository.countByStatus(PurchaseRequestStatus.PENDING)).willReturn(2L);
         given(absenceRequestRepository.countByStatus(RequestStatus.PENDING)).willReturn(5L);
         given(studentRepository.count()).willReturn(11L);
+        given(subjectRepository.countByIsActiveTrue()).willReturn(7L);
         given(lessonRepository.countByIsDeletedFalse()).willReturn(20L);
         given(lessonRepository.countByIsDeletedFalseAndDate(any(LocalDate.class))).willReturn(3L);
         given(lessonRepository.countByStatusAndIsDeletedFalseAndDateBetween(
@@ -75,6 +80,7 @@ class AdminDashboardServiceTest {
         assertThat(summary.pendingPurchaseRequestCount()).isEqualTo(2L);
         assertThat(summary.pendingAbsenceRequestCount()).isEqualTo(5L);
         assertThat(summary.studentCount()).isEqualTo(11L);
+        assertThat(summary.subjectCount()).isEqualTo(7L);
         assertThat(summary.lessonCount()).isEqualTo(20L);
         assertThat(summary.todayLessonCount()).isEqualTo(3L);
         assertThat(summary.weeklyScheduledLessonCount()).isEqualTo(8L);


### PR DESCRIPTION
## 개요

과목 도메인의 관리자 페이지를 추가했습니다. 관리자는 과목 목록/상세를 조회하고, 과목 등록, 기본 정보 수정, 담당 교사 배정/해제, 일정 수정, 비활성화를 처리할 수 있습니다. 또한 관리자 사이드바와 대시보드에 과목 관리 진입점을 추가했습니다.

## 변경 유형

- [x] 새 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [x] 테스트 (test)
- [ ] 기타 (chore)

## 변경 내용

- 과목 관리자 목록/상세 화면 추가
- 분반 및 활성 상태 필터 추가
- 담당 교사 미배정 상태 표시
- 과목 등록 화면 및 처리 로직 추가
- 과목 기본 정보 수정 기능 추가
- 담당 교사 배정/해제 기능 추가
- 과목 일정 수정 기능 추가
- 과목 비활성화 기능 추가
- 일정/교사 변경 실패 시 관리자 화면 내 오류 메시지 표시
- 과목 조회 권한 `subject:read:*` 추가
- 관리자 사이드바에 과목 메뉴 추가
- 대시보드에 활성 과목 수 및 과목 관리 카드 추가
- 대시보드 과목 수 추가에 따른 단위 테스트 보완

## 관련 이슈

Closes #76

## 스크린샷 (선택)

- 과목 목록 화면
<img width="1920" height="923" alt="image" src="https://github.com/user-attachments/assets/2273cc0b-be26-42b0-8a8a-d114a452c28d" />

- 과목 상세 화면
<img width="1920" height="921" alt="image" src="https://github.com/user-attachments/assets/79c0783f-b269-45aa-bfd7-7eba73dc91bf" />

- 과목 등록 화면
<img width="1918" height="920" alt="image" src="https://github.com/user-attachments/assets/75c4bc1d-9b6a-4de4-90d2-b003c8223f70" />

- 과목 기본 정보 수정 화면
<img width="1920" height="917" alt="image" src="https://github.com/user-attachments/assets/db2ce0de-6292-4973-8a7b-482bdf9d4100" />

- 대시보드 과목 진입점
<img width="1920" height="917" alt="image" src="https://github.com/user-attachments/assets/f1b7d0e4-ba78-4c06-8861-5bf0068cf578" />

## 체크리스트

- [x] 코드 컨벤션을 준수했습니다
- [x] 테스트 코드를 작성/수정했습니다
- [ ] 모든 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요한 경우)

## 리뷰어에게