### PR TITLE
[FEAT] 교원 신청 관리자 페이지 추가

### DIFF
--- a/src/main/java/geumjeongyahak/domain/base/service/AdminDashboardService.java
+++ b/src/main/java/geumjeongyahak/domain/base/service/AdminDashboardService.java
@@ -10,6 +10,8 @@ import geumjeongyahak.domain.request.enums.RequestStatus;
 import geumjeongyahak.domain.request.repository.AbsenceRequestRepository;
 import geumjeongyahak.domain.student.repository.StudentRepository;
 import geumjeongyahak.domain.subject.repository.SubjectRepository;
+import geumjeongyahak.domain.teacher_application.enums.TeacherApplicationStatus;
+import geumjeongyahak.domain.teacher_application.repository.TeacherApplicationRepository;
 import geumjeongyahak.domain.users.repository.UserRepository;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -31,6 +33,7 @@ public class AdminDashboardService {
     private final StudentRepository studentRepository;
     private final LessonRepository lessonRepository;
     private final SubjectRepository subjectRepository;
+    private final TeacherApplicationRepository teacherApplicationRepository;
 
     public AdminDashboardSummary getSummary() {
         LocalDate today = LocalDate.now();
@@ -43,6 +46,7 @@ public class AdminDashboardService {
             classroomRepository.count(),
             purchaseRequestRepository.countByStatus(PurchaseRequestStatus.PENDING),
             absenceRequestRepository.countByStatus(RequestStatus.PENDING),
+            teacherApplicationRepository.countByStatus(TeacherApplicationStatus.PENDING),
             studentRepository.count(),
             subjectRepository.countByIsActiveTrue(),
             lessonRepository.countByIsDeletedFalse(),
@@ -60,6 +64,7 @@ public class AdminDashboardService {
         long classroomCount,
         long pendingPurchaseRequestCount,
         long pendingAbsenceRequestCount,
+        long pendingTeacherApplicationCount,
         long studentCount,
         long subjectCount,
         long lessonCount,

--- a/src/main/java/geumjeongyahak/domain/teacher_application/repository/TeacherApplicationRepository.java
+++ b/src/main/java/geumjeongyahak/domain/teacher_application/repository/TeacherApplicationRepository.java
@@ -15,6 +15,8 @@ public interface TeacherApplicationRepository
 
     boolean existsByApplicant_IdAndStatus(Long applicantId, TeacherApplicationStatus status);
 
+    long countByStatus(TeacherApplicationStatus status);
+
     @EntityGraph(attributePaths = {"applicant", "preferredSubject", "preferredSubject.classroom", "reviewedBy"})
     Optional<TeacherApplication> findById(Long applicationId);
 

--- a/src/main/java/geumjeongyahak/domain/teacher_application/service/TeacherApplicationAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/teacher_application/service/TeacherApplicationAdminViewService.java
@@ -1,0 +1,177 @@
+package geumjeongyahak.domain.teacher_application.service;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import geumjeongyahak.domain.base.dto.response.AdminPage;
+import geumjeongyahak.domain.base.dto.response.PaginationResponse;
+import geumjeongyahak.domain.classroom.entity.Classroom;
+import geumjeongyahak.domain.classroom.service.ClassroomProxyService;
+import geumjeongyahak.domain.teacher_application.enums.TeacherApplicationStatus;
+import geumjeongyahak.domain.teacher_application.v1.dto.request.ApproveTeacherApplicationRequest;
+import geumjeongyahak.domain.teacher_application.v1.dto.request.RejectTeacherApplicationRequest;
+import geumjeongyahak.domain.teacher_application.v1.dto.request.TeacherApplicationPaginationRequest;
+import geumjeongyahak.domain.teacher_application.v1.dto.response.TeacherApplicationResponse;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeacherApplicationAdminViewService {
+
+    private final TeacherApplicationService teacherApplicationService;
+    private final ClassroomProxyService classroomProxyService;
+
+    public TeacherApplicationPage getTeacherApplications(TeacherApplicationFilter filter) {
+        TeacherApplicationPaginationRequest request = new TeacherApplicationPaginationRequest();
+        request.setPage(filter.page());
+        request.setSize(filter.size());
+        request.setKeyword(filter.keyword());
+
+        PaginationResponse<TeacherApplicationResponse> response =
+            teacherApplicationService.getTeacherApplications(filter.status(), request);
+        AdminPage<TeacherApplicationResponse> sourcePage = AdminPage.from(response);
+        AdminPage<TeacherApplicationRow> page = new AdminPage<>(
+            sourcePage.content().stream()
+                .map(this::toRow)
+                .toList(),
+            sourcePage.page(),
+            sourcePage.size(),
+            sourcePage.totalElements(),
+            sourcePage.totalPages()
+        );
+
+        return new TeacherApplicationPage(
+            page,
+            filter,
+            getStatusOptions()
+        );
+    }
+
+    public TeacherApplicationDetail getTeacherApplication(Long applicationId) {
+        TeacherApplicationResponse application = teacherApplicationService.getTeacherApplication(applicationId);
+
+        return new TeacherApplicationDetail(
+            application,
+            statusLabel(application.status()),
+            application.status() == TeacherApplicationStatus.PENDING,
+            getActiveClassrooms()
+        );
+    }
+
+    public List<StatusOption> getStatusOptions() {
+        return Arrays.stream(TeacherApplicationStatus.values())
+            .map(status -> new StatusOption(status, statusLabel(status)))
+            .toList();
+    }
+
+    public List<ClassroomOption> getActiveClassrooms() {
+        return classroomProxyService.getActiveClassroomsOrderByName()
+            .stream()
+            .map(this::toClassroomOption)
+            .toList();
+    }
+
+    public long getPendingCount() {
+        TeacherApplicationPaginationRequest request = new TeacherApplicationPaginationRequest();
+        request.setPage(0);
+        request.setSize(1);
+
+        return teacherApplicationService
+            .getTeacherApplications(TeacherApplicationStatus.PENDING, request)
+            .getTotalElements();
+    }
+
+    @Transactional
+    public void approve(
+        Long reviewerId,
+        Long applicationId,
+        Long classroomId,
+        LocalDate teacherStartAt,
+        LocalDate teacherEndAt,
+        String note
+    ) {
+        teacherApplicationService.approveTeacherApplication(
+            reviewerId,
+            applicationId,
+            new ApproveTeacherApplicationRequest(classroomId, teacherStartAt, teacherEndAt, note)
+        );
+    }
+
+    @Transactional
+    public void reject(Long reviewerId, Long applicationId, String note) {
+        teacherApplicationService.rejectTeacherApplication(
+            reviewerId,
+            applicationId,
+            new RejectTeacherApplicationRequest(note)
+        );
+    }
+
+    private TeacherApplicationRow toRow(TeacherApplicationResponse application) {
+        return new TeacherApplicationRow(
+            application,
+            statusLabel(application.status())
+        );
+    }
+
+    private ClassroomOption toClassroomOption(Classroom classroom) {
+        return new ClassroomOption(
+            classroom.getId(),
+            classroom.getName()
+        );
+    }
+
+    private String statusLabel(TeacherApplicationStatus status) {
+        return switch (status) {
+            case PENDING -> "승인 대기";
+            case APPROVED -> "승인";
+            case REJECTED -> "반려";
+            case CANCELLED -> "취소";
+        };
+    }
+
+    public record TeacherApplicationFilter(
+        TeacherApplicationStatus status,
+        String keyword,
+        Integer page,
+        Integer size
+    ) {
+    }
+
+    public record TeacherApplicationPage(
+        AdminPage<TeacherApplicationRow> applications,
+        TeacherApplicationFilter filter,
+        List<StatusOption> statusOptions
+    ) {
+    }
+
+    public record TeacherApplicationRow(
+        TeacherApplicationResponse application,
+        String statusLabel
+    ) {
+    }
+
+    public record TeacherApplicationDetail(
+        TeacherApplicationResponse application,
+        String statusLabel,
+        boolean pending,
+        List<ClassroomOption> classroomOptions
+    ) {
+    }
+
+    public record StatusOption(
+        TeacherApplicationStatus status,
+        String label
+    ) {
+    }
+
+    public record ClassroomOption(
+        Long id,
+        String name
+    ) {
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/teacher_application/service/TeacherApplicationAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/teacher_application/service/TeacherApplicationAdminViewService.java
@@ -28,8 +28,12 @@ public class TeacherApplicationAdminViewService {
 
     public TeacherApplicationPage getTeacherApplications(TeacherApplicationFilter filter) {
         TeacherApplicationPaginationRequest request = new TeacherApplicationPaginationRequest();
-        request.setPage(filter.page());
-        request.setSize(filter.size());
+        if (filter.page() != null) {
+            request.setPage(filter.page());
+        }
+        if (filter.size() != null) {
+            request.setSize(filter.size());
+        }
         request.setKeyword(filter.keyword());
 
         PaginationResponse<TeacherApplicationResponse> response =

--- a/src/main/java/geumjeongyahak/domain/teacher_application/v1/controller/TeacherApplicationViewController.java
+++ b/src/main/java/geumjeongyahak/domain/teacher_application/v1/controller/TeacherApplicationViewController.java
@@ -1,0 +1,132 @@
+package geumjeongyahak.domain.teacher_application.v1.controller;
+
+import geumjeongyahak.common.security.service.CustomUserDetails;
+import geumjeongyahak.domain.teacher_application.enums.TeacherApplicationStatus;
+import geumjeongyahak.domain.teacher_application.service.TeacherApplicationAdminViewService;
+import geumjeongyahak.domain.teacher_application.service.TeacherApplicationAdminViewService.TeacherApplicationFilter;
+import geumjeongyahak.domain.teacher_application.v1.dto.request.ApproveTeacherApplicationRequest;
+import geumjeongyahak.domain.teacher_application.v1.dto.request.RejectTeacherApplicationRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequestMapping("/admin/request/teacher-applications")
+@RequiredArgsConstructor
+public class TeacherApplicationViewController {
+
+    private static final String TEACHER_APPLICATION_READ_ACCESS =
+        "hasRole('ADMIN') or hasAuthority('teacher-application:read:*')";
+    private static final String TEACHER_APPLICATION_MANAGE_ACCESS =
+        "hasRole('ADMIN') or hasAuthority('teacher-application:manage:*')";
+
+    private final TeacherApplicationAdminViewService teacherApplicationAdminViewService;
+
+    @PreAuthorize(TEACHER_APPLICATION_READ_ACCESS)
+    @GetMapping
+    public String teacherApplications(
+        @RequestParam(required = false) TeacherApplicationStatus status,
+        @RequestParam(required = false) String keyword,
+        @RequestParam(required = false) Integer page,
+        @RequestParam(required = false) Integer size,
+        Model model,
+        Authentication authentication
+    ) {
+        TeacherApplicationFilter filter = new TeacherApplicationFilter(status, keyword, page, size);
+
+        model.addAttribute("active", "teacherApplications");
+        model.addAttribute("adminName", authentication.getName());
+        model.addAttribute("pageModel", teacherApplicationAdminViewService.getTeacherApplications(filter));
+        return "admin/request/teacher-application/teacher-applications";
+    }
+
+    @PreAuthorize(TEACHER_APPLICATION_READ_ACCESS)
+    @GetMapping("/{applicationId}")
+    public String teacherApplicationDetail(
+        @PathVariable Long applicationId,
+        Model model,
+        Authentication authentication
+    ) {
+        model.addAttribute("active", "teacherApplications");
+        model.addAttribute("adminName", authentication.getName());
+        model.addAttribute("detail", teacherApplicationAdminViewService.getTeacherApplication(applicationId));
+        return "admin/request/teacher-application/teacher-application-detail";
+    }
+
+    @PreAuthorize(TEACHER_APPLICATION_MANAGE_ACCESS)
+    @PostMapping("/{applicationId}/approve")
+    public String approve(
+        @PathVariable Long applicationId,
+        @Valid @ModelAttribute ApproveTeacherApplicationRequest request,
+        BindingResult bindingResult,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        RedirectAttributes redirectAttributes
+    ) {
+        if (bindingResult.hasErrors()) {
+            redirectAttributes.addFlashAttribute("error", getValidationMessage(bindingResult));
+            return "redirect:/admin/request/teacher-applications/" + applicationId;
+        }
+
+        teacherApplicationAdminViewService.approve(
+            userDetails.getUserId(),
+            applicationId,
+            request.classroomId(),
+            request.teacherStartAt(),
+            request.teacherEndAt(),
+            request.note()
+        );
+        redirectAttributes.addFlashAttribute("message", "교원 신청을 승인했습니다.");
+        return "redirect:/admin/request/teacher-applications/" + applicationId;
+    }
+
+    @PreAuthorize(TEACHER_APPLICATION_MANAGE_ACCESS)
+    @PostMapping("/{applicationId}/reject")
+    public String reject(
+        @PathVariable Long applicationId,
+        @Valid @ModelAttribute RejectTeacherApplicationRequest request,
+        BindingResult bindingResult,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        RedirectAttributes redirectAttributes
+    ) {
+        if (bindingResult.hasErrors()) {
+            redirectAttributes.addFlashAttribute("error", getValidationMessage(bindingResult));
+            return "redirect:/admin/request/teacher-applications/" + applicationId;
+        }
+
+        teacherApplicationAdminViewService.reject(userDetails.getUserId(), applicationId, request.note());
+        redirectAttributes.addFlashAttribute("message", "교원 신청을 반려했습니다.");
+        return "redirect:/admin/request/teacher-applications/" + applicationId;
+    }
+
+    private String getValidationMessage(BindingResult bindingResult) {
+        return bindingResult.getAllErrors()
+            .stream()
+            .findFirst()
+            .map(this::getErrorMessage)
+            .orElse("입력값이 올바르지 않습니다.");
+    }
+
+    private String getErrorMessage(ObjectError error) {
+        if (error instanceof FieldError fieldError && fieldError.getDefaultMessage() != null) {
+            return fieldError.getDefaultMessage();
+        }
+        if (error.getDefaultMessage() != null) {
+            return error.getDefaultMessage();
+        }
+        return "입력값이 올바르지 않습니다.";
+    }
+}

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -40,6 +40,10 @@
                 <span>대기 중 결석 요청</span>
                 <strong th:text="${summary.pendingAbsenceRequestCount}">0</strong>
             </a>
+            <a class="metric" th:href="@{/admin/request/teacher-applications(status='PENDING')}">
+                <span>대기 중 교원 신청</span>
+                <strong th:text="${summary.pendingTeacherApplicationCount}">0</strong>
+            </a>
             <a class="metric" th:href="@{/admin/lesson/lessons}">
                 <span>전체 수업</span>
                 <strong th:text="${summary.lessonCount}">0</strong>
@@ -132,6 +136,10 @@
                 <a class="metric" th:href="@{/admin/request/absence/absence-requests}">
                     <span>결석 요청</span>
                     <p style="font-size: 13px; margin: 4px 0 0;">교사 결석 요청 처리 현황 확인</p>
+                </a>
+                <a class="metric" th:href="@{/admin/request/teacher-applications}">
+                    <span>교원 신청</span>
+                    <p style="font-size: 13px; margin: 4px 0 0;">신규 교원 지원서 검토와 승인 처리</p>
                 </a>
             </div>
         </section>

--- a/src/main/resources/templates/admin/fragments/layout.html
+++ b/src/main/resources/templates/admin/fragments/layout.html
@@ -500,6 +500,7 @@
             <a th:href="@{/admin/daily-schedule/daily-schedules}" th:classappend="${active == 'dailySchedules'} ? 'active'">하루 일정</a>
             <a th:href="@{/admin/request/absence/absence-requests}" th:classappend="${active == 'absenceRequests'} ? 'active'">결석 요청</a>
             <a th:href="@{/admin/request/lesson-exchange}" th:classappend="${active == 'lessonExchangeRequests'} ? 'active'">수업 교환</a>
+            <a th:href="@{/admin/request/teacher-applications}" th:classappend="${active == 'teacherApplications'} ? 'active'">교원 신청</a>
             <a th:href="@{/admin/request/purchase/purchase-requests}" th:classappend="${active == 'purchaseRequests'} ? 'active'">구매 요청</a>
             <a th:href="@{/admin/request/purchase/vendors}" th:classappend="${active == 'vendors'} ? 'active'">거래처</a>
         </nav>

--- a/src/main/resources/templates/admin/request/teacher-application/teacher-application-detail.html
+++ b/src/main/resources/templates/admin/request/teacher-application/teacher-application-detail.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/layout :: head('교원 신청 상세')}"></head>
+<body>
+<div th:replace="~{admin/fragments/layout :: shell(~{::main})}">
+    <main class="stack">
+        <div class="page-title">
+            <div>
+                <h1 th:text="|${detail.application.applicantName} 교원 신청|">교원 신청</h1>
+                <p>교원 지원서 상세와 승인, 반려 처리를 관리합니다.</p>
+            </div>
+            <div>
+                <a class="reset-link" th:href="@{/admin/request/teacher-applications}">목록</a>
+            </div>
+        </div>
+
+        <div class="flash" style="background: #fff0ed; color: var(--danger);" th:if="${error}" th:text="${error}">
+            입력값이 올바르지 않습니다.
+        </div>
+
+        <section class="panel detail-grid">
+            <div class="detail-item">
+                <span>상태</span>
+                <strong>
+                    <span class="pill"
+                          th:classappend="'status-' + ${detail.application.status.name()}"
+                          th:text="${detail.statusLabel}">승인 대기</span>
+                </strong>
+            </div>
+            <div class="detail-item">
+                <span>신청자</span>
+                <strong>
+                    <a class="link"
+                       th:href="@{/admin/user/users/{userId}(userId=${detail.application.applicantId})}"
+                       th:text="|${detail.application.applicantName} (#${detail.application.applicantId})|">홍길동 (#5)</a>
+                </strong>
+            </div>
+            <div class="detail-item">
+                <span>연락처</span>
+                <strong th:text="${detail.application.applicantPhoneNumber}">010-0000-0000</strong>
+            </div>
+            <div class="detail-item">
+                <span>이메일</span>
+                <strong th:text="${detail.application.applicantEmail}">hong@example.com</strong>
+            </div>
+            <div class="detail-item">
+                <span>생년월일</span>
+                <strong th:text="${detail.application.birthDate}">1999-03-15</strong>
+            </div>
+            <div class="detail-item">
+                <span>주소</span>
+                <strong th:text="${detail.application.address}">부산광역시 금정구</strong>
+            </div>
+            <div class="detail-item">
+                <span>최종 학력 및 전공</span>
+                <strong th:text="${detail.application.educationAndMajor}">부산대학교 국어국문학과 졸업</strong>
+            </div>
+            <div class="detail-item">
+                <span>신청일</span>
+                <strong th:text="${#temporals.format(detail.application.createdAt, 'yyyy.MM.dd HH:mm')}">2026.05.24 10:00</strong>
+            </div>
+            <div class="detail-item">
+                <span>처리자</span>
+                <strong th:text="${detail.application.reviewedByName ?: '-'}">-</strong>
+            </div>
+            <div class="detail-item">
+                <span>처리일</span>
+                <strong th:text="${detail.application.reviewedAt != null ? #temporals.format(detail.application.reviewedAt, 'yyyy.MM.dd HH:mm') : '-'}">-</strong>
+            </div>
+            <div class="detail-item" style="grid-column: 1 / -1;">
+                <span>승인 메모 또는 반려 사유</span>
+                <strong th:text="${detail.application.reviewNote ?: '-'}">-</strong>
+            </div>
+        </section>
+
+        <section class="panel detail-grid">
+            <div class="detail-item">
+                <span>선호 과목</span>
+                <strong th:text="${detail.application.preferredSubjectName}">국어</strong>
+            </div>
+            <div class="detail-item">
+                <span>선호 분반</span>
+                <strong th:text="${detail.application.preferredClassroomName}">국화반</strong>
+            </div>
+            <div class="detail-item">
+                <span>요일</span>
+                <strong th:text="${detail.application.preferredDayOfWeek}">FRIDAY</strong>
+            </div>
+            <div class="detail-item">
+                <span>시간</span>
+                <strong th:text="|${detail.application.preferredStartTime} - ${detail.application.preferredEndTime}|">19:00 - 22:00</strong>
+            </div>
+        </section>
+
+        <section class="panel stack">
+            <h2>지원서 답변</h2>
+            <div class="detail-item">
+                <span>금정열린배움터에 관심을 가지게 된 동기</span>
+                <strong style="white-space: pre-wrap;" th:text="${detail.application.motivation}">지원 동기</strong>
+            </div>
+            <div class="detail-item">
+                <span>금정열린배움터에서 희망하는 교사상</span>
+                <strong style="white-space: pre-wrap;" th:text="${detail.application.desiredTeacherImage}">교사상</strong>
+            </div>
+            <div class="detail-item">
+                <span>지원자가 생각하는 나눔의 의미</span>
+                <strong style="white-space: pre-wrap;" th:text="${detail.application.meaningOfSharing}">나눔의 의미</strong>
+            </div>
+        </section>
+
+        <section class="panel stack" th:if="${detail.pending}">
+            <h2>신청 처리</h2>
+            <form class="form-grid"
+                  th:action="@{/admin/request/teacher-applications/{applicationId}/approve(applicationId=${detail.application.id})}"
+                  method="post">
+                <label>배정 분반
+                    <select name="classroomId" required>
+                        <option value="">분반 선택</option>
+                        <option th:each="classroom : ${detail.classroomOptions}"
+                                th:value="${classroom.id}"
+                                th:text="${classroom.name}">국화반</option>
+                    </select>
+                </label>
+                <label>교원 활동 시작일
+                    <input type="date" name="teacherStartAt" required>
+                </label>
+                <label>교원 활동 종료일
+                    <input type="date" name="teacherEndAt" required>
+                </label>
+                <label>승인 메모
+                    <textarea name="note" placeholder="면접 후 승인"></textarea>
+                </label>
+                <div>
+                    <button class="button" type="submit">승인</button>
+                </div>
+            </form>
+            <form class="form-grid"
+                  th:action="@{/admin/request/teacher-applications/{applicationId}/reject(applicationId=${detail.application.id})}"
+                  method="post">
+                <label>반려 사유
+                    <textarea name="note" placeholder="반려 사유" required></textarea>
+                </label>
+                <div>
+                    <button class="button danger" type="submit">반려</button>
+                </div>
+            </form>
+        </section>
+
+        <section class="panel" th:unless="${detail.pending}">
+            <p style="margin: 0; font-weight: 800;">이미 처리된 교원 신청입니다.</p>
+        </section>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/request/teacher-application/teacher-applications.html
+++ b/src/main/resources/templates/admin/request/teacher-application/teacher-applications.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/layout :: head('교원 신청 관리')}"></head>
+<body>
+<div th:replace="~{admin/fragments/layout :: shell(~{::main})}">
+    <main class="stack">
+        <div class="page-title">
+            <div>
+                <h1>교원 신청</h1>
+                <p>교원 지원서를 상태와 검색어 기준으로 조회합니다.</p>
+            </div>
+        </div>
+
+        <div class="flash" style="background: #fff0ed; color: var(--danger);" th:if="${error}" th:text="${error}">
+            입력값이 올바르지 않습니다.
+        </div>
+
+        <form class="panel filter-grid" th:action="@{/admin/request/teacher-applications}" method="get">
+            <label>검색어
+                <input name="keyword" th:value="${pageModel.filter.keyword}" placeholder="이름, 이메일, 연락처, 과목">
+            </label>
+            <label>상태
+                <select name="status">
+                    <option value="">전체</option>
+                    <option th:each="option : ${pageModel.statusOptions}"
+                            th:value="${option.status.name()}"
+                            th:text="${option.label}"
+                            th:selected="${pageModel.filter.status == option.status}">승인 대기</option>
+                </select>
+            </label>
+            <label>페이지 크기
+                <select name="size">
+                    <option value="10" th:selected="${pageModel.applications.size == 10}">10</option>
+                    <option value="20" th:selected="${pageModel.applications.size == 20}">20</option>
+                    <option value="50" th:selected="${pageModel.applications.size == 50}">50</option>
+                    <option value="100" th:selected="${pageModel.applications.size == 100}">100</option>
+                </select>
+            </label>
+            <button class="button" type="submit">조회</button>
+            <a class="reset-link" th:href="@{/admin/request/teacher-applications}">초기화</a>
+        </form>
+
+        <section class="panel table-panel">
+            <div class="table-scroll">
+                <table>
+                    <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>신청자</th>
+                        <th>연락처</th>
+                        <th>이메일</th>
+                        <th>선호 과목</th>
+                        <th>선호 분반</th>
+                        <th>상태</th>
+                        <th>신청일</th>
+                        <th>처리일</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="row : ${pageModel.applications.content}">
+                        <td th:text="${row.application.id}">1</td>
+                        <td>
+                            <a class="link"
+                               th:href="@{/admin/request/teacher-applications/{applicationId}(applicationId=${row.application.id})}"
+                               th:text="${row.application.applicantName}">홍길동</a>
+                        </td>
+                        <td th:text="${row.application.applicantPhoneNumber}">010-0000-0000</td>
+                        <td th:text="${row.application.applicantEmail}">hong@example.com</td>
+                        <td th:text="${row.application.preferredSubjectName}">국어</td>
+                        <td th:text="${row.application.preferredClassroomName}">국화반</td>
+                        <td>
+                            <span class="pill"
+                                  th:classappend="'status-' + ${row.application.status.name()}"
+                                  th:text="${row.statusLabel}">승인 대기</span>
+                        </td>
+                        <td th:text="${#temporals.format(row.application.createdAt, 'yyyy.MM.dd HH:mm')}">2026.05.24 10:00</td>
+                        <td th:text="${row.application.reviewedAt != null ? #temporals.format(row.application.reviewedAt, 'yyyy.MM.dd HH:mm') : '-'}">-</td>
+                    </tr>
+                    <tr th:if="${#lists.isEmpty(pageModel.applications.content)}">
+                        <td colspan="9" class="empty">교원 신청이 없습니다.</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+            <div class="pager">
+                <span th:text="|총 ${pageModel.applications.totalElements}건 · ${pageModel.applications.page + 1}/${pageModel.applications.totalPages == 0 ? 1 : pageModel.applications.totalPages} 페이지|">총 0건</span>
+                <div>
+                    <a class="reset-link"
+                       th:classappend="${!pageModel.applications.hasPrevious()} ? 'disabled'"
+                       th:href="@{/admin/request/teacher-applications(status=${pageModel.filter.status},keyword=${pageModel.filter.keyword},size=${pageModel.applications.size},page=${pageModel.applications.previousPage()})}">이전</a>
+                    <a class="reset-link"
+                       th:classappend="${!pageModel.applications.hasNext()} ? 'disabled'"
+                       th:href="@{/admin/request/teacher-applications(status=${pageModel.filter.status},keyword=${pageModel.filter.keyword},size=${pageModel.applications.size},page=${pageModel.applications.nextPage()})}">다음</a>
+                </div>
+            </div>
+        </section>
+    </main>
+</div>
+</body>
+</html>

--- a/src/test/java/geumjeongyahak/e2e/teacher_application/TeacherApplicationAdminViewTest.java
+++ b/src/test/java/geumjeongyahak/e2e/teacher_application/TeacherApplicationAdminViewTest.java
@@ -1,0 +1,207 @@
+package geumjeongyahak.e2e.teacher_application;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import geumjeongyahak.e2e.BaseE2ETest;
+import io.restassured.http.ContentType;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@Tag("teacher-application")
+@DisplayName("E2E: 교원 신청 관리자 화면 테스트")
+@ResourceLock("teacher-application-e2e-shared-state")
+class TeacherApplicationAdminViewTest extends BaseE2ETest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private String sessionId;
+
+    @BeforeEach
+    @Override
+    protected void setUp() {
+        super.setUp();
+        cleanupTeacherApplications();
+        resetApplicant();
+        sessionId = loginAdminSession();
+    }
+
+    @AfterEach
+    void cleanup() {
+        cleanupTeacherApplications();
+        resetApplicant();
+    }
+
+    @Test
+    @DisplayName("관리자 교원 신청 목록 화면을 조회할 수 있다")
+    void teacherApplicationsPage_asAdmin_rendersList() {
+        insertTeacherApplication(120L, "PENDING", "이영희", "지원 동기");
+
+        given()
+            .cookie("JSESSIONID", sessionId)
+        .when()
+            .get("/admin/request/teacher-applications")
+        .then()
+            .statusCode(200)
+            .contentType(containsString("text/html"))
+            .body(containsString("교원 신청"))
+            .body(containsString("이영희"))
+            .body(containsString("승인 대기"));
+    }
+
+    @Test
+    @DisplayName("관리자 교원 신청 상세 화면을 조회할 수 있다")
+    void teacherApplicationDetailPage_asAdmin_rendersDetail() {
+        insertTeacherApplication(121L, "PENDING", "이영희", "금정열린배움터에서 함께 배우고 싶습니다.");
+
+        given()
+            .cookie("JSESSIONID", sessionId)
+        .when()
+            .get("/admin/request/teacher-applications/{applicationId}", 121L)
+        .then()
+            .statusCode(200)
+            .contentType(containsString("text/html"))
+            .body(containsString("이영희 교원 신청"))
+            .body(containsString("금정열린배움터에서 함께 배우고 싶습니다."))
+            .body(containsString("신청 처리"))
+            .body(containsString("배정 분반"))
+            .body(containsString("반려 사유"));
+    }
+
+    @Test
+    @DisplayName("관리자 대시보드에서 교원 신청 진입점과 대기 건수를 확인할 수 있다")
+    void dashboard_asAdmin_rendersTeacherApplicationEntry() {
+        insertTeacherApplication(122L, "PENDING", "이영희", "지원 동기");
+
+        given()
+            .cookie("JSESSIONID", sessionId)
+        .when()
+            .get("/admin")
+        .then()
+            .statusCode(200)
+            .contentType(containsString("text/html"))
+            .body(containsString("대기 중 교원 신청"))
+            .body(containsString("/admin/request/teacher-applications?status=PENDING"))
+            .body(containsString("<strong>1</strong>"));
+    }
+
+    @Test
+    @DisplayName("관리자 화면에서 교원 신청을 승인할 수 있다")
+    void approveTeacherApplicationFromAdminPage_redirectsAndApproves() {
+        insertTeacherApplication(123L, "PENDING", "이영희", "지원 동기");
+
+        given()
+            .cookie("JSESSIONID", sessionId)
+            .contentType(ContentType.URLENC)
+            .formParam("classroomId", 2)
+            .formParam("teacherStartAt", "2026-06-01")
+            .formParam("teacherEndAt", "2026-12-31")
+            .formParam("note", "면접 후 승인")
+            .redirects()
+            .follow(false)
+        .when()
+            .post("/admin/request/teacher-applications/{applicationId}/approve", 123L)
+        .then()
+            .statusCode(302)
+            .header("Location", containsString("/admin/request/teacher-applications/123"));
+
+        String status = jdbcTemplate.queryForObject(
+            "SELECT status FROM teacher_applications WHERE id = 123",
+            String.class
+        );
+        String role = jdbcTemplate.queryForObject("SELECT role FROM users WHERE id = 4", String.class);
+        assertThat(status).isEqualTo("APPROVED");
+        assertThat(role).isEqualTo("VOLUNTEER");
+    }
+
+    @Test
+    @DisplayName("관리자 화면에서 교원 신청을 반려할 수 있다")
+    void rejectTeacherApplicationFromAdminPage_redirectsAndRejects() {
+        insertTeacherApplication(124L, "PENDING", "이영희", "지원 동기");
+
+        given()
+            .cookie("JSESSIONID", sessionId)
+            .contentType(ContentType.URLENC)
+            .formParam("note", "reject-note")
+            .redirects()
+            .follow(false)
+        .when()
+            .post("/admin/request/teacher-applications/{applicationId}/reject", 124L)
+        .then()
+            .statusCode(302)
+            .header("Location", containsString("/admin/request/teacher-applications/124"));
+
+        String status = jdbcTemplate.queryForObject(
+            "SELECT status FROM teacher_applications WHERE id = 124",
+            String.class
+        );
+        String note = jdbcTemplate.queryForObject(
+            "SELECT review_note FROM teacher_applications WHERE id = 124",
+            String.class
+        );
+        assertThat(status).isEqualTo("REJECTED");
+        assertThat(note).isEqualTo("reject-note");
+    }
+
+    private String loginAdminSession() {
+        return given()
+            .contentType(ContentType.URLENC)
+            .formParam("username", TEST_ADMIN_EMAIL)
+            .formParam("password", TEST_ADMIN_PASSWORD)
+            .redirects()
+            .follow(false)
+        .when()
+            .post("/admin/auth/login")
+        .then()
+            .statusCode(302)
+            .extract()
+            .cookie("JSESSIONID");
+    }
+
+    private void insertTeacherApplication(Long id, String status, String applicantName, String motivation) {
+        jdbcTemplate.update("""
+            INSERT INTO teacher_applications (
+                id, applicant_id, applicant_name, applicant_phone_number, applicant_email,
+                birth_date, address, education_and_major, preferred_subject_id,
+                motivation, desired_teacher_image, meaning_of_sharing,
+                status, reviewed_at, reviewed_by, review_note, created_at, updated_at
+            )
+            VALUES (?, 4, ?, '010-1234-5678', 'guest01@test.com',
+                    '1999-03-15', '부산광역시 금정구', '부산대학교 국어국문학과 졸업', 1,
+                    ?, '희망하는 교사상', '나눔의 의미',
+                    ?, NULL, NULL, NULL, ?, ?)
+            """,
+            id,
+            applicantName,
+            motivation,
+            status,
+            LocalDateTime.parse("2026-05-20T10:00:00"),
+            LocalDateTime.parse("2026-05-20T10:00:00")
+        );
+    }
+
+    private void cleanupTeacherApplications() {
+        jdbcTemplate.update("DELETE FROM teacher_applications");
+    }
+
+    private void resetApplicant() {
+        jdbcTemplate.update("""
+            UPDATE users
+            SET role = 'GUEST',
+                classroom_id = NULL,
+                teacher_start_at = NULL,
+                teacher_end_at = NULL
+            WHERE id = 4
+            """);
+        jdbcTemplate.update("DELETE FROM user_permissions WHERE user_id = 4 AND permission_code LIKE 'channel:write:%'");
+    }
+}


### PR DESCRIPTION
## 개요

교원 신청을 관리자 화면에서 조회하고 처리할 수 있도록 관리자 페이지를 추가했습니다.

## 변경 유형

- [x] 새 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [x] 테스트 (test)
- [ ] 기타 (chore)

## 변경 내용

- 교원 신청 관리자 뷰 서비스 추가
- 교원 신청 관리자 목록/상세 컨트롤러 추가
- 교원 신청 관리자 목록/상세 Thymeleaf 템플릿 추가
- 관리자 사이드바 및 대시보드에 교원 신청 진입점 추가
- 대기 중 교원 신청 수를 대시보드 요약에 추가
- 관리자 화면 E2E 테스트 추가

## 관련 이슈

Closes #108

## 스크린샷 (선택)

- 관리자 대시보드 교원 신청 진입점
- 교원 신청 목록 화면
- 교원 신청 상세 및 승인/반려 처리 화면

## 체크리스트

- [x] 코드 컨벤션을 준수했습니다
- [x] 테스트 코드를 작성/수정했습니다
- [x] 모든 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)

## 리뷰어에게

- 승인 시 분반, 교원 활동 시작일, 교원 활동 종료일을 입력받고 기존 교원 승인 이벤트 흐름을 재사용합니다.
- 과목 배정은 자동 처리하지 않고 기존 과목 관리 흐름에서 별도로 처리하는 전제로 구현했습니다.
- 관리자 화면 권한은 API와 동일하게 조회 권한과 관리 권한을 분리했습니다.