### PR TITLE
fix(global): CORS preflight 요청 허용

### DIFF
--- a/src/main/java/geumjeongyahak/common/security/config/WebSecurityConfig.java
+++ b/src/main/java/geumjeongyahak/common/security/config/WebSecurityConfig.java
@@ -102,6 +102,8 @@ public class WebSecurityConfig {
 
             // 인가 정책: 화이트리스트만 permitAll + 나머지 authenticated
             .authorizeHttpRequests(auth -> auth
+                // CORS preflight 요청
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 // 관리자 로그인 페이지로 redirect 용
                 .requestMatchers(HttpMethod.GET, "/").permitAll()
                 // 정적 리소스 및 문서/헬스체크


### PR DESCRIPTION
## 요약
- 모든 OPTIONS 요청을 인증 없이 허용해 CORS preflight가 보안 필터에서 막히지 않도록 수정

## 검증
- ./gradlew compileJava
- git diff --check