### PR TITLE
[FEAT]: 게시글 목록 조회 권한 정책 변경

### DIFF
--- a/src/main/java/geumjeongyahak/common/security/config/WebSecurityConfig.java
+++ b/src/main/java/geumjeongyahak/common/security/config/WebSecurityConfig.java
@@ -115,6 +115,7 @@ public class WebSecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/api/v1/departments").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/lessons").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/channels").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/posts").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/channels/*/posts", "/api/v1/channels/*/posts/**").permitAll()
                 // 그 외는 인증 필요
                 .anyRequest().authenticated()

--- a/src/main/java/geumjeongyahak/domain/post/service/PostCrudService.java
+++ b/src/main/java/geumjeongyahak/domain/post/service/PostCrudService.java
@@ -3,6 +3,7 @@ package geumjeongyahak.domain.post.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import geumjeongyahak.common.event.EventPublisher;
@@ -11,6 +12,7 @@ import geumjeongyahak.common.exception.CommonErrorCode;
 import geumjeongyahak.common.exception.ResourceNotFoundException;
 import geumjeongyahak.domain.base.dto.response.PaginationResponse;
 import geumjeongyahak.domain.channel.entity.Channel;
+import geumjeongyahak.domain.channel.service.ChannelAccessChecker;
 import geumjeongyahak.domain.channel.service.ChannelProxyService;
 import geumjeongyahak.domain.post.config.PostProperties;
 import geumjeongyahak.domain.post.entity.Post;
@@ -22,6 +24,7 @@ import geumjeongyahak.domain.post.repository.PostRepository;
 import geumjeongyahak.domain.post.repository.PostSpecs;
 import geumjeongyahak.domain.post.repository.PostAttachmentRepository;
 import geumjeongyahak.domain.post.repository.PostFileRepository;
+import geumjeongyahak.domain.post.v1.dto.request.PostBoardSearchRequest;
 import geumjeongyahak.domain.post.v1.dto.request.CreatePostRequest;
 import geumjeongyahak.domain.post.v1.dto.request.PostSearchRequest;
 import geumjeongyahak.domain.post.v1.dto.request.UpdatePostRequest;
@@ -46,6 +49,7 @@ import org.springframework.data.domain.Pageable;
 public class PostCrudService {
     private final PostRepository postRepository;
     private final ChannelProxyService channelProxyService;
+    private final ChannelAccessChecker channelAccessChecker;
     private final UserProxyService userProxyService;
     private final PostSearchSpecificationBuilder postSearchSpecificationBuilder;
     private final EventPublisher eventPublisher;
@@ -78,7 +82,9 @@ public class PostCrudService {
     }
 
     public PaginationResponse<PostSummaryResponse> getPosts(Long channelId, CustomUserDetails userDetails, PostSearchRequest request) {
-        Specification<Post> spec = postSearchSpecificationBuilder.build(request, userDetails)
+        ensureContentSearchAllowed(channelId, userDetails, request);
+
+        Specification<Post> spec = postSearchSpecificationBuilder.build(request)
                 .and(PostSpecs.hasChannelId(channelId));
 
         return PaginationResponse.from(
@@ -87,9 +93,11 @@ public class PostCrudService {
         );
     }
 
-    public PaginationResponse<PostSummaryResponse> getPosts(CustomUserDetails userDetails, PostSearchRequest request) {
+    public PaginationResponse<PostSummaryResponse> getPosts(CustomUserDetails userDetails, PostBoardSearchRequest request) {
+        ensureContentSearchAllowed(request.getChannelId(), userDetails, request);
+
         return PaginationResponse.from(
-                postRepository.findAll(postSearchSpecificationBuilder.build(request, userDetails), request.toRequest()),
+                postRepository.findAll(postSearchSpecificationBuilder.build(request), request.toRequest()),
                 PostSummaryResponse::from
         );
     }
@@ -217,6 +225,42 @@ public class PostCrudService {
             return null;
         }
         return LocalDateTime.now().plusMinutes(postProperties.getDraftExpirationMinutes());
+    }
+
+    private void ensureContentSearchAllowed(Long channelId, CustomUserDetails userDetails, PostSearchRequest request) {
+        if (!hasText(request.getContent())) {
+            return;
+        }
+
+        if (canSearchContent(channelId, userDetails)) {
+            return;
+        }
+
+        throw new AccessDeniedException("게시글 본문 검색 권한이 없습니다.");
+    }
+
+    private boolean canSearchContent(Long channelId, CustomUserDetails userDetails) {
+        if (userDetails == null) {
+            return false;
+        }
+        if (userDetails.isAdmin()) {
+            return true;
+        }
+        if (channelId != null && channelAccessChecker.can("read", channelId, userDetails)) {
+            return true;
+        }
+        return hasWildcardChannelPermission(userDetails);
+    }
+
+    private boolean hasWildcardChannelPermission(CustomUserDetails userDetails) {
+        return userDetails.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals("channel:read:*")
+                        || a.getAuthority().equals("channel:write:*")
+                        || a.getAuthority().equals("channel:manage:*"));
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 
     private void publishPostChangedEvent(Long channelId) {

--- a/src/main/java/geumjeongyahak/domain/post/service/PostSearchSpecificationBuilder.java
+++ b/src/main/java/geumjeongyahak/domain/post/service/PostSearchSpecificationBuilder.java
@@ -1,15 +1,12 @@
 package geumjeongyahak.domain.post.service;
 
-import geumjeongyahak.common.security.service.CustomUserDetails;
-
-import java.util.List;
-
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
 import geumjeongyahak.domain.channel.enums.ChannelType;
 import geumjeongyahak.domain.post.entity.Post;
 import geumjeongyahak.domain.post.enums.PostStatus;
 import geumjeongyahak.domain.post.repository.PostSpecs;
+import geumjeongyahak.domain.post.v1.dto.request.PostBoardSearchRequest;
 import geumjeongyahak.domain.post.v1.dto.request.PostSearchRequest;
 
 /**
@@ -18,44 +15,14 @@ import geumjeongyahak.domain.post.v1.dto.request.PostSearchRequest;
 @Component
 public class PostSearchSpecificationBuilder {
 
-    public Specification<Post> build(PostSearchRequest request, CustomUserDetails userDetails) {
-        // 1. 기본 필터: 삭제되지 않은 게시글 + 삭제되지 않은 채널
-        Specification<Post> spec = PostSpecs.withoutDeleted()
-                .and((root, query, cb) -> cb.isFalse(root.get("channel").get("isDeleted")));
+    public Specification<Post> build(PostSearchRequest request) {
+        return applyCommonFilters(baseSpec(), request);
+    }
 
-        // 2. 가시성 필터 (ADMIN 및 권한 보유자 대응)
-        if (userDetails == null) {
-            // 미인증: 공개 채널만 노출
-            spec = spec.and(PostSpecs.hasPublicAccess());
-        } else if (!userDetails.isAdmin()) {
-            // ADMIN이 아닌 경우
-            if (!hasWildcardChannelPermission(userDetails)) {
-                // 전체 조회 권한(*)이 없는 경우: 공개 채널 + 개별 권한 있는 채널만 노출
-                java.util.List<Long> allowedIds = extractAllowedChannelIds(userDetails);
-                Specification<Post> visibility = PostSpecs.hasPublicAccess();
-                if (!allowedIds.isEmpty()) {
-                    visibility = visibility.or(PostSpecs.hasAnyChannelId(allowedIds));
-                }
-                spec = spec.and(visibility);
-            }
-            // 전체 조회 권한(*)이 있으면 추가 가시성 필터 없이 모든 비삭제 채널 노출
-        }
-
-        // 3. 요청 조건 필터
+    public Specification<Post> build(PostBoardSearchRequest request) {
+        Specification<Post> spec = applyCommonFilters(baseSpec(), request);
         if (request.getChannelId() != null) {
             spec = spec.and(PostSpecs.hasChannelId(request.getChannelId()));
-        }
-        if (request.getAuthor() != null && !request.getAuthor().isBlank()) {
-            spec = spec.and(PostSpecs.containsAuthor(request.getAuthor()));
-        }
-        if (request.getTitle() != null && !request.getTitle().isBlank()) {
-            spec = spec.and(PostSpecs.containsTitle(request.getTitle()));
-        }
-        if (request.getContent() != null && !request.getContent().isBlank()) {
-            spec = spec.and(PostSpecs.containsContent(request.getContent()));
-        }
-        if (request.getStatus() != null && !request.getStatus().isBlank()) {
-            spec = spec.and(PostSpecs.hasStatus(PostStatus.valueOf(request.getStatus())));
         }
         if (request.getChannelType() != null && !request.getChannelType().isBlank()
                 && !"ALL".equalsIgnoreCase(request.getChannelType())) {
@@ -69,27 +36,30 @@ public class PostSearchSpecificationBuilder {
             spec = spec.and(PostSpecs.hasChannelType(ChannelType.DEPARTMENT))
                     .and(PostSpecs.hasChannelRefId(request.getDepartmentId()));
         }
+        return spec;
+    }
+
+    private Specification<Post> baseSpec() {
+        return PostSpecs.withoutDeleted()
+                .and((root, query, cb) -> cb.isFalse(root.get("channel").get("isDeleted")));
+    }
+
+    private Specification<Post> applyCommonFilters(Specification<Post> spec, PostSearchRequest request) {
+        if (request.getAuthor() != null && !request.getAuthor().isBlank()) {
+            spec = spec.and(PostSpecs.containsAuthor(request.getAuthor()));
+        }
+        if (request.getTitle() != null && !request.getTitle().isBlank()) {
+            spec = spec.and(PostSpecs.containsTitle(request.getTitle()));
+        }
+        if (request.getContent() != null && !request.getContent().isBlank()) {
+            spec = spec.and(PostSpecs.containsContent(request.getContent()));
+        }
+        if (request.getStatus() != null && !request.getStatus().isBlank()) {
+            spec = spec.and(PostSpecs.hasStatus(PostStatus.valueOf(request.getStatus())));
+        }
         if (request.getIsPinned() != null) {
             spec = spec.and(PostSpecs.hasIsPinned(request.getIsPinned()));
         }
         return spec;
-    }
-
-    private boolean hasWildcardChannelPermission(CustomUserDetails userDetails) {
-        return userDetails.getAuthorities().stream()
-                .anyMatch(a -> a.getAuthority().startsWith("channel:read:*") ||
-                               a.getAuthority().startsWith("channel:write:*") ||
-                               a.getAuthority().startsWith("channel:manage:*"));
-    }
-
-    private List<Long> extractAllowedChannelIds(CustomUserDetails userDetails) {
-        return userDetails.getAuthorities().stream()
-                .map(org.springframework.security.core.GrantedAuthority::getAuthority)
-                .filter(a -> a.startsWith("channel:read:") || a.startsWith("channel:write:") || a.startsWith("channel:manage:"))
-                .map(a -> a.substring(a.lastIndexOf(":") + 1))
-                .filter(id -> !id.equals("*"))
-                .map(Long::valueOf)
-                .distinct()
-                .toList();
     }
 }

--- a/src/main/java/geumjeongyahak/domain/post/v1/controller/PostBoardController.java
+++ b/src/main/java/geumjeongyahak/domain/post/v1/controller/PostBoardController.java
@@ -7,7 +7,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import geumjeongyahak.common.security.service.CustomUserDetails;
 import geumjeongyahak.domain.base.dto.response.PaginationResponse;
 import geumjeongyahak.domain.post.service.PostCrudService;
-import geumjeongyahak.domain.post.v1.dto.request.PostSearchRequest;
+import geumjeongyahak.domain.post.v1.dto.request.PostBoardSearchRequest;
 import geumjeongyahak.domain.post.v1.dto.response.PostSummaryResponse;
 
 @Slf4j
@@ -33,7 +32,6 @@ import geumjeongyahak.domain.post.v1.dto.response.PostSummaryResponse;
 public class PostBoardController {
     private final PostCrudService postCrudService;
 
-    @PreAuthorize("isAuthenticated()")
     @Operation(
             summary = "통합 게시글 목록 조회",
             description = """
@@ -60,7 +58,7 @@ public class PostBoardController {
     )
     @GetMapping
     public ResponseEntity<PaginationResponse<PostSummaryResponse>> getPosts(
-            @ParameterObject @Valid PostSearchRequest request,
+            @ParameterObject @Valid PostBoardSearchRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         log.debug("GET /api/v1/posts - 통합 게시글 목록 조회 요청");

--- a/src/main/java/geumjeongyahak/domain/post/v1/controller/PostQueryController.java
+++ b/src/main/java/geumjeongyahak/domain/post/v1/controller/PostQueryController.java
@@ -24,7 +24,6 @@ public class PostQueryController {
 
     private final PostCrudService postCrudService;
 
-    @PreAuthorize("@channelAccess.can('read', #channelId, principal)")
     @Operation(
             summary = "게시글 목록 조회",
             description = """
@@ -32,6 +31,7 @@ public class PostQueryController {
 
                     동작 방식:
                     - 고정 글이 먼저 정렬되고, 그다음 최신 생성 글 순으로 내려옵니다.
+                    - 모든 사용자가 읽을수 있습니다.
 
                     사이드 이펙트:
                     - 읽기 전용입니다. 조회수는 상세 조회 시점에만 증가합니다.
@@ -46,7 +46,7 @@ public class PostQueryController {
         return ResponseEntity.ok(postCrudService.getPosts(channelId, userDetails, request));
     }
 
-    @PreAuthorize("@channelAccess.can('read', #channelId, principal)")
+    @PreAuthorize("isAuthenticated() && @channelAccess.can('read', #channelId, principal)")
     @Operation(
             summary = "게시글 상세 조회",
             description = """

--- a/src/main/java/geumjeongyahak/domain/post/v1/dto/request/PostBoardSearchRequest.java
+++ b/src/main/java/geumjeongyahak/domain/post/v1/dto/request/PostBoardSearchRequest.java
@@ -1,0 +1,46 @@
+package geumjeongyahak.domain.post.v1.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PostBoardSearchRequest extends PostSearchRequest {
+
+    @Schema(
+            description = """
+                    특정 채널 ID로 범위를 제한합니다.
+                    통합 게시판 API에서 단일 채널만 별도로 조회하고 싶을 때 사용할 수 있습니다.
+                    """,
+            example = "2"
+    )
+    private Long channelId;
+
+    @Schema(
+            description = """
+                    채널 유형 필터입니다.
+                    CLASSROOM이면 반 게시판 전체, DEPARTMENT면 부서 게시판 전체, ALL이면 전역 공지 채널 중심 조회 같은 구성이 가능합니다.
+                    """,
+            example = "CLASSROOM"
+    )
+    private String channelType;
+
+    @Schema(
+            description = """
+                    특정 분반 게시판만 조회할 때 사용하는 분반 ID입니다.
+                    내부적으로 CLASSROOM 타입 채널 중 refId가 일치하는 채널의 게시글만 반환합니다.
+                    """,
+            example = "3"
+    )
+    private Long classroomId;
+
+    @Schema(
+            description = """
+                    특정 부서 게시판만 조회할 때 사용하는 부서 ID입니다.
+                    내부적으로 DEPARTMENT 타입 채널 중 refId가 일치하는 채널의 게시글만 반환합니다.
+                    """,
+            example = "2"
+    )
+    private Long departmentId;
+}

--- a/src/main/java/geumjeongyahak/domain/post/v1/dto/request/PostSearchRequest.java
+++ b/src/main/java/geumjeongyahak/domain/post/v1/dto/request/PostSearchRequest.java
@@ -53,42 +53,6 @@ public class PostSearchRequest extends BasePaginationRequest {
 
     @Schema(
             description = """
-                    특정 채널 ID로 범위를 제한합니다.
-                    통합 게시판 API에서 단일 채널만 별도로 조회하고 싶을 때 사용할 수 있습니다.
-                    """,
-            example = "2"
-    )
-    private Long channelId;
-
-    @Schema(
-            description = """
-                    채널 유형 필터입니다.
-                    CLASSROOM이면 반 게시판 전체, DEPARTMENT면 부서 게시판 전체, ALL이면 전역 공지 채널 중심 조회 같은 구성이 가능합니다.
-                    """,
-            example = "CLASSROOM"
-    )
-    private String channelType;
-
-    @Schema(
-            description = """
-                    특정 분반 게시판만 조회할 때 사용하는 분반 ID입니다.
-                    내부적으로 CLASSROOM 타입 채널 중 refId가 일치하는 채널의 게시글만 반환합니다.
-                    """,
-            example = "3"
-    )
-    private Long classroomId;
-
-    @Schema(
-            description = """
-                    특정 부서 게시판만 조회할 때 사용하는 부서 ID입니다.
-                    내부적으로 DEPARTMENT 타입 채널 중 refId가 일치하는 채널의 게시글만 반환합니다.
-                    """,
-            example = "2"
-    )
-    private Long departmentId;
-
-    @Schema(
-            description = """
                     상단 고정 글 여부 필터입니다.
                     true면 공지처럼 강조된 글만, false면 일반 위치 글만 따로 볼 수 있습니다.
                     """,

--- a/src/test/java/geumjeongyahak/e2e/post/PostBoardQueryTest.java
+++ b/src/test/java/geumjeongyahak/e2e/post/PostBoardQueryTest.java
@@ -11,6 +11,7 @@ import geumjeongyahak.domain.post.v1.dto.request.CreatePostRequest;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -101,6 +102,80 @@ public class PostBoardQueryTest extends BasePostTest {
                 .body("content", hasSize(1))
                 .body("content[0].title", equalTo("교육연구부 회의"))
                 .body("content[0].channelType", equalTo("DEPARTMENT"));
+    }
+
+    @Test
+    @DisplayName("비인증 사용자는 게시글 목록을 조회할 수 있지만 본문 검색과 상세 조회는 제한된다")
+    void getBoardPosts_WithoutAuth_AllowsListButRestrictsContentSearchAndDetail() {
+        Channel closedChannel = channelRepository.save(Channel.builder()
+                .name("닫힌 운영 채널")
+                .description("목록 노출 테스트")
+                .channelType(ChannelType.CUSTOM)
+                .bindingType(ChannelBindingType.STANDALONE)
+                .accessLevel(ChannelAccessLevel.CLOSED)
+                .isActive(true)
+                .build());
+        testChannelHelper.registerChannel(closedChannel.getId());
+
+        Long postId = createPost(closedChannel.getId(), "닫힌 채널 목록 노출");
+
+        given()
+                .when()
+                .get("/api/v1/posts")
+                .then()
+                .statusCode(200)
+                .body("content.title", hasItem("닫힌 채널 목록 노출"));
+
+        given()
+                .queryParam("content", "닫힌")
+                .when()
+                .get("/api/v1/posts")
+                .then()
+                .statusCode(403);
+
+        given()
+                .when()
+                .get("/api/v1/channels/{channelId}/posts/{postId}", closedChannel.getId(), postId)
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    @DisplayName("관리자는 게시글 본문으로 통합 목록을 검색할 수 있다")
+    void getBoardPosts_WithContent_AsAdmin_Success() {
+        createPost(noticeChannelId, "본문 검색 허용");
+
+        given()
+                .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+                .queryParam("content", "본문 검색 허용")
+                .when()
+                .get("/api/v1/posts")
+                .then()
+                .statusCode(200)
+                .body("content", hasSize(1))
+                .body("content[0].title", equalTo("본문 검색 허용"));
+    }
+
+    @Test
+    @DisplayName("채널 하위 게시글 목록은 통합 게시판 전용 필터를 바인딩하지 않는다")
+    void getChannelPosts_WithBoardScopeFilters_IgnoresBoardOnlyFilters() {
+        Long postId = createPost(noticeChannelId, "채널 범위 필터 테스트");
+
+        given()
+                .queryParam("channelType", "NOTICE")
+                .when()
+                .get("/api/v1/channels/{channelId}/posts", noticeChannelId)
+                .then()
+                .statusCode(200)
+                .body("content.id", hasItem(postId.intValue()));
+
+        given()
+                .queryParam("channelId", noticeChannelId)
+                .when()
+                .get("/api/v1/channels/{channelId}/posts", noticeChannelId)
+                .then()
+                .statusCode(200)
+                .body("content.id", hasItem(postId.intValue()));
     }
 
     private Long createPost(Long channelId, String title) {


### PR DESCRIPTION
## 변경 사항
- /api/v1/posts 통합 게시글 목록 조회를 비인증 사용자도 호출할 수 있도록 변경
- 게시글 목록 조회에서는 채널 가시성 제한을 제거하고, 실제 게시글 상세 조회는 기존 채널 읽기 권한으로 보호
- 본문(content) 검색은 권한 있는 사용자만 가능하도록 제한
- 통합 게시판 전용 필터를 PostBoardSearchRequest로 분리하고, 채널 하위 목록은 PostSearchRequest만 사용하도록 정리
- 관련 E2E 테스트 추가

## 검증
- ./gradlew compileJava
- ./gradlew compileTestJava
- ./gradlew test --tests geumjeongyahak.e2e.post.PostBoardQueryTest