### PR TITLE
[FEAT] 요청 API 입력값을 dailyScheduleId에서 lessonDate 기반으로 변경

### DIFF
--- a/docs/api/Requests.md
+++ b/docs/api/Requests.md
@@ -41,18 +41,18 @@
 ### 2.3 하루 단위 교환 규칙
 
 - 요청과 제안은 교시 범위를 입력받지 않습니다.
-- 요청은 `dailyScheduleId`에 해당하는 하루 일정을 대상으로 삼습니다.
-- 교환형 제안은 `dailyScheduleId`에 해당하는 제안자 하루 일정을 대상으로 삼습니다.
-- 교환형 제안은 요청과 같은 `DailySchedule`로 생성하거나 수정할 수 없습니다.
+- 요청은 로그인 사용자와 `lessonDate`를 기준으로 조회한 하루 일정을 대상으로 삼습니다.
+- 교환형 제안은 로그인 사용자와 `lessonDate`를 기준으로 조회한 제안자 하루 일정을 대상으로 삼습니다.
+- 교환형 제안은 요청과 같은 수업일로 생성하거나 수정할 수 없습니다.
 - 제안 수락 시 `DailySchedule.teacher`를 변경하고, 해당 DailySchedule의 반/날짜에 연결된 `Lesson.teacher`도 함께 변경합니다.
-- 응답의 `lessonDate`는 기존 화면 호환과 이력 표시를 위한 snapshot 성격의 값이며, 요청/제안의 기준 식별자는 `dailyScheduleId`입니다.
+- 응답의 `dailyScheduleId`는 내부 연결된 하루 일정 식별자이며, 생성/수정 요청 입력은 `lessonDate`를 사용합니다.
 
 ### 2.4 제안 타입 규칙
 
 | 조건 | proposalType |
 |---|---|
-| `dailyScheduleId` 있음 | `EXCHANGE` |
-| `dailyScheduleId` 없음 | `SUBSTITUTION` |
+| `lessonDate` 있음 | `EXCHANGE` |
+| `lessonDate` 없음 | `SUBSTITUTION` |
 
 - `EXCHANGE`는 제안자가 자신의 다른 수업을 내놓는 교환형 제안입니다.
 - `SUBSTITUTION`은 제안 수업 없이 요청 수업을 대신 맡는 대체형 제안입니다.
@@ -125,7 +125,7 @@
 
 ## 5. 결석 요청 API
 
-결석 요청은 하루 단위 결강 요청입니다. 수업 결강 페이지는 `DailySchedule` 목록 또는 상세를 기준으로 요청 대상을 선택하고, 생성 API에는 `dailyScheduleId`를 전달합니다.
+결석 요청은 하루 단위 결강 요청입니다. 수업 결강 페이지는 사용자가 선택한 수업일을 기준으로 요청을 생성하며, 생성 API에는 `lessonDate`를 전달합니다. 백엔드는 로그인 사용자와 `lessonDate`로 대상 `DailySchedule`을 조회합니다.
 
 ## 5.1 결석 요청 생성
 
@@ -138,7 +138,7 @@
 ```json
 {
   "title": "개인 사정으로 결석합니다",
-  "dailyScheduleId": 1,
+  "lessonDate": "2026-05-12",
   "reason": "개인 사정으로 인한 결석"
 }
 ```
@@ -177,7 +177,7 @@
 
 | 상황 | HTTP |
 |---|---|
-| 대상 하루 일정 담당 교사가 아님 | 403 |
+| 로그인 사용자의 해당 수업일 DailySchedule 없음 | 404 |
 | 같은 하루 일정에 진행 중인 결석 요청 존재 | 409 |
 | 이미 만료된 하루 일정에 대한 요청 | 400 |
 
@@ -319,7 +319,7 @@
 
 ## 6. 수업 교환 요청 API
 
-수업 교환 요청은 `DailySchedule` 기반으로 동작합니다. API 입력은 `dailyScheduleId`이며, 서비스는 해당 DailySchedule의 담당 교사와 요청자를 검증한 뒤 하루 단위 교환 요청을 생성합니다. 제안 수락 시에는 DailySchedule의 담당 교사를 변경하고, 같은 반/날짜의 활성 Lesson 담당 교사도 함께 변경합니다.
+수업 교환 요청은 `DailySchedule` 기반으로 동작합니다. API 입력은 `lessonDate`이며, 서비스는 로그인 사용자와 수업일로 대상 DailySchedule을 조회한 뒤 하루 단위 교환 요청을 생성합니다. 제안 수락 시에는 DailySchedule의 담당 교사를 변경하고, 같은 반/날짜의 활성 Lesson 담당 교사도 함께 변경합니다.
 
 ## 6.1 요청 생성
 
@@ -331,7 +331,7 @@
 
 ```json
 {
-  "dailyScheduleId": 1,
+  "lessonDate": "2026-05-12",
   "title": "금요일 수업 교환 요청",
   "content": "개인 일정으로 인해 교환이 필요합니다.",
   "expiresAt": "2026-05-09T23:00:00"
@@ -347,7 +347,7 @@
 
 | 상황 | HTTP |
 |---|---|
-| 본인이 담당하지 않는 DailySchedule | 403 |
+| 로그인 사용자의 해당 수업일 DailySchedule 없음 | 404 |
 | 이미 같은 DailySchedule에 `PENDING`/`APPROVED` 요청 존재 | 409 |
 | 교환 요청 가능 기간(현재+4일) 이전 수업 | 400 |
 | 만료 시각 정책 위반 | 400 |
@@ -382,7 +382,7 @@
 
 - 요청 생성과 동일한 입력 정책을 사용합니다.
 - 수정 후 반 이름 snapshot도 함께 갱신됩니다.
-- `dailyScheduleId`를 변경하면 변경된 DailySchedule의 담당 교사와 정책을 다시 검증합니다.
+- `lessonDate`를 변경하면 변경된 수업일의 DailySchedule과 정책을 다시 검증합니다.
 
 ## 6.5 요청 취소
 
@@ -437,7 +437,7 @@
 
 ```json
 {
-  "dailyScheduleId": 2,
+  "lessonDate": "2026-05-13",
   "content": "수요일 수업으로 교환 가능합니다."
 }
 ```
@@ -453,8 +453,8 @@
 ### 구현 기준 동작
 
 - 같은 요청에 대해 동일 제안자는 `ACTIVE` 제안 1건만 가질 수 있습니다.
-- `EXCHANGE` 제안은 요청 DailySchedule과 같은 DailySchedule로 생성할 수 없습니다.
-- `EXCHANGE` 제안은 제안자가 담당하는 DailySchedule이어야 하며, 해당 DailySchedule의 반/날짜 수업 전체가 교환 대상입니다.
+- `EXCHANGE` 제안은 요청 수업일과 같은 수업일로 생성할 수 없습니다.
+- `EXCHANGE` 제안은 제안자가 해당 수업일에 담당하는 DailySchedule이어야 하며, 해당 DailySchedule의 반/날짜 수업 전체가 교환 대상입니다.
 - `SUBSTITUTION` 제안은 요청 수업 시간대에 제안자의 기존 수업이 충돌하면 생성할 수 없습니다.
 
 ## 7.2 제안 목록 조회

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/repository/DailyScheduleRepository.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/repository/DailyScheduleRepository.java
@@ -14,6 +14,9 @@ public interface DailyScheduleRepository extends JpaRepository<DailySchedule, Lo
     Optional<DailySchedule> findByClassroomIdAndLessonDate(Long classroomId, LocalDate lessonDate);
 
     @EntityGraph(attributePaths = {"classroom", "teacher"})
+    Optional<DailySchedule> findByTeacherIdAndLessonDateAndIsDeletedFalse(Long teacherId, LocalDate lessonDate);
+
+    @EntityGraph(attributePaths = {"classroom", "teacher"})
     List<DailySchedule> findAllByIsDeletedFalseAndLessonDateBetweenOrderByLessonDateAscIdAsc(
         LocalDate from,
         LocalDate to

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleProxyService.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleProxyService.java
@@ -3,6 +3,7 @@ package geumjeongyahak.domain.daily_schedule.service;
 import geumjeongyahak.domain.daily_schedule.entity.DailySchedule;
 import geumjeongyahak.domain.daily_schedule.exception.DailyScheduleNotFoundException;
 import geumjeongyahak.domain.daily_schedule.repository.DailyScheduleRepository;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,5 +18,12 @@ public class DailyScheduleProxyService {
     public DailySchedule getActiveById(Long dailyScheduleId) {
         return dailyScheduleRepository.findByIdAndIsDeletedFalse(dailyScheduleId)
             .orElseThrow(() -> new DailyScheduleNotFoundException(dailyScheduleId));
+    }
+
+    public DailySchedule getActiveByTeacherIdAndLessonDate(Long teacherId, LocalDate lessonDate) {
+        return dailyScheduleRepository.findByTeacherIdAndLessonDateAndIsDeletedFalse(teacherId, lessonDate)
+            .orElseThrow(() -> new DailyScheduleNotFoundException(
+                "teacherId=" + teacherId + ", lessonDate=" + lessonDate
+            ));
     }
 }

--- a/src/main/java/geumjeongyahak/domain/request/service/AbsenceRequestService.java
+++ b/src/main/java/geumjeongyahak/domain/request/service/AbsenceRequestService.java
@@ -46,12 +46,15 @@ public class AbsenceRequestService {
     @Transactional
     public AbsenceRequestResponse createAbsenceRequest(Long requesterId, CreateAbsenceRequestRequest request) {
         log.debug(
-            "결석 요청 생성 (requesterId={}, dailyScheduleId={})",
+            "결석 요청 생성 (requesterId={}, lessonDate={})",
             requesterId,
-            request.dailyScheduleId()
+            request.lessonDate()
         );
 
-        DailySchedule dailySchedule = dailyScheduleProxyService.getActiveById(request.dailyScheduleId());
+        DailySchedule dailySchedule = dailyScheduleProxyService.getActiveByTeacherIdAndLessonDate(
+            requesterId,
+            request.lessonDate()
+        );
         User requester = userProxyService.getById(requesterId);
 
         validateRequesterIsDailyScheduleTeacher(dailySchedule, requesterId);

--- a/src/main/java/geumjeongyahak/domain/request/service/LessonExchangeProposalService.java
+++ b/src/main/java/geumjeongyahak/domain/request/service/LessonExchangeProposalService.java
@@ -56,14 +56,14 @@ public class LessonExchangeProposalService {
         validateNotOwnRequest(exchangeRequest, proposerId);
         validateNoDuplicateActiveProposal(requestId, proposerId);
 
-        LessonExchangeProposalType proposalType = resolveProposalType(request.dailyScheduleId());
+        LessonExchangeProposalType proposalType = resolveProposalType(request.lessonDate());
 
         String classroomName = null;
         DailySchedule proposalDailySchedule = null;
 
         // 교환형 제안과 대체형 제안을 구분
         if (proposalType == LessonExchangeProposalType.EXCHANGE) {
-            proposalDailySchedule = getProposalDailySchedule(proposerId, request.dailyScheduleId());
+            proposalDailySchedule = getProposalDailySchedule(proposerId, request.lessonDate());
             validateNoTimeOverlapWithRequest(
                 exchangeRequest,
                 proposalDailySchedule
@@ -132,13 +132,13 @@ public class LessonExchangeProposalService {
         // 생성 시 적용한 "요청당 제안자별 ACTIVE 제안 1건만 허용" 정책을 그대로 유지
         // 즉 여기서는 새 ACTIVE 제안을 추가하지 않으므로 중복 ACTIVE 제안 검증을 다시 수행하지 않음
 
-        LessonExchangeProposalType proposalType = resolveProposalType(request.dailyScheduleId());
+        LessonExchangeProposalType proposalType = resolveProposalType(request.lessonDate());
 
         String classroomName = null;
         DailySchedule proposalDailySchedule = null;
 
         if (proposalType == LessonExchangeProposalType.EXCHANGE) {
-            proposalDailySchedule = getProposalDailySchedule(proposerId, request.dailyScheduleId());
+            proposalDailySchedule = getProposalDailySchedule(proposerId, request.lessonDate());
             validateNoTimeOverlapWithRequest(
                 exchangeRequest,
                 proposalDailySchedule
@@ -304,7 +304,7 @@ public class LessonExchangeProposalService {
         LessonExchangeRequest exchangeRequest,
         DailySchedule proposalDailySchedule
     ) {
-        if (exchangeRequest.getDailySchedule().getId().equals(proposalDailySchedule.getId())) {
+        if (exchangeRequest.getLessonDate().equals(proposalDailySchedule.getLessonDate())) {
             throw new ProposalTimeOverlapWithRequestException();
         }
     }
@@ -324,12 +324,8 @@ public class LessonExchangeProposalService {
     }
 
     // 교환형 제안 대상 DailySchedule을 조회하고 제안자 담당 일정인지 확인
-    private DailySchedule getProposalDailySchedule(Long proposerId, Long dailyScheduleId) {
-        DailySchedule dailySchedule = dailyScheduleProxyService.getActiveById(dailyScheduleId);
-        if (!dailySchedule.getTeacher().getId().equals(proposerId)) {
-            throw new ProposalLessonsNotFoundException();
-        }
-        return dailySchedule;
+    private DailySchedule getProposalDailySchedule(Long proposerId, LocalDate lessonDate) {
+        return dailyScheduleProxyService.getActiveByTeacherIdAndLessonDate(proposerId, lessonDate);
     }
 
     // 제안자가 수업 교환 요청의 기존 수업과 충돌하는 수업이 있는지 검증
@@ -365,8 +361,8 @@ public class LessonExchangeProposalService {
     }
 
     // 제안 수업 유형을 판단하는 메서드(대체형/교환형)
-    private LessonExchangeProposalType resolveProposalType(Long dailyScheduleId) {
-        if (dailyScheduleId == null) {
+    private LessonExchangeProposalType resolveProposalType(LocalDate lessonDate) {
+        if (lessonDate == null) {
             return LessonExchangeProposalType.SUBSTITUTION;
         }
 

--- a/src/main/java/geumjeongyahak/domain/request/service/LessonExchangeRequestService.java
+++ b/src/main/java/geumjeongyahak/domain/request/service/LessonExchangeRequestService.java
@@ -58,14 +58,14 @@ public class LessonExchangeRequestService {
         CreateLessonExchangeRequestRequest request
     ) {
         log.debug(
-            "수업 교환 요청 생성 (requesterId={}, dailyScheduleId={})",
+            "수업 교환 요청 생성 (requesterId={}, lessonDate={})",
             requesterId,
-            request.dailyScheduleId()
+            request.lessonDate()
         );
 
         DailySchedule dailySchedule = getTargetDailySchedule(
             requesterId,
-            request.dailyScheduleId()
+            request.lessonDate()
         );
 
         validateNoActiveExchangeRequestExists(
@@ -167,7 +167,7 @@ public class LessonExchangeRequestService {
 
         DailySchedule dailySchedule = getTargetDailySchedule(
             requesterId,
-            request.dailyScheduleId()
+            request.lessonDate()
         );
 
         validateNoActiveExchangeRequestExists(
@@ -346,13 +346,9 @@ public class LessonExchangeRequestService {
 
     private DailySchedule getTargetDailySchedule(
         Long requesterId,
-        Long dailyScheduleId
+        LocalDate lessonDate
     ) {
-        DailySchedule dailySchedule = dailyScheduleProxyService.getActiveById(dailyScheduleId);
-        if (!dailySchedule.getTeacher().getId().equals(requesterId)) {
-            throw new RequestForbiddenException();
-        }
-        return dailySchedule;
+        return dailyScheduleProxyService.getActiveByTeacherIdAndLessonDate(requesterId, lessonDate);
     }
 
     private Specification<LessonExchangeRequest> buildListSpecification(

--- a/src/main/java/geumjeongyahak/domain/request/v1/controller/AbsenceRequestController.java
+++ b/src/main/java/geumjeongyahak/domain/request/v1/controller/AbsenceRequestController.java
@@ -65,8 +65,8 @@ public class AbsenceRequestController {
         @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         log.debug(
-            "POST /api/v1/absence-requests - 결석 요청 생성 (dailyScheduleId={})",
-            request.dailyScheduleId()
+            "POST /api/v1/absence-requests - 결석 요청 생성 (lessonDate={})",
+            request.lessonDate()
         );
         AbsenceRequestResponse response = absenceRequestService.createAbsenceRequest(
             userDetails.getUserId(), request

--- a/src/main/java/geumjeongyahak/domain/request/v1/controller/LessonExchangeProposalController.java
+++ b/src/main/java/geumjeongyahak/domain/request/v1/controller/LessonExchangeProposalController.java
@@ -34,8 +34,8 @@ public class LessonExchangeProposalController {
     @Operation(
         summary = "수업 교환 제안 생성",
         description = "교사 이상 권한(VOLUNTEER, MANAGER, ADMIN)을 가진 사용자가 APPROVED 상태의 수업 교환 요청에 대해 교환 제안을 생성합니다. "
-            + "제안은 교시 범위를 받지 않으며, dailyScheduleId를 입력하면 해당 DailySchedule의 수업 전체를 내놓는 교환형 제안으로 처리됩니다. "
-            + "dailyScheduleId를 입력하지 않으면 대체형 제안으로 처리됩니다. "
+            + "제안은 교시 범위를 받지 않으며, lessonDate를 입력하면 해당 날짜의 본인 DailySchedule 수업 전체를 내놓는 교환형 제안으로 처리됩니다. "
+            + "lessonDate를 입력하지 않으면 대체형 제안으로 처리됩니다. "
             + "교환형 제안은 요청 DailySchedule과 같은 DailySchedule로 생성할 수 없습니다. "
             + "교환형 제안의 반 이름은 생성 시점의 표시값을 snapshot 으로 함께 저장하며, 이후 실제 수업 교사가 변경되더라도 제안 화면에는 기존 값이 유지됩니다. "
             + "대체형 제안은 제안 자체에 대응하는 교환 수업이 없으므로 반 이름을 별도로 저장하거나 반환하지 않습니다."
@@ -79,7 +79,7 @@ public class LessonExchangeProposalController {
     @Operation(
         summary = "수업 교환 제안 수정",
         description = "교사 이상 권한(VOLUNTEER, MANAGER, ADMIN)을 가진 사용자가 본인이 작성한 ACTIVE 상태의 수업 교환 제안을 수정합니다. "
-            + "입력 규칙은 제안 생성 API와 동일하며, 교시 범위 없이 dailyScheduleId 유무로 교환형/대체형을 결정합니다. "
+            + "입력 규칙은 제안 생성 API와 동일하며, 교시 범위 없이 lessonDate 유무로 교환형/대체형을 결정합니다. "
             + "요청이 여전히 제안 가능 상태인지와 제안자가 실제 수업 조건을 만족하는지도 다시 검증합니다. "
             + "교환형 제안의 반 이름 snapshot 도 함께 갱신되며, 대체형 제안은 반 이름 없이 유지됩니다. "
             + "이후 조회 시에는 최신 수정 기준의 표시값이 유지됩니다."

--- a/src/main/java/geumjeongyahak/domain/request/v1/dto/request/CreateAbsenceRequestRequest.java
+++ b/src/main/java/geumjeongyahak/domain/request/v1/dto/request/CreateAbsenceRequestRequest.java
@@ -3,12 +3,13 @@ package geumjeongyahak.domain.request.v1.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
 
 public record CreateAbsenceRequestRequest(
 
     @NotNull
-    @Schema(description = "결석할 하루 일정 ID", example = "1")
-    Long dailyScheduleId,
+    @Schema(description = "결석할 수업일. 로그인 사용자의 해당 날짜 DailySchedule을 대상으로 결석 요청을 생성합니다.", example = "2026-06-10")
+    LocalDate lessonDate,
 
     @NotBlank
     @Schema(description = "결석 요청 제목", example = "개인 사정으로 결석합니다")

--- a/src/main/java/geumjeongyahak/domain/request/v1/dto/request/CreateLessonExchangeProposalRequest.java
+++ b/src/main/java/geumjeongyahak/domain/request/v1/dto/request/CreateLessonExchangeProposalRequest.java
@@ -2,11 +2,12 @@ package geumjeongyahak.domain.request.v1.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDate;
 
 public record CreateLessonExchangeProposalRequest(
 
-    @Schema(description = "제안 하루 일정 ID. 입력하면 교환형(EXCHANGE), 생략하면 대체형(SUBSTITUTION)으로 처리됩니다.", example = "2")
-    Long dailyScheduleId,
+    @Schema(description = "제안 수업일. 입력하면 로그인 사용자의 해당 날짜 DailySchedule을 내놓는 교환형(EXCHANGE), 생략하면 대체형(SUBSTITUTION)으로 처리됩니다.", example = "2026-06-11")
+    LocalDate lessonDate,
 
     @NotBlank
     @Schema(description = "제안 내용", example = "해당 날짜 수업으로 교환 가능합니다.")

--- a/src/main/java/geumjeongyahak/domain/request/v1/dto/request/CreateLessonExchangeRequestRequest.java
+++ b/src/main/java/geumjeongyahak/domain/request/v1/dto/request/CreateLessonExchangeRequestRequest.java
@@ -5,13 +5,14 @@ import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record CreateLessonExchangeRequestRequest(
 
     @NotNull
-    @Schema(description = "교환 대상 하루 일정 ID. 해당 DailySchedule에 연결된 수업 전체를 하루 단위로 교환 요청합니다.", example = "1")
-    Long dailyScheduleId,
+    @Schema(description = "교환 대상 수업일. 로그인 사용자의 해당 날짜 DailySchedule에 연결된 수업 전체를 하루 단위로 교환 요청합니다.", example = "2026-06-10")
+    LocalDate lessonDate,
 
     @NotBlank
     @Schema(description = "요청 제목", example = "수업 교환 요청")

--- a/src/main/java/geumjeongyahak/domain/request/v1/dto/request/UpdateLessonExchangeProposalRequest.java
+++ b/src/main/java/geumjeongyahak/domain/request/v1/dto/request/UpdateLessonExchangeProposalRequest.java
@@ -2,11 +2,12 @@ package geumjeongyahak.domain.request.v1.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDate;
 
 public record UpdateLessonExchangeProposalRequest(
 
-    @Schema(description = "제안 하루 일정 ID. 입력하면 교환형(EXCHANGE), 생략하면 대체형(SUBSTITUTION)으로 처리됩니다.", example = "2")
-    Long dailyScheduleId,
+    @Schema(description = "제안 수업일. 입력하면 로그인 사용자의 해당 날짜 DailySchedule을 내놓는 교환형(EXCHANGE), 생략하면 대체형(SUBSTITUTION)으로 처리됩니다.", example = "2026-06-11")
+    LocalDate lessonDate,
 
     @NotBlank
     @Schema(description = "제안 내용", example = "해당 날짜 수업으로 교환 가능합니다.")

--- a/src/main/java/geumjeongyahak/domain/request/v1/dto/request/UpdateLessonExchangeRequestRequest.java
+++ b/src/main/java/geumjeongyahak/domain/request/v1/dto/request/UpdateLessonExchangeRequestRequest.java
@@ -5,13 +5,14 @@ import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record UpdateLessonExchangeRequestRequest(
 
     @NotNull
-    @Schema(description = "교환 대상 하루 일정 ID. 해당 DailySchedule에 연결된 수업 전체를 하루 단위로 교환 요청합니다.", example = "1")
-    Long dailyScheduleId,
+    @Schema(description = "교환 대상 수업일. 로그인 사용자의 해당 날짜 DailySchedule에 연결된 수업 전체를 하루 단위로 교환 요청합니다.", example = "2026-06-10")
+    LocalDate lessonDate,
 
     @NotBlank
     @Schema(description = "요청 제목", example = "수업 교환 요청 수정")

--- a/src/test/java/geumjeongyahak/e2e/request/RequestBaseTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/RequestBaseTest.java
@@ -83,12 +83,12 @@ public abstract class RequestBaseTest extends BaseE2ETest {
     }
 
     protected Long createAbsenceRequest(String authHeader, Long lessonId, String title, String reason) {
-        Long dailyScheduleId = getDailyScheduleIdByLessonId(lessonId);
+        String lessonDate = lessonHelper.getLessonDate(getAuthHeader(adminToken), lessonId);
         return given()
             .basePath("/api/v1/absence-requests")
             .header(AUTH_HEADER, authHeader)
             .contentType(ContentType.JSON)
-            .body(Map.of("dailyScheduleId", dailyScheduleId, "title", title, "reason", reason))
+            .body(Map.of("lessonDate", lessonDate, "title", title, "reason", reason))
             .post()
             .then()
             .statusCode(201)

--- a/src/test/java/geumjeongyahak/e2e/request/RequestBaseTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/RequestBaseTest.java
@@ -144,12 +144,8 @@ public abstract class RequestBaseTest extends BaseE2ETest {
         String content,
         LocalDateTime expiresAt
     ) {
-        Long dailyScheduleId = dailyScheduleRepository
-            .findByClassroomIdAndLessonDateAndIsDeletedFalse(CLASSROOM_ID, lessonDate)
-            .orElseThrow()
-            .getId();
         Map<String, Object> body = new LinkedHashMap<>();
-        body.put("dailyScheduleId", dailyScheduleId);
+        body.put("lessonDate", lessonDate.toString());
         body.put("title", title);
         body.put("content", content);
         body.put("expiresAt", expiresAt.toString());

--- a/src/test/java/geumjeongyahak/e2e/request/absence/AbsenceRequestCreateTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/absence/AbsenceRequestCreateTest.java
@@ -107,8 +107,8 @@ class AbsenceRequestCreateTest extends RequestBaseTest {
     }
 
     @Test
-    @DisplayName("관리자가 타인 담당 수업으로 결석 요청 생성 → 403")
-    void createAbsenceRequest_asAdminForOthersLesson_returns403() {
+    @DisplayName("관리자가 본인 담당 DailySchedule이 없는 수업일로 결석 요청 생성 → 404")
+    void createAbsenceRequest_asAdminForOthersLessonDate_returns404() {
         createdSubjectId = lessonHelper.createSubjectAndGetId(
             getAuthHeader(adminToken), CLASSROOM_ID, TEACHER_ID);
         createdLessonId = lessonHelper.createLessonAndGetId(
@@ -121,7 +121,7 @@ class AbsenceRequestCreateTest extends RequestBaseTest {
             .body(absenceRequestBody(createdLessonId, "관리자 대리 결석", "관리자 대리 요청"))
             .post()
             .then()
-            .statusCode(403);
+            .statusCode(404);
     }
 
     // ── 인증 오류 ─────────────────────────────────────────
@@ -132,7 +132,7 @@ class AbsenceRequestCreateTest extends RequestBaseTest {
         given()
             .basePath("/api/v1/absence-requests")
             .contentType(ContentType.JSON)
-            .body(Map.of("dailyScheduleId", 1, "title", "결석 요청", "reason", "사유"))
+            .body(Map.of("lessonDate", LocalDate.now().plusDays(7).toString(), "title", "결석 요청", "reason", "사유"))
             .post()
             .then()
             .statusCode(401);
@@ -145,7 +145,7 @@ class AbsenceRequestCreateTest extends RequestBaseTest {
             .basePath("/api/v1/absence-requests")
             .header(AUTH_HEADER, getAuthHeader(guestToken))
             .contentType(ContentType.JSON)
-            .body(Map.of("dailyScheduleId", 1, "title", "결석 요청", "reason", "사유"))
+            .body(Map.of("lessonDate", LocalDate.now().plusDays(7).toString(), "title", "결석 요청", "reason", "사유"))
             .post()
             .then()
             .statusCode(403);
@@ -154,13 +154,13 @@ class AbsenceRequestCreateTest extends RequestBaseTest {
     // ── 도메인 오류 ───────────────────────────────────────
 
     @Test
-    @DisplayName("존재하지 않는 하루 일정 ID로 결석 요청 → 404")
-    void createAbsenceRequest_nonExistentDailySchedule_returns404() {
+    @DisplayName("담당 DailySchedule이 없는 수업일로 결석 요청 → 404")
+    void createAbsenceRequest_nonExistentLessonDate_returns404() {
         given()
             .basePath("/api/v1/absence-requests")
             .header(AUTH_HEADER, getAuthHeader(volunteerToken))
             .contentType(ContentType.JSON)
-            .body(Map.of("dailyScheduleId", 99999L, "title", "결석 요청", "reason", "사유"))
+            .body(Map.of("lessonDate", LocalDate.now().plusYears(10).toString(), "title", "결석 요청", "reason", "사유"))
             .post()
             .then()
             .statusCode(404);
@@ -192,8 +192,8 @@ class AbsenceRequestCreateTest extends RequestBaseTest {
     }
 
     @Test
-    @DisplayName("타인 담당 수업으로 결석 요청 생성 → 403")
-    void createAbsenceRequest_forOthersLesson_returns403() {
+    @DisplayName("본인 담당 DailySchedule이 없는 수업일로 결석 요청 생성 → 404")
+    void createAbsenceRequest_forOthersLessonDate_returns404() {
         createdSubjectId = lessonHelper.createSubjectAndGetId(
             getAuthHeader(adminToken), CLASSROOM_ID, TEACHER_ID);
         createdLessonId = lessonHelper.createLessonAndGetId(
@@ -206,7 +206,7 @@ class AbsenceRequestCreateTest extends RequestBaseTest {
             .body(absenceRequestBody(createdLessonId, "타인 수업 결석", "타인 수업 결석 요청"))
             .post()
             .then()
-            .statusCode(403);
+            .statusCode(404);
     }
 
     @Test
@@ -329,7 +329,7 @@ class AbsenceRequestCreateTest extends RequestBaseTest {
             .basePath("/api/v1/absence-requests")
             .header(AUTH_HEADER, getAuthHeader(volunteerToken))
             .contentType(ContentType.JSON)
-            .body(Map.of("dailyScheduleId", 1, "title", "결석 요청", "reason", ""))
+            .body(Map.of("lessonDate", LocalDate.now().plusDays(7).toString(), "title", "결석 요청", "reason", ""))
             .post()
             .then()
             .statusCode(400);
@@ -342,15 +342,15 @@ class AbsenceRequestCreateTest extends RequestBaseTest {
             .basePath("/api/v1/absence-requests")
             .header(AUTH_HEADER, getAuthHeader(volunteerToken))
             .contentType(ContentType.JSON)
-            .body(Map.of("dailyScheduleId", 1, "title", "", "reason", "사유"))
+            .body(Map.of("lessonDate", LocalDate.now().plusDays(7).toString(), "title", "", "reason", "사유"))
             .post()
             .then()
             .statusCode(400);
     }
 
     @Test
-    @DisplayName("dailyScheduleId 가 null → 400")
-    void createAbsenceRequest_nullDailyScheduleId_returns400() {
+    @DisplayName("lessonDate 가 null → 400")
+    void createAbsenceRequest_nullLessonDate_returns400() {
         given()
             .basePath("/api/v1/absence-requests")
             .header(AUTH_HEADER, getAuthHeader(volunteerToken))
@@ -366,6 +366,13 @@ class AbsenceRequestCreateTest extends RequestBaseTest {
     }
 
     private Map<String, Object> absenceRequestBody(Long lessonId, String title, String reason) {
-        return Map.of("dailyScheduleId", getDailyScheduleIdByLessonId(lessonId), "title", title, "reason", reason);
+        return Map.of(
+            "lessonDate",
+            lessonHelper.getLessonDate(getAuthHeader(adminToken), lessonId),
+            "title",
+            title,
+            "reason",
+            reason
+        );
     }
 }

--- a/src/test/java/geumjeongyahak/e2e/request/lessonexchange/LessonExchangeProposalAcceptTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/lessonexchange/LessonExchangeProposalAcceptTest.java
@@ -73,7 +73,7 @@ class LessonExchangeProposalAcceptTest extends RequestBaseTest {
             requestId,
             getAuthHeader(volunteer2Token),
             Map.of(
-                "dailyScheduleId", getDailyScheduleIdByLessonDate(proposalDate),
+                "lessonDate", proposalDate.toString(),
                 "content", "교환 제안"
             )
         );
@@ -242,7 +242,7 @@ class LessonExchangeProposalAcceptTest extends RequestBaseTest {
             requestId,
             getAuthHeader(volunteer2Token),
             Map.of(
-                "dailyScheduleId", getDailyScheduleIdByLessonDate(proposalDate),
+                "lessonDate", proposalDate.toString(),
                 "content", "교시 수가 다른 교환 제안"
             )
         );

--- a/src/test/java/geumjeongyahak/e2e/request/lessonexchange/LessonExchangeProposalCreateTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/lessonexchange/LessonExchangeProposalCreateTest.java
@@ -68,7 +68,7 @@ class LessonExchangeProposalCreateTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(volunteer2Token))
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", getDailyScheduleIdByLessonDate(proposalDate),
+                "lessonDate", proposalDate.toString(),
                 "content", "다음 날 수업으로 교환 가능합니다."
             ))
             .post("/{requestId}/proposals", requestId)
@@ -117,8 +117,8 @@ class LessonExchangeProposalCreateTest extends RequestBaseTest {
     }
 
     @Test
-    @DisplayName("요청과 같은 날짜의 교환형 제안 생성 -> 400")
-    void createExchangeProposal_sameDate_returns400() {
+    @DisplayName("요청과 같은 날짜에 본인 DailySchedule이 없으면 교환형 제안 생성 -> 404")
+    void createExchangeProposal_sameDateWithoutOwnDailySchedule_returns404() {
         LocalDate requestDate = LocalDate.now().plusDays(8);
         Long requestId = createApprovedRequest(requestDate);
 
@@ -130,12 +130,12 @@ class LessonExchangeProposalCreateTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(volunteer2Token))
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", getDailyScheduleIdByLessonDate(requestDate),
+                "lessonDate", requestDate.toString(),
                 "content", "같은 날짜 수업으로 교환 가능합니다."
             ))
             .post("/{requestId}/proposals", requestId)
             .then()
-            .statusCode(400);
+            .statusCode(404);
     }
 
     @Test
@@ -229,7 +229,7 @@ class LessonExchangeProposalCreateTest extends RequestBaseTest {
         Long proposalId = createProposal(
             requestId,
             getAuthHeader(volunteer2Token),
-            Map.of("dailyScheduleId", getDailyScheduleIdByLessonDate(proposalDate), "content", "첫 제안")
+            Map.of("lessonDate", proposalDate.toString(), "content", "첫 제안")
         );
         proposalIds.add(proposalId);
 
@@ -237,7 +237,7 @@ class LessonExchangeProposalCreateTest extends RequestBaseTest {
             .basePath("/api/v1/lesson-exchange-requests")
             .header(AUTH_HEADER, getAuthHeader(volunteer2Token))
             .contentType(ContentType.JSON)
-            .body(Map.of("dailyScheduleId", getDailyScheduleIdByLessonDate(proposalDate), "content", "중복 제안"))
+            .body(Map.of("lessonDate", proposalDate.toString(), "content", "중복 제안"))
             .post("/{requestId}/proposals", requestId)
             .then()
             .statusCode(409);
@@ -280,15 +280,15 @@ class LessonExchangeProposalCreateTest extends RequestBaseTest {
             .basePath("/api/v1/lesson-exchange-requests")
             .header(AUTH_HEADER, getAuthHeader(volunteer2Token))
             .contentType(ContentType.JSON)
-            .body(Map.of("dailyScheduleId", 99999L))
+            .body(Map.of("lessonDate", LocalDate.now().plusDays(13).toString()))
             .post("/{requestId}/proposals", requestId)
             .then()
             .statusCode(400);
     }
 
     @Test
-    @DisplayName("존재하지 않는 DailySchedule으로 교환형 제안 생성 -> 404")
-    void createProposal_withoutDailySchedule_returns404() {
+    @DisplayName("본인 DailySchedule이 없는 수업일로 교환형 제안 생성 -> 404")
+    void createProposal_withoutOwnDailySchedule_returns404() {
         Long requestId = createApprovedRequest(LocalDate.now().plusDays(15));
 
         given()
@@ -296,44 +296,12 @@ class LessonExchangeProposalCreateTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(volunteer2Token))
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", 99999L,
+                "lessonDate", LocalDate.now().plusYears(10).toString(),
                 "content", "해당 날짜 수업 없음"
             ))
             .post("/{requestId}/proposals", requestId)
             .then()
             .statusCode(404);
-    }
-
-    @Test
-    @DisplayName("다른 반 DailySchedule으로 교환형 제안 생성 -> 201")
-    void createProposal_withAnotherClassroomDailySchedule_returns201() {
-        LocalDate requestDate = LocalDate.now().plusDays(16);
-        LocalDate proposalDate = LocalDate.now().plusDays(17);
-        Long requestId = createApprovedRequest(requestDate);
-
-        Long subjectId1 = registerSubject(CLASSROOM_ID, TEACHER2_ID);
-        Long subjectId2 = registerSubject(2L, TEACHER2_ID);
-        registerLesson(subjectId1, TEACHER2_ID, proposalDate, "09:00:00", "09:50:00", 1);
-        registerLesson(subjectId2, TEACHER2_ID, proposalDate, "10:00:00", "10:50:00", 2);
-        Long dailyScheduleId = getDailyScheduleIdByClassroomAndLessonDate(2L, proposalDate);
-
-        Long proposalId = given()
-            .basePath("/api/v1/lesson-exchange-requests")
-            .header(AUTH_HEADER, getAuthHeader(volunteer2Token))
-            .contentType(ContentType.JSON)
-            .body(Map.of(
-                "dailyScheduleId", dailyScheduleId,
-                "content", "다른 반 DailySchedule을 선택한 교환 제안"
-            ))
-            .post("/{requestId}/proposals", requestId)
-            .then()
-            .statusCode(201)
-            .body("dailyScheduleId", equalTo(dailyScheduleId.intValue()))
-            .extract()
-            .jsonPath()
-            .getLong("id");
-
-        proposalIds.add(proposalId);
     }
 
     private Long createApprovedRequest(LocalDate lessonDate) {

--- a/src/test/java/geumjeongyahak/e2e/request/lessonexchange/LessonExchangeProposalReadTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/lessonexchange/LessonExchangeProposalReadTest.java
@@ -64,7 +64,7 @@ class LessonExchangeProposalReadTest extends RequestBaseTest {
             requestId,
             getAuthHeader(volunteer2Token),
             Map.of(
-                "dailyScheduleId", getDailyScheduleIdByLessonDate(proposalDate),
+                "lessonDate", proposalDate.toString(),
                 "content", "다음 날 전체 수업으로 교환 가능합니다."
             )
         );

--- a/src/test/java/geumjeongyahak/e2e/request/lessonexchange/LessonExchangeProposalUpdateTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/lessonexchange/LessonExchangeProposalUpdateTest.java
@@ -67,7 +67,7 @@ class LessonExchangeProposalUpdateTest extends RequestBaseTest {
         Long proposalId = createProposal(
             requestId,
             getAuthHeader(volunteer2Token),
-            Map.of("dailyScheduleId", getDailyScheduleIdByLessonDate(originalProposalDate), "content", "기존 제안 내용")
+            Map.of("lessonDate", originalProposalDate.toString(), "content", "기존 제안 내용")
         );
         proposalIds.add(proposalId);
 
@@ -76,7 +76,7 @@ class LessonExchangeProposalUpdateTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(volunteer2Token))
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", getDailyScheduleIdByLessonDate(updatedProposalDate),
+                "lessonDate", updatedProposalDate.toString(),
                 "content", "수정된 제안 내용"
             ))
             .patch("/{requestId}/proposals/{proposalId}", requestId, proposalId)
@@ -105,7 +105,7 @@ class LessonExchangeProposalUpdateTest extends RequestBaseTest {
         Long proposalId = createProposal(
             requestId,
             getAuthHeader(volunteer2Token),
-            Map.of("dailyScheduleId", getDailyScheduleIdByLessonDate(proposalDate), "content", "교환형 제안")
+            Map.of("lessonDate", proposalDate.toString(), "content", "교환형 제안")
         );
         proposalIds.add(proposalId);
 
@@ -148,7 +148,7 @@ class LessonExchangeProposalUpdateTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(volunteer2Token))
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", getDailyScheduleIdByLessonDate(proposalDate),
+                "lessonDate", proposalDate.toString(),
                 "content", "교환형 제안으로 수정"
             ))
             .patch("/{requestId}/proposals/{proposalId}", requestId, proposalId)
@@ -245,8 +245,8 @@ class LessonExchangeProposalUpdateTest extends RequestBaseTest {
     }
 
     @Test
-    @DisplayName("교환형 제안 수정 시 요청 날짜와 같으면 -> 400")
-    void updateProposal_sameDateWithRequest_returns400() {
+    @DisplayName("요청과 같은 날짜에 본인 DailySchedule이 없으면 교환형 제안 수정 -> 404")
+    void updateProposal_sameDateWithoutOwnDailySchedule_returns404() {
         LocalDate requestDate = LocalDate.now().plusDays(14);
         Long requestId = createApprovedRequest(requestDate);
 
@@ -258,7 +258,7 @@ class LessonExchangeProposalUpdateTest extends RequestBaseTest {
             requestId,
             getAuthHeader(volunteer2Token),
             Map.of(
-                "dailyScheduleId", getDailyScheduleIdByLessonDate(LocalDate.now().plusDays(15)),
+                "lessonDate", LocalDate.now().plusDays(15).toString(),
                 "content", "겹치지 않는 제안"
             )
         );
@@ -269,17 +269,17 @@ class LessonExchangeProposalUpdateTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(volunteer2Token))
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", getDailyScheduleIdByLessonDate(requestDate),
+                "lessonDate", requestDate.toString(),
                 "content", "같은 날짜 제안으로 수정"
             ))
             .patch("/{requestId}/proposals/{proposalId}", requestId, proposalId)
             .then()
-            .statusCode(400);
+            .statusCode(404);
     }
 
     @Test
-    @DisplayName("존재하지 않는 DailySchedule으로 교환형 제안 수정 -> 404")
-    void updateProposal_withoutDailySchedule_returns404() {
+    @DisplayName("본인 DailySchedule이 없는 수업일로 교환형 제안 수정 -> 404")
+    void updateProposal_withoutOwnDailySchedule_returns404() {
         Long requestId = createApprovedRequest(LocalDate.now().plusDays(15));
         Long proposalId = createProposal(
             requestId,
@@ -293,7 +293,7 @@ class LessonExchangeProposalUpdateTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(volunteer2Token))
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", 99999L,
+                "lessonDate", LocalDate.now().plusYears(10).toString(),
                 "content", "수업이 없는 날짜로 수정"
             ))
             .patch("/{requestId}/proposals/{proposalId}", requestId, proposalId)

--- a/src/test/java/geumjeongyahak/e2e/request/lessonexchange/LessonExchangeRequestCreateTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/lessonexchange/LessonExchangeRequestCreateTest.java
@@ -56,7 +56,7 @@ class LessonExchangeRequestCreateTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(volunteerToken))
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", getDailyScheduleIdByLessonDate(lessonDate),
+                "lessonDate", lessonDate.toString(),
                 "title", "하루 단위 교환 요청",
                 "content", "해당 날짜 수업 교환을 요청합니다.",
                 "expiresAt", lessonDate.minusDays(3).atTime(23, 0).toString()
@@ -90,7 +90,7 @@ class LessonExchangeRequestCreateTest extends RequestBaseTest {
             .basePath("/api/v1/lesson-exchange-requests")
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", 99999L,
+                "lessonDate", lessonDate.toString(),
                 "title", "제목",
                 "content", "내용",
                 "expiresAt", lessonDate.minusDays(3).atTime(23, 0).toString()
@@ -110,7 +110,7 @@ class LessonExchangeRequestCreateTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(guestToken))
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", 99999L,
+                "lessonDate", lessonDate.toString(),
                 "title", "게스트 요청",
                 "content", "게스트는 요청을 생성할 수 없습니다.",
                 "expiresAt", lessonDate.minusDays(3).atTime(23, 0).toString()
@@ -121,8 +121,8 @@ class LessonExchangeRequestCreateTest extends RequestBaseTest {
     }
 
     @Test
-    @DisplayName("요청자 본인 수업이 없는 날짜로 생성 시도 -> 403")
-    void createRequest_withoutOwnLessons_returns403() {
+    @DisplayName("요청자 본인 DailySchedule이 없는 날짜로 생성 시도 -> 404")
+    void createRequest_withoutOwnDailySchedule_returns404() {
         LocalDate lessonDate = LocalDate.now().plusDays(5);
         Long subjectId = registerSubject(CLASSROOM_ID, TEACHER2_ID);
         registerLesson(subjectId, TEACHER2_ID, lessonDate, "09:00:00", "10:00:00", 1);
@@ -132,14 +132,14 @@ class LessonExchangeRequestCreateTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(volunteerToken))
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", getDailyScheduleIdByLessonDate(lessonDate),
+                "lessonDate", lessonDate.toString(),
                 "title", "타인 수업 요청",
                 "content", "내 수업이 아닌 일정으로 요청",
                 "expiresAt", lessonDate.minusDays(3).atTime(23, 0).toString()
             ))
             .post()
             .then()
-            .statusCode(403);
+            .statusCode(404);
     }
 
     @Test
@@ -163,7 +163,7 @@ class LessonExchangeRequestCreateTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(volunteerToken))
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", getDailyScheduleIdByLessonDate(lessonDate),
+                "lessonDate", lessonDate.toString(),
                 "title", "두 번째 요청",
                 "content", "중복 생성 시도",
                 "expiresAt", lessonDate.minusDays(3).atTime(21, 0).toString()
@@ -183,7 +183,7 @@ class LessonExchangeRequestCreateTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(volunteerToken))
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", 99999L,
+                "lessonDate", lessonDate.toString(),
                 "title", "",
                 "content", "내용",
                 "expiresAt", lessonDate.minusDays(3).atTime(23, 0).toString()
@@ -205,7 +205,7 @@ class LessonExchangeRequestCreateTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(volunteerToken))
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", getDailyScheduleIdByLessonDate(lessonDate),
+                "lessonDate", lessonDate.toString(),
                 "title", "만료 정책 위반",
                 "content", "너무 늦은 만료 시각",
                 "expiresAt", lessonDate.minusDays(2).atTime(12, 0).toString()
@@ -227,7 +227,7 @@ class LessonExchangeRequestCreateTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(volunteerToken))
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", getDailyScheduleIdByLessonDate(lessonDate),
+                "lessonDate", lessonDate.toString(),
                 "title", "경계 날짜 요청",
                 "content", "요청 가능 시작일 경계 테스트",
                 "expiresAt", lessonDate.minusDays(3).atTime(23, 59, 59).toString()
@@ -254,7 +254,7 @@ class LessonExchangeRequestCreateTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(volunteerToken))
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", getDailyScheduleIdByLessonDate(lessonDate),
+                "lessonDate", lessonDate.toString(),
                 "title", "정책 이전 날짜 요청",
                 "content", "요청 가능 시작일보다 이른 날짜",
                 "expiresAt", lessonDate.minusDays(2).atTime(23, 59, 59).toString()
@@ -276,7 +276,7 @@ class LessonExchangeRequestCreateTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(volunteerToken))
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", getDailyScheduleIdByLessonDate(lessonDate),
+                "lessonDate", lessonDate.toString(),
                 "title", "만료 경계 허용",
                 "content", "정책 상한 시각과 같은 만료 시각",
                 "expiresAt", lessonDate.minusDays(3).atTime(23, 59, 59).toString()
@@ -303,7 +303,7 @@ class LessonExchangeRequestCreateTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(volunteerToken))
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", getDailyScheduleIdByLessonDate(lessonDate),
+                "lessonDate", lessonDate.toString(),
                 "title", "수업일 경계 만료",
                 "content", "수업일 자정과 같은 만료 시각",
                 "expiresAt", lessonDate.atStartOfDay().toString()
@@ -335,7 +335,7 @@ class LessonExchangeRequestCreateTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(volunteerToken))
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", getDailyScheduleIdByLessonDate(lessonDate),
+                "lessonDate", lessonDate.toString(),
                 "title", "재요청",
                 "content", "반려 후 같은 날짜 재요청",
                 "expiresAt", lessonDate.minusDays(3).atTime(21, 0).toString()
@@ -372,7 +372,7 @@ class LessonExchangeRequestCreateTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(volunteerToken))
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", getDailyScheduleIdByLessonDate(lessonDate),
+                "lessonDate", lessonDate.toString(),
                 "title", "완료 후 재요청",
                 "content", "완료된 요청 이후 새 요청 생성",
                 "expiresAt", lessonDate.minusDays(3).atTime(21, 0).toString()
@@ -409,7 +409,7 @@ class LessonExchangeRequestCreateTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(volunteerToken))
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", getDailyScheduleIdByLessonDate(lessonDate),
+                "lessonDate", lessonDate.toString(),
                 "title", "취소 후 재요청",
                 "content", "취소된 요청 이후 새 요청 생성",
                 "expiresAt", lessonDate.minusDays(3).atTime(21, 0).toString()

--- a/src/test/java/geumjeongyahak/e2e/request/lessonexchange/LessonExchangeRequestUpdateTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/lessonexchange/LessonExchangeRequestUpdateTest.java
@@ -149,8 +149,8 @@ class LessonExchangeRequestUpdateTest extends RequestBaseTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 DailySchedule로 수정하면 -> 404")
-    void updateRequest_toMissingDailySchedule_returns404() {
+    @DisplayName("본인 DailySchedule이 없는 수업일로 수정하면 -> 404")
+    void updateRequest_toMissingLessonDate_returns404() {
         LocalDate lessonDate = LocalDate.now().plusDays(13);
         LocalDate emptyDate = LocalDate.now().plusDays(14);
         createLessons(TEACHER_ID, lessonDate, 1);
@@ -169,7 +169,7 @@ class LessonExchangeRequestUpdateTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(volunteerToken))
             .contentType(ContentType.JSON)
             .body(Map.of(
-                "dailyScheduleId", 99999L,
+                "lessonDate", emptyDate.toString(),
                 "title", "수업 없는 날짜로 수정",
                 "content", "수업이 없는 날짜",
                 "expiresAt", emptyDate.minusDays(3).atTime(21, 0).toString()


### PR DESCRIPTION
## 개요

요청 API에서 클라이언트가 `dailyScheduleId`를 직접 전달하던 입력 구조를 `lessonDate` 기반으로 변경했습니다.

화면에서는 사용자가 DailySchedule ID를 알기 어렵기 때문에, 결강 신청 / 수업 교환 신청 / 수업 교환 제안 모두 수업일을 입력받고 백엔드에서 로그인 사용자와 수업일을 기준으로 대상 DailySchedule을 조회하도록 정리했습니다.

## 변경 유형

- [x] 새 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 문서 수정 (docs)
- [x] 테스트 (test)
- [ ] 기타 (chore)

## 변경 내용

- DailySchedule 조회 기반을 추가했습니다.
  - `DailyScheduleProxyService`에 교사 ID와 수업일 기준 활성 DailySchedule 조회 메서드를 추가했습니다.
  - 한 교사는 같은 날짜에 하나의 DailySchedule만 가진다는 정책을 전제로 사용합니다.

- 결강 신청 생성 API 입력을 `lessonDate` 기준으로 변경했습니다.
  - `CreateAbsenceRequestRequest`의 `dailyScheduleId`를 제거하고 `lessonDate`를 추가했습니다.
  - 서비스에서 로그인 사용자 ID와 `lessonDate`로 대상 DailySchedule을 조회하도록 변경했습니다.
  - 대상 날짜에 로그인 사용자의 DailySchedule이 없으면 404로 처리합니다.
  - 결강 신청 생성 E2E 테스트를 `lessonDate` 입력 기준으로 갱신했습니다.

- 수업 교환 신청 생성/수정 API 입력을 `lessonDate` 기준으로 변경했습니다.
  - `CreateLessonExchangeRequestRequest`, `UpdateLessonExchangeRequestRequest`의 `dailyScheduleId`를 제거하고 `lessonDate`를 추가했습니다.
  - 서비스에서 로그인 사용자 ID와 `lessonDate`로 교환 대상 DailySchedule을 조회하도록 변경했습니다.
  - 기존 중복 요청 검증, 요청 가능일 검증, 만료 시각 정책 검증은 유지했습니다.
  - 수업 교환 신청 생성/수정 E2E 테스트와 공통 헬퍼를 `lessonDate` 입력 기준으로 갱신했습니다.

- 수업 교환 제안 생성/수정 API 입력을 `lessonDate` 기준으로 변경했습니다.
  - `CreateLessonExchangeProposalRequest`, `UpdateLessonExchangeProposalRequest`의 `dailyScheduleId`를 제거하고 nullable `lessonDate`를 추가했습니다.
  - `lessonDate`가 있으면 교환형(`EXCHANGE`), 없으면 대체형(`SUBSTITUTION`)으로 판단하도록 변경했습니다.
  - 교환형 제안은 로그인 사용자 ID와 `lessonDate`로 제안 대상 DailySchedule을 조회하도록 변경했습니다.
  - 교환형 제안이 요청 수업일과 같은 날짜가 되지 않도록 날짜 기준 검증을 보강했습니다.
  - `dailyScheduleId` 직접 선택으로만 가능했던 테스트 시나리오는 제거하고, `lessonDate` 입력 정책에 맞게 E2E 테스트를 갱신했습니다.

- 문서와 Swagger 설명을 최신화했습니다.
  - 요청 DTO의 Swagger 설명을 `lessonDate` 기준으로 수정했습니다.
  - `docs/api/Requests.md`에서 결강 신청, 수업 교환 신청, 수업 교환 제안의 요청 예시를 `lessonDate` 기준으로 갱신했습니다.
  - 응답 DTO의 `dailyScheduleId`는 실제 연결된 DailySchedule 식별자로 유지된다는 점을 문서에 반영했습니다.

## 관련 이슈

Closes #81

## 스크린샷 (선택)



## 체크리스트

- [x] 코드 컨벤션을 준수했습니다
- [x] 테스트 코드를 작성/수정했습니다
- [ ] 머지 전 `./gradlew test`가 통과합니다
- [x] 문서를 업데이트했습니다 (필요한 경우)

## 리뷰어에게