### PR TITLE
fix: GHCR 배포 토큰 사용

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta


### PR DESCRIPTION
## 변경 내용
- dev 배포 workflow의 Docker registry 로그인에서 GITHUB_TOKEN 대신 GHCR_TOKEN secret을 사용하도록 변경했습니다.
- 원인: merge 후 dev 배포에서 Docker image push 단계가 write_package 권한 부족으로 실패했습니다.

## 검증
- 워크플로 단일 설정 변경입니다.
- 직전 PR #79에서 ./gradlew test 전체 통과를 확인했습니다.

## 배포 흐름
```mermaid
graph TD
    A[dev push] --> B[GHCR_TOKEN으로 ghcr.io 로그인]
    B --> C[Docker image build]
    C --> D[GHCR push]
    D --> E[GCE deploy]
```