### PR TITLE
[FEAT] 수업 일지 작성 API 입력 기준 변경 및 API 정리

### DIFF
--- a/docs/api/DailySchedules.md
+++ b/docs/api/DailySchedules.md
@@ -13,7 +13,9 @@ DailySchedule은 같은 분반과 같은 날짜의 Lesson들을 하루 단위로
 | `GET /api/v1/daily-schedules` | `VOLUNTEER`, `MANAGER`, `ADMIN` |
 | `GET /api/v1/daily-schedules/{dailyScheduleId}` | `VOLUNTEER`, `MANAGER`, `ADMIN` |
 | `GET /api/v1/daily-schedules/volunteer-hours` | `VOLUNTEER`, `MANAGER`, `ADMIN` |
-| `PUT /api/v1/daily-schedules/{dailyScheduleId}/journal` | 담당 교사, `ADMIN`, `daily-schedule:manage:*` |
+| `POST /api/v1/daily-schedules/journal` | 담당 교사, `ADMIN`, `daily-schedule:manage:*` |
+| `PATCH /api/v1/daily-schedules/{dailyScheduleId}/journal` | 담당 교사, `ADMIN`, `daily-schedule:manage:*` |
+| `DELETE /api/v1/daily-schedules/{dailyScheduleId}/journal` | 담당 교사, `ADMIN`, `daily-schedule:manage:*` |
 | `PATCH /api/v1/daily-schedules/{dailyScheduleId}/student-attendances` | 담당 교사, `ADMIN`, `daily-schedule:manage:*` |
 | `PATCH /api/v1/daily-schedules/{dailyScheduleId}/teacher-attendance` | 담당 교사, `ADMIN`, `daily-schedule:manage:*` |
 | `PATCH /api/v1/daily-schedules/{dailyScheduleId}/status` | `ADMIN`, `daily-schedule:manage:*` |
@@ -37,57 +39,93 @@ DailySchedule 도메인은 다음 권한 코드를 사용합니다.
 
 ## 조회 정책
 
-- 목록 조회는 `from`, `to` 기간 필터를 필수로 사용합니다.
-- 기간은 시작일과 종료일을 모두 포함합니다.
-- 목록은 수업 날짜 오름차순, ID 오름차순으로 정렬됩니다.
-- `classroomId`, `teacherId`, `status`로 목록을 추가 필터링할 수 있습니다.
+- `GET /api/v1/daily-schedules`는 수업 일지 목록 화면에서 사용하는 페이지 조회 API입니다.
+- 목록에는 작성된 수업 일지만 포함됩니다. 연결된 활성 Lesson note 중 하나라도 작성되어 있으면 작성된 수업 일지로 판단합니다.
+- 목록은 수업 날짜 내림차순, ID 내림차순으로 정렬됩니다.
+- `keyword`로 분반명, 담당 교사명, 과목명, 수업 일지 내용을 검색할 수 있습니다.
+- `mine=true`이면 로그인 사용자가 담당 교사인 수업 일지만 조회합니다.
+- `page`, `size`로 페이지를 지정합니다. 기본값은 `page=0`, `size=10`입니다.
 - 삭제된 DailySchedule, DailyTeacherAttendance, DailyStudentAttendance는 조회와 집계에서 제외됩니다.
 - 상세 조회는 DailySchedule에 연결된 Lesson 목록, 교사 출석, 학생 출석부를 함께 반환합니다.
 
 예시:
 
 ```http
-GET /api/v1/daily-schedules?from=2026-06-01&to=2026-06-30&classroomId=1
+GET /api/v1/daily-schedules?keyword=수학&mine=true&page=0&size=8
 ```
 
 ```json
-[
-  {
-    "dailyScheduleId": 1,
-    "lessonDate": "2026-06-20",
-    "classroomId": 1,
-    "classroomName": "장미반",
-    "teacherId": 2,
-    "teacherName": "홍길동",
-    "activityStartTime": "14:00:00",
-    "activityEndTime": "16:00:00",
-    "volunteerServiceMinutes": 120,
-    "status": "SCHEDULED",
-    "teacherAttendanceStatus": "ABSENT",
-    "lessonCount": 3
-  }
-]
+{
+  "content": [
+    {
+      "dailyScheduleId": 1,
+      "lessonDate": "2026-06-20",
+      "classroomId": 1,
+      "classroomName": "장미반",
+      "teacherId": 2,
+      "teacherName": "홍길동",
+      "activityStartTime": "14:00:00",
+      "activityEndTime": "16:00:00",
+      "volunteerServiceMinutes": 120,
+      "status": "SCHEDULED",
+      "teacherAttendanceStatus": "ABSENT",
+      "lessonCount": 3,
+      "lessons": [
+        {
+          "lessonId": 11,
+          "period": 1,
+          "startTime": "14:00:00",
+          "endTime": "14:40:00",
+          "subjectName": "수학",
+          "note": "1교시에는 분수 덧셈을 복습했습니다."
+        },
+        {
+          "lessonId": 12,
+          "period": 2,
+          "startTime": "14:50:00",
+          "endTime": "15:30:00",
+          "subjectName": "수학",
+          "note": "2교시에는 문장제 풀이를 진행했습니다."
+        }
+      ]
+    }
+  ],
+  "page": 0,
+  "size": 8,
+  "totalElements": 1,
+  "totalPages": 1
+}
 ```
 
 ## 수업 일지 정책
 
-- 수업 일지는 DailySchedule에 연결된 교시별 Lesson note를 한 번에 저장합니다.
+- 수업 일지는 DailySchedule에 연결된 교시별 Lesson note를 한 번에 작성하거나 수정합니다.
+- 최초 작성은 `lessonDate`, `classroomId` 기준으로 DailySchedule을 조회해 처리합니다.
+- 수정과 삭제는 `dailyScheduleId` 기준으로 처리합니다.
 - 요청에 포함된 `lessonId`는 해당 DailySchedule과 같은 분반, 같은 날짜의 활성 Lesson이어야 합니다.
+- 생성/수정 요청에는 해당 DailySchedule에 연결된 모든 활성 Lesson의 `lessonId`와 `note`가 포함되어야 합니다.
 - 수업 일지 내용은 공백일 수 없습니다.
 - 개인정보 활용 동의가 `true`이면 주민번호 앞자리 6자리를 함께 입력해야 합니다.
 - 개인정보 활용 동의가 `false`이면 주민번호 앞자리를 입력할 수 없습니다.
 - `CANCELLED` 상태의 DailySchedule에는 수업 일지를 저장할 수 없습니다.
 - `COMPLETED` 상태에서도 잘못 작성한 수업 일지는 수정할 수 있습니다.
+- 이미 작성된 수업 일지가 있는 DailySchedule에 생성 API를 호출하면 `409 Conflict`를 반환합니다.
+- 수업 일지 삭제는 DailySchedule 자체 삭제가 아니라 연결된 Lesson note와 개인정보 입력값을 초기화합니다.
+- 수업 일지 삭제 시 교사 출석과 학생 출석부는 유지합니다.
+- 수업 일지 삭제 후 같은 `lessonDate`, `classroomId`로 다시 생성할 수 있습니다.
+- 삭제 대상이 `COMPLETED` 상태였다면 DailySchedule과 연결된 Lesson 상태를 `SCHEDULED`로 되돌립니다.
 
-요청:
+최초 작성 요청:
 
 ```http
-PUT /api/v1/daily-schedules/1/journal
+POST /api/v1/daily-schedules/journal
 Content-Type: application/json
 ```
 
 ```json
 {
+  "lessonDate": "2026-06-20",
+  "classroomId": 1,
   "personalInfoConsent": true,
   "residentRegistrationNumberPrefix": "900101",
   "lessonJournals": [
@@ -102,6 +140,38 @@ Content-Type: application/json
   ]
 }
 ```
+
+수정 요청:
+
+```http
+PATCH /api/v1/daily-schedules/1/journal
+Content-Type: application/json
+```
+
+```json
+{
+  "personalInfoConsent": true,
+  "residentRegistrationNumberPrefix": "900101",
+  "lessonJournals": [
+    {
+      "lessonId": 11,
+      "note": "1교시에는 국어 읽기 활동 내용을 수정했습니다."
+    },
+    {
+      "lessonId": 12,
+      "note": "2교시에는 받아쓰기 활동 내용을 수정했습니다."
+    }
+  ]
+}
+```
+
+삭제 요청:
+
+```http
+DELETE /api/v1/daily-schedules/1/journal
+```
+
+성공 시 `204 No Content`를 반환합니다.
 
 ## 출석 정책
 
@@ -201,7 +271,9 @@ GET /api/v1/daily-schedules/volunteer-hours
 | 다른 교사의 민감 정보 또는 봉사 시간 조회 권한 없음 | `403 Forbidden` |
 | 담당자가 아닌 사용자가 수업 일지/출석 변경 시도 | `403 Forbidden` |
 | 존재하지 않거나 삭제된 DailySchedule 접근 | `404 Not Found` |
+| 이미 작성된 수업 일지 생성 시도 | `409 Conflict` |
 | DailySchedule에 연결되지 않은 Lesson으로 수업 일지 저장 | `400 Bad Request` |
+| 수업 일지 생성/수정 요청에 일부 교시가 누락됨 | `400 Bad Request` |
 | DailySchedule에 연결되지 않은 학생으로 출석 처리 | `400 Bad Request` |
 | 학생 출석 요청에 같은 학생이 중복됨 | `400 Bad Request` |
 | 휴강 상태에서 수업 일지 또는 출석 처리 시도 | `400 Bad Request` |

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/exception/DailyScheduleErrorCode.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/exception/DailyScheduleErrorCode.java
@@ -10,12 +10,14 @@ import org.springframework.http.HttpStatus;
 public enum DailyScheduleErrorCode implements ErrorCode {
     DAILY_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "RES-11-001", "하루 일정을 찾을 수 없습니다."),
     DAILY_SCHEDULE_FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH-11-001", "하루 일정에 접근할 권한이 없습니다."),
+    DAILY_SCHEDULE_JOURNAL_ALREADY_EXISTS(HttpStatus.CONFLICT, "BIZ-11-001", "이미 작성된 수업 일지가 있습니다."),
     LESSON_NOT_IN_DAILY_SCHEDULE(HttpStatus.BAD_REQUEST, "VAL-11-001", "하루 일정에 연결되지 않은 수업입니다."),
     INVALID_DAILY_SCHEDULE_JOURNAL_STATE(HttpStatus.BAD_REQUEST, "VAL-11-002", "수업 일지를 저장할 수 없는 하루 일정 상태입니다."),
     INVALID_DAILY_SCHEDULE_PERSONAL_INFO(HttpStatus.BAD_REQUEST, "VAL-11-003", "수업 일지 개인정보 입력값이 유효하지 않습니다."),
     STUDENT_NOT_IN_DAILY_SCHEDULE(HttpStatus.BAD_REQUEST, "VAL-11-004", "하루 일정에 연결되지 않은 학생입니다."),
     INVALID_DAILY_SCHEDULE_ATTENDANCE_STATE(HttpStatus.BAD_REQUEST, "VAL-11-005", "출석을 처리할 수 없는 하루 일정 상태입니다."),
-    DUPLICATE_DAILY_STUDENT_ATTENDANCE(HttpStatus.BAD_REQUEST, "VAL-11-006", "중복된 학생 출석 요청입니다.");
+    DUPLICATE_DAILY_STUDENT_ATTENDANCE(HttpStatus.BAD_REQUEST, "VAL-11-006", "중복된 학생 출석 요청입니다."),
+    INVALID_DAILY_SCHEDULE_JOURNAL_LESSONS(HttpStatus.BAD_REQUEST, "VAL-11-007", "수업 일지 교시 입력값이 유효하지 않습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/exception/DailyScheduleJournalAlreadyExistsException.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/exception/DailyScheduleJournalAlreadyExistsException.java
@@ -1,0 +1,13 @@
+package geumjeongyahak.domain.daily_schedule.exception;
+
+import geumjeongyahak.common.exception.BusinessException;
+
+public class DailyScheduleJournalAlreadyExistsException extends BusinessException {
+
+    public DailyScheduleJournalAlreadyExistsException(Long dailyScheduleId) {
+        super(
+            DailyScheduleErrorCode.DAILY_SCHEDULE_JOURNAL_ALREADY_EXISTS,
+            "이미 작성된 수업 일지가 있습니다. (dailyScheduleId: " + dailyScheduleId + ")"
+        );
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/exception/InvalidDailyScheduleJournalLessonsException.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/exception/InvalidDailyScheduleJournalLessonsException.java
@@ -1,0 +1,13 @@
+package geumjeongyahak.domain.daily_schedule.exception;
+
+import geumjeongyahak.common.exception.BusinessException;
+
+public class InvalidDailyScheduleJournalLessonsException extends BusinessException {
+
+    public InvalidDailyScheduleJournalLessonsException(Long dailyScheduleId) {
+        super(
+            DailyScheduleErrorCode.INVALID_DAILY_SCHEDULE_JOURNAL_LESSONS,
+            "하루 일정에 연결된 모든 교시의 수업 일지를 입력해야 합니다. (dailyScheduleId: " + dailyScheduleId + ")"
+        );
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/repository/DailyScheduleRepository.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/repository/DailyScheduleRepository.java
@@ -23,5 +23,8 @@ public interface DailyScheduleRepository extends JpaRepository<DailySchedule, Lo
     );
 
     @EntityGraph(attributePaths = {"classroom", "teacher"})
+    List<DailySchedule> findAllByIsDeletedFalseOrderByLessonDateDescIdDesc();
+
+    @EntityGraph(attributePaths = {"classroom", "teacher"})
     Optional<DailySchedule> findByIdAndIsDeletedFalse(Long dailyScheduleId);
 }

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleService.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleService.java
@@ -326,17 +326,17 @@ public class DailyScheduleService {
         UpdateDailyScheduleJournalRequest request
     ) {
         log.debug(
-            "DailySchedule 수업 일지 저장 요청 (dailyScheduleId={}, authorId={}, lessonJournalCount={})",
+            "DailySchedule 수업 일지 수정 요청 (dailyScheduleId={}, authorId={}, lessonJournalCount={})",
             dailyScheduleId,
             authorId,
             request.lessonJournals().size()
         );
         DailySchedule dailySchedule = dailyScheduleRepository.findByIdAndIsDeletedFalse(dailyScheduleId)
             .orElseThrow(() -> {
-                log.info("DailySchedule 수업 일지 저장 실패 - 하루 일정을 찾을 수 없습니다. ID: {}", dailyScheduleId);
+                log.info("DailySchedule 수업 일지 수정 실패 - 하루 일정을 찾을 수 없습니다. ID: {}", dailyScheduleId);
                 return new DailyScheduleNotFoundException(dailyScheduleId);
         });
-        validateDailyScheduleWritable(dailySchedule, authorId, canWriteAnyDailySchedule, "수업 일지 저장");
+        validateDailyScheduleWritable(dailySchedule, authorId, canWriteAnyDailySchedule, "수업 일지 수정");
         validateJournalState(dailySchedule);
         validateJournalPersonalInfo(
             dailySchedule.getId(),
@@ -351,7 +351,7 @@ public class DailyScheduleService {
             request.residentRegistrationNumberPrefix(),
             request.lessonJournals()
         );
-        log.debug("DailySchedule 수업 일지 저장 완료 (dailyScheduleId={})", dailyScheduleId);
+        log.debug("DailySchedule 수업 일지 수정 완료 (dailyScheduleId={})", dailyScheduleId);
         return getDailySchedule(dailyScheduleId, authorId, canWriteAnyDailySchedule);
     }
 

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleService.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleService.java
@@ -9,16 +9,19 @@ import geumjeongyahak.domain.daily_schedule.enums.DailyScheduleStatus;
 import geumjeongyahak.domain.daily_schedule.enums.DailyTeacherAttendanceStatus;
 import geumjeongyahak.domain.daily_schedule.exception.DuplicateDailyStudentAttendanceException;
 import geumjeongyahak.domain.daily_schedule.exception.DailyScheduleForbiddenException;
+import geumjeongyahak.domain.daily_schedule.exception.DailyScheduleJournalAlreadyExistsException;
 import geumjeongyahak.domain.daily_schedule.exception.DailyScheduleNotFoundException;
 import geumjeongyahak.domain.daily_schedule.exception.DailyScheduleVolunteerHoursForbiddenException;
 import geumjeongyahak.domain.daily_schedule.exception.InvalidDailyScheduleAttendanceStateException;
 import geumjeongyahak.domain.daily_schedule.exception.InvalidDailyScheduleJournalStateException;
+import geumjeongyahak.domain.daily_schedule.exception.InvalidDailyScheduleJournalLessonsException;
 import geumjeongyahak.domain.daily_schedule.exception.InvalidDailySchedulePersonalInfoException;
 import geumjeongyahak.domain.daily_schedule.exception.LessonNotInDailyScheduleException;
 import geumjeongyahak.domain.daily_schedule.exception.StudentNotInDailyScheduleException;
 import geumjeongyahak.domain.daily_schedule.repository.DailyScheduleRepository;
 import geumjeongyahak.domain.daily_schedule.repository.DailyStudentAttendanceRepository;
 import geumjeongyahak.domain.daily_schedule.repository.DailyTeacherAttendanceRepository;
+import geumjeongyahak.domain.daily_schedule.v1.dto.request.CreateDailyScheduleJournalRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailyScheduleListRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailySchedulePaginationRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailyScheduleVolunteerHoursRequest;
@@ -264,6 +267,58 @@ public class DailyScheduleService {
     }
 
     @Transactional
+    public DailyScheduleDetailResponse createJournal(
+        Long authorId,
+        boolean canWriteAnyDailySchedule,
+        CreateDailyScheduleJournalRequest request
+    ) {
+        log.debug(
+            "DailySchedule 수업 일지 생성 요청 (authorId={}, classroomId={}, lessonDate={}, lessonJournalCount={})",
+            authorId,
+            request.classroomId(),
+            request.lessonDate(),
+            request.lessonJournals().size()
+        );
+        DailySchedule dailySchedule = dailyScheduleRepository
+            .findByClassroomIdAndLessonDateAndIsDeletedFalse(request.classroomId(), request.lessonDate())
+            .orElseThrow(() -> {
+                log.info(
+                    "DailySchedule 수업 일지 생성 실패 - 하루 일정을 찾을 수 없습니다. classroomId={}, lessonDate={}",
+                    request.classroomId(),
+                    request.lessonDate()
+                );
+                return new DailyScheduleNotFoundException(
+                    "하루 일정을 찾을 수 없습니다. (classroomId: " + request.classroomId()
+                        + ", lessonDate: " + request.lessonDate() + ")"
+                );
+            });
+        validateDailyScheduleWritable(dailySchedule, authorId, canWriteAnyDailySchedule, "수업 일지 생성");
+        validateJournalState(dailySchedule);
+        validateJournalPersonalInfo(
+            dailySchedule.getId(),
+            request.personalInfoConsent(),
+            request.residentRegistrationNumberPrefix()
+        );
+        List<Lesson> lessons = getDailyScheduleLessons(dailySchedule);
+        if (hasWrittenJournal(lessons)) {
+            log.info(
+                "DailySchedule 수업 일지 생성 실패 - 이미 작성된 수업 일지가 있습니다. dailyScheduleId={}",
+                dailySchedule.getId()
+            );
+            throw new DailyScheduleJournalAlreadyExistsException(dailySchedule.getId());
+        }
+        saveJournal(
+            dailySchedule,
+            lessons,
+            request.personalInfoConsent(),
+            request.residentRegistrationNumberPrefix(),
+            request.lessonJournals()
+        );
+        log.debug("DailySchedule 수업 일지 생성 완료 (dailyScheduleId={})", dailySchedule.getId());
+        return getDailySchedule(dailySchedule.getId(), authorId, canWriteAnyDailySchedule);
+    }
+
+    @Transactional
     public DailyScheduleDetailResponse updateJournal(
         Long dailyScheduleId,
         Long authorId,
@@ -280,38 +335,41 @@ public class DailyScheduleService {
             .orElseThrow(() -> {
                 log.info("DailySchedule 수업 일지 저장 실패 - 하루 일정을 찾을 수 없습니다. ID: {}", dailyScheduleId);
                 return new DailyScheduleNotFoundException(dailyScheduleId);
-            });
+        });
         validateDailyScheduleWritable(dailySchedule, authorId, canWriteAnyDailySchedule, "수업 일지 저장");
         validateJournalState(dailySchedule);
-        validateJournalPersonalInfo(dailySchedule.getId(), request);
-        List<Lesson> lessons = lessonProxyService.getActiveLessonsByClassroomAndDate(
-            dailySchedule.getClassroom().getId(),
-            dailySchedule.getLessonDate()
+        validateJournalPersonalInfo(
+            dailySchedule.getId(),
+            request.personalInfoConsent(),
+            request.residentRegistrationNumberPrefix()
         );
-        Map<Long, Lesson> lessonsById = lessons
-            .stream()
-            .collect(toMap(Lesson::getId, Function.identity()));
-
-        for (UpdateDailyScheduleJournalRequest.LessonJournalRequest lessonJournal : request.lessonJournals()) {
-            Lesson lesson = lessonsById.get(lessonJournal.lessonId());
-            if (lesson == null) {
-                log.info(
-                    "DailySchedule 수업 일지 저장 실패 - 하루 일정에 연결되지 않은 수업입니다. dailyScheduleId={}, lessonId={}",
-                    dailyScheduleId,
-                    lessonJournal.lessonId()
-                );
-                throw new LessonNotInDailyScheduleException(dailyScheduleId, lessonJournal.lessonId());
-            }
-            lesson.updateNote(lessonJournal.note());
-        }
-
-        dailySchedule.updateJournalPersonalInfo(
+        List<Lesson> lessons = getDailyScheduleLessons(dailySchedule);
+        saveJournal(
+            dailySchedule,
+            lessons,
+            request.personalInfoConsent(),
             request.residentRegistrationNumberPrefix(),
-            request.personalInfoConsent()
+            request.lessonJournals()
         );
-        completeIfReady(dailySchedule, lessons);
         log.debug("DailySchedule 수업 일지 저장 완료 (dailyScheduleId={})", dailyScheduleId);
         return getDailySchedule(dailyScheduleId, authorId, canWriteAnyDailySchedule);
+    }
+
+    @Transactional
+    public void deleteJournal(Long dailyScheduleId, Long authorId, boolean canWriteAnyDailySchedule) {
+        log.debug("DailySchedule 수업 일지 삭제 요청 (dailyScheduleId={}, authorId={})", dailyScheduleId, authorId);
+        DailySchedule dailySchedule = dailyScheduleRepository.findByIdAndIsDeletedFalse(dailyScheduleId)
+            .orElseThrow(() -> {
+                log.info("DailySchedule 수업 일지 삭제 실패 - 하루 일정을 찾을 수 없습니다. ID: {}", dailyScheduleId);
+                return new DailyScheduleNotFoundException(dailyScheduleId);
+            });
+        validateDailyScheduleWritable(dailySchedule, authorId, canWriteAnyDailySchedule, "수업 일지 삭제");
+        validateJournalState(dailySchedule);
+        List<Lesson> lessons = getDailyScheduleLessons(dailySchedule);
+        lessons.forEach(lesson -> lesson.updateNote(null));
+        dailySchedule.updateJournalPersonalInfo(null, false);
+        markIncompleteAfterJournalDelete(dailySchedule, lessons);
+        log.debug("DailySchedule 수업 일지 삭제 완료 (dailyScheduleId={})", dailyScheduleId);
     }
 
     @Transactional
@@ -497,6 +555,15 @@ public class DailyScheduleService {
         }
     }
 
+    private void markIncompleteAfterJournalDelete(DailySchedule dailySchedule, List<Lesson> lessons) {
+        if (dailySchedule.getStatus() != DailyScheduleStatus.COMPLETED) {
+            return;
+        }
+
+        dailySchedule.updateStatus(DailyScheduleStatus.SCHEDULED);
+        lessons.forEach(lesson -> lesson.updateStatus(LessonStatus.SCHEDULED));
+    }
+
     private void validateJournalState(DailySchedule dailySchedule) {
         if (dailySchedule.getStatus() != DailyScheduleStatus.CANCELLED) {
             return;
@@ -526,27 +593,87 @@ public class DailyScheduleService {
 
     private void validateJournalPersonalInfo(
         Long dailyScheduleId,
-        UpdateDailyScheduleJournalRequest request
+        Boolean personalInfoConsent,
+        String residentRegistrationNumberPrefix
     ) {
-        if (request.personalInfoConsent()
-            && request.residentRegistrationNumberPrefix() != null
-            && !request.residentRegistrationNumberPrefix().isBlank()) {
+        if (Boolean.TRUE.equals(personalInfoConsent)
+            && residentRegistrationNumberPrefix != null
+            && !residentRegistrationNumberPrefix.isBlank()) {
             return;
         }
 
-        if (!request.personalInfoConsent()
-            && (request.residentRegistrationNumberPrefix() == null
-            || request.residentRegistrationNumberPrefix().isBlank())) {
+        if (Boolean.FALSE.equals(personalInfoConsent)
+            && (residentRegistrationNumberPrefix == null || residentRegistrationNumberPrefix.isBlank())) {
             return;
         }
 
         log.info(
             "DailySchedule 수업 일지 저장 실패 - 개인정보 입력값이 유효하지 않습니다. dailyScheduleId={}, personalInfoConsent={}, hasResidentPrefix={}",
             dailyScheduleId,
-            request.personalInfoConsent(),
-            request.residentRegistrationNumberPrefix() != null && !request.residentRegistrationNumberPrefix().isBlank()
+            personalInfoConsent,
+            residentRegistrationNumberPrefix != null && !residentRegistrationNumberPrefix.isBlank()
         );
         throw new InvalidDailySchedulePersonalInfoException(dailyScheduleId);
+    }
+
+    private List<Lesson> getDailyScheduleLessons(DailySchedule dailySchedule) {
+        return lessonProxyService.getActiveLessonsByClassroomAndDate(
+            dailySchedule.getClassroom().getId(),
+            dailySchedule.getLessonDate()
+        );
+    }
+
+    private void saveJournal(
+        DailySchedule dailySchedule,
+        List<Lesson> lessons,
+        Boolean personalInfoConsent,
+        String residentRegistrationNumberPrefix,
+        List<UpdateDailyScheduleJournalRequest.LessonJournalRequest> lessonJournals
+    ) {
+        validateJournalLessons(dailySchedule.getId(), lessons, lessonJournals);
+        Map<Long, Lesson> lessonsById = lessons.stream()
+            .collect(toMap(Lesson::getId, Function.identity()));
+
+        for (UpdateDailyScheduleJournalRequest.LessonJournalRequest lessonJournal : lessonJournals) {
+            Lesson lesson = lessonsById.get(lessonJournal.lessonId());
+            if (lesson == null) {
+                log.info(
+                    "DailySchedule 수업 일지 저장 실패 - 하루 일정에 연결되지 않은 수업입니다. dailyScheduleId={}, lessonId={}",
+                    dailySchedule.getId(),
+                    lessonJournal.lessonId()
+                );
+                throw new LessonNotInDailyScheduleException(dailySchedule.getId(), lessonJournal.lessonId());
+            }
+            lesson.updateNote(lessonJournal.note());
+        }
+
+        dailySchedule.updateJournalPersonalInfo(residentRegistrationNumberPrefix, personalInfoConsent);
+        completeIfReady(dailySchedule, lessons);
+    }
+
+    private void validateJournalLessons(
+        Long dailyScheduleId,
+        List<Lesson> lessons,
+        List<UpdateDailyScheduleJournalRequest.LessonJournalRequest> lessonJournals
+    ) {
+        Set<Long> lessonIds = lessons.stream()
+            .map(Lesson::getId)
+            .collect(Collectors.toSet());
+        Set<Long> requestedLessonIds = lessonJournals.stream()
+            .map(UpdateDailyScheduleJournalRequest.LessonJournalRequest::lessonId)
+            .collect(Collectors.toSet());
+
+        if (lessonIds.equals(requestedLessonIds) && lessonJournals.size() == requestedLessonIds.size()) {
+            return;
+        }
+
+        log.info(
+            "DailySchedule 수업 일지 저장 실패 - 연결된 모든 교시의 수업 일지를 입력해야 합니다. dailyScheduleId={}, lessonIds={}, requestedLessonIds={}",
+            dailyScheduleId,
+            lessonIds,
+            requestedLessonIds
+        );
+        throw new InvalidDailyScheduleJournalLessonsException(dailyScheduleId);
     }
 
     private void validateDailyScheduleWritable(

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleService.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleService.java
@@ -1,6 +1,7 @@
 package geumjeongyahak.domain.daily_schedule.service;
 
 import geumjeongyahak.domain.classroom.entity.Classroom;
+import geumjeongyahak.domain.base.dto.response.PaginationResponse;
 import geumjeongyahak.domain.daily_schedule.entity.DailySchedule;
 import geumjeongyahak.domain.daily_schedule.entity.DailyStudentAttendance;
 import geumjeongyahak.domain.daily_schedule.entity.DailyTeacherAttendance;
@@ -19,12 +20,14 @@ import geumjeongyahak.domain.daily_schedule.repository.DailyScheduleRepository;
 import geumjeongyahak.domain.daily_schedule.repository.DailyStudentAttendanceRepository;
 import geumjeongyahak.domain.daily_schedule.repository.DailyTeacherAttendanceRepository;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailyScheduleListRequest;
+import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailySchedulePaginationRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailyScheduleVolunteerHoursRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyScheduleJournalRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyStudentAttendanceItemRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyStudentAttendancesRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyTeacherAttendanceRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleDetailResponse;
+import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleLessonResponse;
 import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleSummaryResponse;
 import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleVolunteerHoursResponse;
 import geumjeongyahak.domain.lesson.entity.Lesson;
@@ -44,8 +47,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -122,7 +128,7 @@ public class DailyScheduleService {
             request.status()
         );
 
-        List<DailyScheduleSummaryResponse> responses = dailyScheduleRepository
+        List<DailySchedule> dailySchedules = dailyScheduleRepository
             .findAllByIsDeletedFalseAndLessonDateBetweenOrderByLessonDateAscIdAsc(request.from(), request.to())
             .stream()
             .filter(dailySchedule -> request.classroomId() == null
@@ -130,10 +136,49 @@ public class DailyScheduleService {
             .filter(dailySchedule -> request.teacherId() == null
                 || dailySchedule.getTeacher().getId().equals(request.teacherId()))
             .filter(dailySchedule -> request.status() == null || dailySchedule.getStatus() == request.status())
+            .toList();
+        Map<DailyScheduleLessonKey, List<Lesson>> lessonsByScheduleKey = getLessonsByScheduleKey(dailySchedules);
+        List<DailyScheduleSummaryResponse> responses = dailySchedules
+            .stream()
+            .map(dailySchedule -> new DailyScheduleWithLessons(
+                dailySchedule,
+                lessonsByScheduleKey.getOrDefault(DailyScheduleLessonKey.from(dailySchedule), List.of())
+            ))
             .map(this::toSummaryResponse)
             .toList();
         log.debug("DailySchedule 목록 조회 완료 - 총 {}건", responses.size());
         return responses;
+    }
+
+    public PaginationResponse<DailyScheduleSummaryResponse> getJournalDailySchedules(
+        DailySchedulePaginationRequest request,
+        Long requesterId
+    ) {
+        List<DailySchedule> dailySchedules = dailyScheduleRepository
+            .findAllByIsDeletedFalseOrderByLessonDateDescIdDesc()
+            .stream()
+            .filter(dailySchedule -> !Boolean.TRUE.equals(request.getMine())
+                || dailySchedule.getTeacher().getId().equals(requesterId))
+            .toList();
+        Map<DailyScheduleLessonKey, List<Lesson>> lessonsByScheduleKey = getLessonsByScheduleKey(dailySchedules);
+        List<DailyScheduleSummaryResponse> responses = dailySchedules
+            .stream()
+            .map(dailySchedule -> new DailyScheduleWithLessons(
+                dailySchedule,
+                lessonsByScheduleKey.getOrDefault(DailyScheduleLessonKey.from(dailySchedule), List.of())
+            ))
+            .filter(dailyScheduleWithLessons -> hasWrittenJournal(dailyScheduleWithLessons.lessons()))
+            .filter(dailyScheduleWithLessons -> matchesKeyword(dailyScheduleWithLessons, request.getKeyword()))
+            .map(this::toSummaryResponse)
+            .toList();
+        PageRequest pageRequest = request.toRequest();
+        int start = Math.min((int) pageRequest.getOffset(), responses.size());
+        int end = Math.min(start + pageRequest.getPageSize(), responses.size());
+        return new PaginationResponse<>(new PageImpl<>(
+            responses.subList(start, end),
+            pageRequest,
+            responses.size()
+        ));
     }
 
     public DailyScheduleDetailResponse getDailySchedule(
@@ -563,14 +608,79 @@ public class DailyScheduleService {
             });
     }
 
-    private DailyScheduleSummaryResponse toSummaryResponse(DailySchedule dailySchedule) {
+    private boolean hasWrittenJournal(List<Lesson> lessons) {
+        return lessons.stream().anyMatch(lesson -> hasText(lesson.getNote()));
+    }
+
+    private boolean matchesKeyword(DailyScheduleWithLessons dailyScheduleWithLessons, String keyword) {
+        if (!hasText(keyword)) {
+            return true;
+        }
+
+        String normalizedKeyword = keyword.trim().toLowerCase();
+        DailySchedule dailySchedule = dailyScheduleWithLessons.dailySchedule();
+        return containsIgnoreCase(dailySchedule.getClassroom().getName(), normalizedKeyword)
+            || containsIgnoreCase(dailySchedule.getTeacher().getName(), normalizedKeyword)
+            || dailyScheduleWithLessons.lessons().stream()
+                .anyMatch(lesson -> containsIgnoreCase(lesson.getSubject().getName(), normalizedKeyword)
+                    || containsIgnoreCase(lesson.getNote(), normalizedKeyword));
+    }
+
+    private boolean containsIgnoreCase(String value, String normalizedKeyword) {
+        return value != null && value.toLowerCase().contains(normalizedKeyword);
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private Map<DailyScheduleLessonKey, List<Lesson>> getLessonsByScheduleKey(List<DailySchedule> dailySchedules) {
+        Set<Long> classroomIds = dailySchedules.stream()
+            .map(dailySchedule -> dailySchedule.getClassroom().getId())
+            .collect(Collectors.toSet());
+        Set<LocalDate> lessonDates = dailySchedules.stream()
+            .map(DailySchedule::getLessonDate)
+            .collect(Collectors.toSet());
+
+        return lessonProxyService.getActiveLessonsByClassroomIdsAndDates(classroomIds, lessonDates)
+            .stream()
+            .collect(Collectors.groupingBy(DailyScheduleLessonKey::from));
+    }
+
+    private DailyScheduleSummaryResponse toSummaryResponse(DailyScheduleWithLessons dailyScheduleWithLessons) {
+        DailySchedule dailySchedule = dailyScheduleWithLessons.dailySchedule();
         DailyTeacherAttendance teacherAttendance = dailyTeacherAttendanceRepository
             .findByDailyScheduleIdAndIsDeletedFalse(dailySchedule.getId())
             .orElse(null);
-        int lessonCount = lessonProxyService.getActiveLessonsByClassroomAndDate(
-            dailySchedule.getClassroom().getId(),
-            dailySchedule.getLessonDate()
-        ).size();
-        return DailyScheduleSummaryResponse.of(dailySchedule, teacherAttendance, lessonCount);
+        List<DailyScheduleLessonResponse> lessons = dailyScheduleWithLessons.lessons()
+            .stream()
+            .map(DailyScheduleLessonResponse::from)
+            .toList();
+        return DailyScheduleSummaryResponse.of(dailySchedule, teacherAttendance, lessons);
+    }
+
+    private record DailyScheduleWithLessons(
+        DailySchedule dailySchedule,
+        List<Lesson> lessons
+    ) {
+    }
+
+    private record DailyScheduleLessonKey(
+        Long classroomId,
+        LocalDate lessonDate
+    ) {
+        private static DailyScheduleLessonKey from(DailySchedule dailySchedule) {
+            return new DailyScheduleLessonKey(
+                dailySchedule.getClassroom().getId(),
+                dailySchedule.getLessonDate()
+            );
+        }
+
+        private static DailyScheduleLessonKey from(Lesson lesson) {
+            return new DailyScheduleLessonKey(
+                lesson.getSubject().getClassroom().getId(),
+                lesson.getDate()
+            );
+        }
     }
 }

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/DailyScheduleController.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/DailyScheduleController.java
@@ -3,6 +3,7 @@ package geumjeongyahak.domain.daily_schedule.v1.controller;
 import geumjeongyahak.common.security.service.CustomUserDetails;
 import geumjeongyahak.domain.base.dto.response.PaginationResponse;
 import geumjeongyahak.domain.daily_schedule.service.DailyScheduleService;
+import geumjeongyahak.domain.daily_schedule.v1.dto.request.CreateDailyScheduleJournalRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailySchedulePaginationRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailyScheduleVolunteerHoursRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyScheduleJournalRequest;
@@ -22,11 +23,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -104,15 +106,35 @@ public class DailyScheduleController {
     }
 
     @PreAuthorize(DAILY_SCHEDULE_WRITE_ACCESS)
-    @Operation(summary = "하루 일정 수업 일지 저장", description = "하루 일정에 연결된 교시별 수업 일지를 저장하거나 수정합니다.")
-    @PutMapping("/{dailyScheduleId}/journal")
+    @Operation(summary = "하루 일정 수업 일지 최초 작성", description = "수업 날짜와 분반 기준으로 하루 일정을 찾아 교시별 수업 일지를 최초 작성합니다.")
+    @PostMapping("/journal")
+    public ResponseEntity<DailyScheduleDetailResponse> createJournal(
+        @Valid @RequestBody CreateDailyScheduleJournalRequest request,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        log.debug(
+            "POST /api/v1/daily-schedules/journal - 수업 일지 생성 요청 (classroomId={}, lessonDate={}, lessonJournalCount={})",
+            request.classroomId(),
+            request.lessonDate(),
+            request.lessonJournals().size()
+        );
+        return ResponseEntity.ok(dailyScheduleService.createJournal(
+            userDetails.getUserId(),
+            canManageAnyDailySchedule(userDetails),
+            request
+        ));
+    }
+
+    @PreAuthorize(DAILY_SCHEDULE_WRITE_ACCESS)
+    @Operation(summary = "하루 일정 수업 일지 수정", description = "하루 일정에 연결된 교시별 수업 일지를 수정합니다.")
+    @PatchMapping("/{dailyScheduleId}/journal")
     public ResponseEntity<DailyScheduleDetailResponse> updateJournal(
         @PathVariable Long dailyScheduleId,
         @Valid @RequestBody UpdateDailyScheduleJournalRequest request,
         @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         log.debug(
-            "PUT /api/v1/daily-schedules/{}/journal - 수업 일지 저장 요청 (lessonJournalCount={})",
+            "PATCH /api/v1/daily-schedules/{}/journal - 수업 일지 수정 요청 (lessonJournalCount={})",
             dailyScheduleId,
             request.lessonJournals().size()
         );
@@ -122,6 +144,22 @@ public class DailyScheduleController {
             canManageAnyDailySchedule(userDetails),
             request
         ));
+    }
+
+    @PreAuthorize(DAILY_SCHEDULE_WRITE_ACCESS)
+    @Operation(summary = "하루 일정 수업 일지 삭제", description = "DailySchedule 자체는 유지하고 연결된 교시별 수업 일지 내용과 개인정보 입력값을 초기화합니다.")
+    @DeleteMapping("/{dailyScheduleId}/journal")
+    public ResponseEntity<Void> deleteJournal(
+        @PathVariable Long dailyScheduleId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        log.debug("DELETE /api/v1/daily-schedules/{}/journal - 수업 일지 삭제 요청", dailyScheduleId);
+        dailyScheduleService.deleteJournal(
+            dailyScheduleId,
+            userDetails.getUserId(),
+            canManageAnyDailySchedule(userDetails)
+        );
+        return ResponseEntity.noContent().build();
     }
 
     @PreAuthorize(DAILY_SCHEDULE_WRITE_ACCESS)

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/DailyScheduleController.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/DailyScheduleController.java
@@ -1,8 +1,9 @@
 package geumjeongyahak.domain.daily_schedule.v1.controller;
 
 import geumjeongyahak.common.security.service.CustomUserDetails;
+import geumjeongyahak.domain.base.dto.response.PaginationResponse;
 import geumjeongyahak.domain.daily_schedule.service.DailyScheduleService;
-import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailyScheduleListRequest;
+import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailySchedulePaginationRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailyScheduleVolunteerHoursRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyScheduleJournalRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyStudentAttendancesRequest;
@@ -50,18 +51,18 @@ public class DailyScheduleController {
         description = "수업 일지 목록 화면에서 사용할 하루 단위 일정을 조회합니다. 캘린더 교시 조회는 Lesson API를 사용합니다."
     )
     @GetMapping
-    public ResponseEntity<List<DailyScheduleSummaryResponse>> getDailySchedules(
-        @ParameterObject @Valid @ModelAttribute DailyScheduleListRequest request
+    public ResponseEntity<PaginationResponse<DailyScheduleSummaryResponse>> getDailySchedules(
+        @ParameterObject @Valid @ModelAttribute DailySchedulePaginationRequest request,
+        @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         log.debug(
-            "GET /api/v1/daily-schedules - 하루 일정 목록 조회 요청 (from={}, to={}, classroomId={}, teacherId={}, status={})",
-            request.from(),
-            request.to(),
-            request.classroomId(),
-            request.teacherId(),
-            request.status()
+            "GET /api/v1/daily-schedules - 수업 일지 목록 조회 요청 (keyword={}, mine={}, page={}, size={})",
+            request.getKeyword(),
+            request.getMine(),
+            request.getPage(),
+            request.getSize()
         );
-        return ResponseEntity.ok(dailyScheduleService.getDailySchedules(request));
+        return ResponseEntity.ok(dailyScheduleService.getJournalDailySchedules(request, userDetails.getUserId()));
     }
 
     @PreAuthorize(DAILY_SCHEDULE_READ_ACCESS)

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/DailyScheduleController.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/DailyScheduleController.java
@@ -49,8 +49,8 @@ public class DailyScheduleController {
 
     @PreAuthorize(DAILY_SCHEDULE_READ_ACCESS)
     @Operation(
-        summary = "하루 일정 목록 조회",
-        description = "수업 일지 목록 화면에서 사용할 하루 단위 일정을 조회합니다. 캘린더 교시 조회는 Lesson API를 사용합니다."
+        summary = "수업 일지 목록 조회",
+        description = "작성된 수업 일지를 페이지로 조회합니다. keyword로 분반명, 담당 교사명, 과목명, 수업 일지 내용을 검색하고, mine=true이면 로그인 사용자가 담당자인 수업 일지만 조회합니다."
     )
     @GetMapping
     public ResponseEntity<PaginationResponse<DailyScheduleSummaryResponse>> getDailySchedules(
@@ -68,7 +68,7 @@ public class DailyScheduleController {
     }
 
     @PreAuthorize(DAILY_SCHEDULE_READ_ACCESS)
-    @Operation(summary = "하루 일정 상세 조회", description = "수업 일지 작성/출석 처리 화면에 필요한 하루 일정 상세 정보를 조회합니다.")
+    @Operation(summary = "하루 일정 상세 조회", description = "하루 일정의 수업, 교사 출석, 학생 출석부, 수업 일지 내용을 조회합니다.")
     @GetMapping("/{dailyScheduleId}")
     public ResponseEntity<DailyScheduleDetailResponse> getDailySchedule(
         @PathVariable Long dailyScheduleId,
@@ -106,7 +106,10 @@ public class DailyScheduleController {
     }
 
     @PreAuthorize(DAILY_SCHEDULE_WRITE_ACCESS)
-    @Operation(summary = "하루 일정 수업 일지 최초 작성", description = "수업 날짜와 분반 기준으로 하루 일정을 찾아 교시별 수업 일지를 최초 작성합니다.")
+    @Operation(
+        summary = "수업 일지 최초 작성",
+        description = "수업 날짜와 분반 ID 기준으로 하루 일정을 찾아 교시별 수업 일지를 최초 작성합니다. 이미 작성된 수업 일지가 있으면 409 Conflict를 반환합니다."
+    )
     @PostMapping("/journal")
     public ResponseEntity<DailyScheduleDetailResponse> createJournal(
         @Valid @RequestBody CreateDailyScheduleJournalRequest request,
@@ -126,7 +129,7 @@ public class DailyScheduleController {
     }
 
     @PreAuthorize(DAILY_SCHEDULE_WRITE_ACCESS)
-    @Operation(summary = "하루 일정 수업 일지 수정", description = "하루 일정에 연결된 교시별 수업 일지를 수정합니다.")
+    @Operation(summary = "수업 일지 수정", description = "dailyScheduleId 기준으로 교시별 수업 일지 내용과 개인정보 입력값을 수정합니다.")
     @PatchMapping("/{dailyScheduleId}/journal")
     public ResponseEntity<DailyScheduleDetailResponse> updateJournal(
         @PathVariable Long dailyScheduleId,
@@ -147,7 +150,7 @@ public class DailyScheduleController {
     }
 
     @PreAuthorize(DAILY_SCHEDULE_WRITE_ACCESS)
-    @Operation(summary = "하루 일정 수업 일지 삭제", description = "DailySchedule 자체는 유지하고 연결된 교시별 수업 일지 내용과 개인정보 입력값을 초기화합니다.")
+    @Operation(summary = "수업 일지 삭제", description = "DailySchedule 자체와 출석 정보는 유지하고, 연결된 교시별 수업 일지 내용과 개인정보 입력값만 초기화합니다.")
     @DeleteMapping("/{dailyScheduleId}/journal")
     public ResponseEntity<Void> deleteJournal(
         @PathVariable Long dailyScheduleId,

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/v1/dto/request/CreateDailyScheduleJournalRequest.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/v1/dto/request/CreateDailyScheduleJournalRequest.java
@@ -1,0 +1,37 @@
+package geumjeongyahak.domain.daily_schedule.v1.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import static org.springframework.format.annotation.DateTimeFormat.ISO.DATE;
+
+public record CreateDailyScheduleJournalRequest(
+    @NotNull
+    @DateTimeFormat(iso = DATE)
+    @Schema(description = "수업 일지를 작성할 수업 날짜", example = "2026-06-20")
+    LocalDate lessonDate,
+
+    @NotNull
+    @Schema(description = "수업 일지를 작성할 분반 ID", example = "1")
+    Long classroomId,
+
+    @NotNull
+    @Schema(description = "개인정보 활용 동의 여부", example = "true")
+    Boolean personalInfoConsent,
+
+    @Pattern(regexp = "\\d{6}", message = "주민번호 앞자리는 숫자 6자리여야 합니다.")
+    @Schema(description = "주민번호 앞자리", example = "900101")
+    String residentRegistrationNumberPrefix,
+
+    @Valid
+    @NotEmpty
+    @Schema(description = "교시별 수업 일지 내용")
+    List<UpdateDailyScheduleJournalRequest.LessonJournalRequest> lessonJournals
+) {
+}

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/v1/dto/request/DailySchedulePaginationRequest.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/v1/dto/request/DailySchedulePaginationRequest.java
@@ -1,0 +1,23 @@
+package geumjeongyahak.domain.daily_schedule.v1.dto.request;
+
+import geumjeongyahak.domain.base.dto.request.BasePaginationRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.domain.PageRequest;
+
+@Getter
+@Setter
+public class DailySchedulePaginationRequest extends BasePaginationRequest {
+
+    @Schema(description = "검색어. 분반명, 담당 교사명, 과목명, 수업 일지 내용에서 검색합니다.", example = "수학")
+    private String keyword;
+
+    @Schema(description = "true이면 로그인 사용자가 담당자인 하루 일정만 조회합니다.", example = "true")
+    private Boolean mine;
+
+    @Override
+    public PageRequest toRequest() {
+        return PageRequest.of(getPage(), getSize());
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/v1/dto/response/DailyScheduleSummaryResponse.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/v1/dto/response/DailyScheduleSummaryResponse.java
@@ -7,6 +7,7 @@ import geumjeongyahak.domain.daily_schedule.enums.DailyTeacherAttendanceStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 public record DailyScheduleSummaryResponse(
     @Schema(description = "하루 일정 식별자", example = "1")
@@ -51,13 +52,16 @@ public record DailyScheduleSummaryResponse(
     DailyTeacherAttendanceStatus teacherAttendanceStatus,
 
     @Schema(description = "연결된 수업 수", example = "3")
-    int lessonCount
+    int lessonCount,
+
+    @Schema(description = "하루 일정에 연결된 교시별 수업 일지 요약")
+    List<DailyScheduleLessonResponse> lessons
 ) {
 
     public static DailyScheduleSummaryResponse of(
         DailySchedule dailySchedule,
         DailyTeacherAttendance teacherAttendance,
-        int lessonCount
+        List<DailyScheduleLessonResponse> lessons
     ) {
         return new DailyScheduleSummaryResponse(
             dailySchedule.getId(),
@@ -71,7 +75,8 @@ public record DailyScheduleSummaryResponse(
             teacherAttendance != null ? teacherAttendance.getVolunteerServiceMinutes() : null,
             dailySchedule.getStatus(),
             teacherAttendance != null ? teacherAttendance.getStatus() : null,
-            lessonCount
+            lessons.size(),
+            lessons
         );
     }
 }

--- a/src/main/java/geumjeongyahak/domain/lesson/repository/LessonRepository.java
+++ b/src/main/java/geumjeongyahak/domain/lesson/repository/LessonRepository.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LessonRepository extends JpaRepository<Lesson, Long> {
 
@@ -35,6 +37,19 @@ public interface LessonRepository extends JpaRepository<Lesson, Long> {
     List<Lesson> findAllBySubjectClassroomIdAndDateAndIsDeletedFalseOrderByPeriodAscStartTimeAsc(
         Long classroomId,
         LocalDate date
+    );
+
+    @EntityGraph(attributePaths = {"teacher", "subject", "subject.classroom"})
+    @Query("""
+        SELECT l FROM Lesson l
+        WHERE l.isDeleted = false
+            AND l.subject.classroom.id IN :classroomIds
+            AND l.date IN :dates
+        ORDER BY l.date DESC, l.period ASC, l.startTime ASC
+        """)
+    List<Lesson> findAllActiveByClassroomIdsAndDates(
+        @Param("classroomIds") List<Long> classroomIds,
+        @Param("dates") List<LocalDate> dates
     );
 
     @EntityGraph(attributePaths = {"teacher", "subject", "subject.classroom"})

--- a/src/main/java/geumjeongyahak/domain/lesson/service/LessonProxyService.java
+++ b/src/main/java/geumjeongyahak/domain/lesson/service/LessonProxyService.java
@@ -4,6 +4,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,6 +44,17 @@ public class LessonProxyService {
         return lessonRepository.findAllBySubjectClassroomIdAndDateAndIsDeletedFalseOrderByPeriodAscStartTimeAsc(
             classroomId,
             date
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<Lesson> getActiveLessonsByClassroomIdsAndDates(Set<Long> classroomIds, Set<LocalDate> dates) {
+        if (classroomIds.isEmpty() || dates.isEmpty()) {
+            return List.of();
+        }
+        return lessonRepository.findAllActiveByClassroomIdsAndDates(
+            List.copyOf(classroomIds),
+            List.copyOf(dates)
         );
     }
 

--- a/src/test/java/geumjeongyahak/unit/daily_schedule/DailyScheduleServiceReadTest.java
+++ b/src/test/java/geumjeongyahak/unit/daily_schedule/DailyScheduleServiceReadTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import geumjeongyahak.domain.auth.enums.RoleType;
+import geumjeongyahak.domain.base.dto.response.PaginationResponse;
 import geumjeongyahak.domain.classroom.entity.Classroom;
 import geumjeongyahak.domain.classroom.enums.ClassroomType;
 import geumjeongyahak.domain.daily_schedule.entity.DailySchedule;
@@ -25,6 +26,7 @@ import geumjeongyahak.domain.daily_schedule.repository.DailyStudentAttendanceRep
 import geumjeongyahak.domain.daily_schedule.repository.DailyTeacherAttendanceRepository;
 import geumjeongyahak.domain.daily_schedule.service.DailyScheduleService;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailyScheduleListRequest;
+import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailySchedulePaginationRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyScheduleJournalRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyStudentAttendanceItemRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyStudentAttendancesRequest;
@@ -44,6 +46,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -83,7 +86,7 @@ class DailyScheduleServiceReadTest {
         )).willReturn(List.of(dailySchedule));
         given(dailyTeacherAttendanceRepository.findByDailyScheduleIdAndIsDeletedFalse(dailySchedule.getId()))
             .willReturn(Optional.of(teacherAttendance));
-        given(lessonProxyService.getActiveLessonsByClassroomAndDate(classroom.getId(), lessonDate))
+        given(lessonProxyService.getActiveLessonsByClassroomIdsAndDates(Set.of(classroom.getId()), Set.of(lessonDate)))
             .willReturn(List.of(lesson(subject(classroom, teacher, lessonDate), teacher, lessonDate, 1)));
 
         List<DailyScheduleSummaryResponse> responses = dailyScheduleService.getDailySchedules(
@@ -94,6 +97,40 @@ class DailyScheduleServiceReadTest {
         assertThat(responses.get(0).dailyScheduleId()).isEqualTo(dailySchedule.getId());
         assertThat(responses.get(0).volunteerServiceMinutes()).isEqualTo(120);
         assertThat(responses.get(0).lessonCount()).isEqualTo(1);
+    }
+
+    @Test
+    void getJournalDailySchedules_returnsPagedWrittenJournals() {
+        LocalDate lessonDate = LocalDate.of(2026, 5, 20);
+        Classroom classroom = classroom(1L);
+        User teacher = teacher(2L, "홍길동");
+        DailySchedule writtenSchedule = dailySchedule(100L, classroom, teacher, lessonDate);
+        DailySchedule emptySchedule = dailySchedule(101L, classroom, teacher, lessonDate.plusDays(1));
+        Subject subject = subject(classroom, teacher, lessonDate);
+        Lesson writtenLesson = lesson(subject, teacher, lessonDate, 1);
+        writtenLesson.updateNote("수학 수업 내용");
+        Lesson emptyLesson = lesson(subject, teacher, lessonDate.plusDays(1), 1);
+
+        given(dailyScheduleRepository.findAllByIsDeletedFalseOrderByLessonDateDescIdDesc())
+            .willReturn(List.of(writtenSchedule, emptySchedule));
+        given(lessonProxyService.getActiveLessonsByClassroomIdsAndDates(
+            Set.of(classroom.getId()),
+            Set.of(lessonDate, lessonDate.plusDays(1))
+        )).willReturn(List.of(writtenLesson, emptyLesson));
+        given(dailyTeacherAttendanceRepository.findByDailyScheduleIdAndIsDeletedFalse(writtenSchedule.getId()))
+            .willReturn(Optional.empty());
+
+        PaginationResponse<DailyScheduleSummaryResponse> response = dailyScheduleService.getJournalDailySchedules(
+            journalPaginationRequest("수학", true, 0, 1),
+            teacher.getId()
+        );
+
+        assertThat(response.getContent()).hasSize(1);
+        assertThat(response.getTotalElements()).isEqualTo(1);
+        assertThat(response.getTotalPages()).isEqualTo(1);
+        assertThat(response.getContent().get(0).dailyScheduleId()).isEqualTo(writtenSchedule.getId());
+        assertThat(response.getContent().get(0).lessons()).hasSize(1);
+        assertThat(response.getContent().get(0).lessons().get(0).note()).isEqualTo("수학 수업 내용");
     }
 
     @Test
@@ -584,6 +621,24 @@ class DailyScheduleServiceReadTest {
         );
         ReflectionTestUtils.setField(dailySchedule, "id", id);
         return dailySchedule;
+    }
+
+    private DailySchedulePaginationRequest journalPaginationRequest(
+        String keyword,
+        Boolean mine,
+        Integer page,
+        Integer size
+    ) {
+        DailySchedulePaginationRequest request = new DailySchedulePaginationRequest();
+        request.setKeyword(keyword);
+        request.setMine(mine);
+        if (page != null) {
+            request.setPage(page);
+        }
+        if (size != null) {
+            request.setSize(size);
+        }
+        return request;
     }
 
     private Classroom classroom(Long id) {

--- a/src/test/java/geumjeongyahak/unit/daily_schedule/DailyScheduleServiceReadTest.java
+++ b/src/test/java/geumjeongyahak/unit/daily_schedule/DailyScheduleServiceReadTest.java
@@ -16,15 +16,18 @@ import geumjeongyahak.domain.daily_schedule.enums.DailyScheduleStatus;
 import geumjeongyahak.domain.daily_schedule.enums.DailyStudentAttendanceStatus;
 import geumjeongyahak.domain.daily_schedule.enums.DailyTeacherAttendanceStatus;
 import geumjeongyahak.domain.daily_schedule.exception.DailyScheduleForbiddenException;
+import geumjeongyahak.domain.daily_schedule.exception.DailyScheduleJournalAlreadyExistsException;
 import geumjeongyahak.domain.daily_schedule.exception.DuplicateDailyStudentAttendanceException;
 import geumjeongyahak.domain.daily_schedule.exception.InvalidDailyScheduleAttendanceStateException;
 import geumjeongyahak.domain.daily_schedule.exception.InvalidDailyScheduleJournalStateException;
+import geumjeongyahak.domain.daily_schedule.exception.InvalidDailyScheduleJournalLessonsException;
 import geumjeongyahak.domain.daily_schedule.exception.InvalidDailySchedulePersonalInfoException;
 import geumjeongyahak.domain.daily_schedule.exception.StudentNotInDailyScheduleException;
 import geumjeongyahak.domain.daily_schedule.repository.DailyScheduleRepository;
 import geumjeongyahak.domain.daily_schedule.repository.DailyStudentAttendanceRepository;
 import geumjeongyahak.domain.daily_schedule.repository.DailyTeacherAttendanceRepository;
 import geumjeongyahak.domain.daily_schedule.service.DailyScheduleService;
+import geumjeongyahak.domain.daily_schedule.v1.dto.request.CreateDailyScheduleJournalRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailyScheduleListRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailySchedulePaginationRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyScheduleJournalRequest;
@@ -223,6 +226,79 @@ class DailyScheduleServiceReadTest {
     }
 
     @Test
+    void createJournal_createsByLessonDateAndClassroom() {
+        LocalDate lessonDate = LocalDate.of(2026, 5, 20);
+        Classroom classroom = classroom(1L);
+        User teacher = teacher(2L, "홍길동");
+        DailySchedule dailySchedule = dailySchedule(100L, classroom, teacher, lessonDate);
+        Subject subject = subject(classroom, teacher, lessonDate);
+        Lesson firstLesson = lesson(subject, teacher, lessonDate, 1);
+        Lesson secondLesson = lesson(subject, teacher, lessonDate, 2);
+        ReflectionTestUtils.setField(firstLesson, "id", 11L);
+        ReflectionTestUtils.setField(secondLesson, "id", 12L);
+
+        given(dailyScheduleRepository.findByClassroomIdAndLessonDateAndIsDeletedFalse(classroom.getId(), lessonDate))
+            .willReturn(Optional.of(dailySchedule));
+        given(lessonProxyService.getActiveLessonsByClassroomAndDate(classroom.getId(), lessonDate))
+            .willReturn(List.of(firstLesson, secondLesson));
+        given(dailyScheduleRepository.findByIdAndIsDeletedFalse(dailySchedule.getId()))
+            .willReturn(Optional.of(dailySchedule));
+        given(dailyTeacherAttendanceRepository.findByDailyScheduleIdAndIsDeletedFalse(dailySchedule.getId()))
+            .willReturn(Optional.empty());
+        given(dailyStudentAttendanceRepository.findAllByDailyScheduleIdAndIsDeletedFalse(dailySchedule.getId()))
+            .willReturn(List.of());
+
+        DailyScheduleDetailResponse response = dailyScheduleService.createJournal(
+            teacher.getId(),
+            false,
+            new CreateDailyScheduleJournalRequest(
+                lessonDate,
+                classroom.getId(),
+                true,
+                "900101",
+                List.of(
+                    new UpdateDailyScheduleJournalRequest.LessonJournalRequest(11L, "1교시 수업 내용"),
+                    new UpdateDailyScheduleJournalRequest.LessonJournalRequest(12L, "2교시 수업 내용")
+                )
+            )
+        );
+
+        assertThat(firstLesson.getNote()).isEqualTo("1교시 수업 내용");
+        assertThat(secondLesson.getNote()).isEqualTo("2교시 수업 내용");
+        assertThat(dailySchedule.getResidentRegistrationNumberPrefix()).isEqualTo("900101");
+        assertThat(response.lessons()).hasSize(2);
+    }
+
+    @Test
+    void createJournal_throwsWhenJournalAlreadyExists() {
+        LocalDate lessonDate = LocalDate.of(2026, 5, 20);
+        Classroom classroom = classroom(1L);
+        User teacher = teacher(2L, "홍길동");
+        DailySchedule dailySchedule = dailySchedule(100L, classroom, teacher, lessonDate);
+        Subject subject = subject(classroom, teacher, lessonDate);
+        Lesson lesson = lesson(subject, teacher, lessonDate, 1);
+        ReflectionTestUtils.setField(lesson, "id", 11L);
+        lesson.updateNote("기존 수업 내용");
+
+        given(dailyScheduleRepository.findByClassroomIdAndLessonDateAndIsDeletedFalse(classroom.getId(), lessonDate))
+            .willReturn(Optional.of(dailySchedule));
+        given(lessonProxyService.getActiveLessonsByClassroomAndDate(classroom.getId(), lessonDate))
+            .willReturn(List.of(lesson));
+
+        assertThatThrownBy(() -> dailyScheduleService.createJournal(
+            teacher.getId(),
+            false,
+            new CreateDailyScheduleJournalRequest(
+                lessonDate,
+                classroom.getId(),
+                true,
+                "900101",
+                List.of(new UpdateDailyScheduleJournalRequest.LessonJournalRequest(11L, "수업 내용"))
+            )
+        )).isInstanceOf(DailyScheduleJournalAlreadyExistsException.class);
+    }
+
+    @Test
     void updateJournal_updatesAuthorPersonalInfoAndLessonNotes() {
         LocalDate lessonDate = LocalDate.of(2026, 5, 20);
         Classroom classroom = classroom(1L);
@@ -304,6 +380,62 @@ class DailyScheduleServiceReadTest {
             lessonDate,
             LessonStatus.COMPLETED
         );
+    }
+
+    @Test
+    void updateJournal_throwsWhenNotAllLessonsAreRequested() {
+        LocalDate lessonDate = LocalDate.of(2026, 5, 20);
+        Classroom classroom = classroom(1L);
+        User teacher = teacher(2L, "홍길동");
+        DailySchedule dailySchedule = dailySchedule(100L, classroom, teacher, lessonDate);
+        Subject subject = subject(classroom, teacher, lessonDate);
+        Lesson firstLesson = lesson(subject, teacher, lessonDate, 1);
+        Lesson secondLesson = lesson(subject, teacher, lessonDate, 2);
+        ReflectionTestUtils.setField(firstLesson, "id", 11L);
+        ReflectionTestUtils.setField(secondLesson, "id", 12L);
+
+        given(dailyScheduleRepository.findByIdAndIsDeletedFalse(dailySchedule.getId()))
+            .willReturn(Optional.of(dailySchedule));
+        given(lessonProxyService.getActiveLessonsByClassroomAndDate(classroom.getId(), lessonDate))
+            .willReturn(List.of(firstLesson, secondLesson));
+
+        assertThatThrownBy(() -> dailyScheduleService.updateJournal(
+            dailySchedule.getId(),
+            teacher.getId(),
+            false,
+            new UpdateDailyScheduleJournalRequest(
+                true,
+                "900101",
+                List.of(new UpdateDailyScheduleJournalRequest.LessonJournalRequest(11L, "1교시 수업 내용"))
+            )
+        )).isInstanceOf(InvalidDailyScheduleJournalLessonsException.class);
+    }
+
+    @Test
+    void deleteJournal_clearsNotesAndPersonalInfo() {
+        LocalDate lessonDate = LocalDate.of(2026, 5, 20);
+        Classroom classroom = classroom(1L);
+        User teacher = teacher(2L, "홍길동");
+        DailySchedule dailySchedule = dailySchedule(100L, classroom, teacher, lessonDate);
+        dailySchedule.updateJournalPersonalInfo("900101", true);
+        dailySchedule.updateStatus(DailyScheduleStatus.COMPLETED);
+        Subject subject = subject(classroom, teacher, lessonDate);
+        Lesson lesson = lesson(subject, teacher, lessonDate, 1);
+        lesson.updateNote("수업 내용");
+        lesson.updateStatus(LessonStatus.COMPLETED);
+
+        given(dailyScheduleRepository.findByIdAndIsDeletedFalse(dailySchedule.getId()))
+            .willReturn(Optional.of(dailySchedule));
+        given(lessonProxyService.getActiveLessonsByClassroomAndDate(classroom.getId(), lessonDate))
+            .willReturn(List.of(lesson));
+
+        dailyScheduleService.deleteJournal(dailySchedule.getId(), teacher.getId(), false);
+
+        assertThat(lesson.getNote()).isNull();
+        assertThat(lesson.getStatus()).isEqualTo(LessonStatus.SCHEDULED);
+        assertThat(dailySchedule.getStatus()).isEqualTo(DailyScheduleStatus.SCHEDULED);
+        assertThat(dailySchedule.getResidentRegistrationNumberPrefix()).isNull();
+        assertThat(dailySchedule.isPersonalInfoConsent()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## 개요

수업 일지 디자인 시안에 맞춰 DailySchedule 기반 수업 일지 API 흐름을 정리했습니다.

기존 `PUT /api/v1/daily-schedules/{dailyScheduleId}/journal` API는 생성과 수정을 함께 처리하고 있었지만, 신규 작성 화면에서는 `dailyScheduleId`보다 `lessonDate`, `classroomId`를 입력값으로 받는 흐름이 더 자연스럽다고 판단했습니다.

이에 따라 수업 일지 생성/수정/삭제 API를 분리하고, 목록 조회는 디자인 시안의 카드 목록에 맞게 페이지네이션, 검색, 내가 작성한 글 필터, 교시별 note 응답을 지원하도록 개선했습니다.

## 변경 유형

- [x] 새 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 문서 수정 (docs)
- [x] 테스트 (test)
- [ ] 기타 (chore)

## 변경 내용

- 수업 일지 목록 조회 API 개선
  - `GET /api/v1/daily-schedules`
  - 페이지네이션 응답 적용
  - 작성된 수업 일지만 조회
  - `keyword`, `mine` 필터 추가
  - 목록 카드 표시용 교시별 수업 일지 내용 응답 추가

- 수업 일지 생성 API 추가
  - `POST /api/v1/daily-schedules/journal`
  - `lessonDate`, `classroomId` 기준으로 DailySchedule 조회 후 수업 일지 생성
  - 이미 작성된 수업 일지가 있으면 `409 Conflict` 반환
  - 연결된 모든 교시의 note 입력 검증

- 수업 일지 수정 API 추가
  - `PATCH /api/v1/daily-schedules/{dailyScheduleId}/journal`
  - 교시별 수업 일지 내용과 개인정보 입력값 수정

- 수업 일지 삭제 API 추가
  - `DELETE /api/v1/daily-schedules/{dailyScheduleId}/journal`
  - DailySchedule과 출석 정보는 유지
  - Lesson note와 개인정보 입력값만 초기화
  - 삭제 후 재생성 가능

- 기존 API 정리
  - 기존 `PUT /api/v1/daily-schedules/{dailyScheduleId}/journal` 제거
  - Swagger 설명 최신화
  - `docs/api/DailySchedules.md` 문서 최신화

- 테스트 추가/수정
  - 수업 일지 목록 조회
  - 수업 일지 생성
  - 중복 생성 예외
  - 교시 누락 검증
  - 수업 일지 삭제 후 초기화 검증

## 관련 이슈

Closes #86

## 스크린샷 (선택)



## 체크리스트

- [x] 코드 컨벤션을 준수했습니다
- [x] 테스트 코드를 작성/수정했습니다
- [x] 주요 테스트가 통과합니다
- [x] 문서를 업데이트했습니다

## 리뷰어에게

- 신규 수업 일지 생성 시 `dailyScheduleId` 대신 `lessonDate`, `classroomId`를 받도록 변경했습니다.
- 수정/삭제는 목록 또는 상세 조회 이후의 동작이므로 `dailyScheduleId` 기준으로 처리했습니다.
- 수업 일지 삭제는 실제 DailySchedule 삭제가 아니라 수업 일지 내용과 개인정보 입력값 초기화로 처리했습니다.
- 출석 정보는 수업 일지 삭제와 별개로 유지하도록 했습니다.
- 현재 목록 조회의 keyword/mine 필터는 기존 서비스 레이어 필터링 흐름을 따랐습니다. 데이터가 많아져 성능 이슈가 생기면 DB 레벨 필터링/페이지네이션으로 개선할 수 있습니다.