### PR TITLE
[FEAT] 행사 일정 관리자 페이지 구현

### DIFF
--- a/src/main/java/geumjeongyahak/domain/base/service/AdminDashboardService.java
+++ b/src/main/java/geumjeongyahak/domain/base/service/AdminDashboardService.java
@@ -4,6 +4,7 @@ import geumjeongyahak.domain.lesson.enums.LessonStatus;
 import geumjeongyahak.domain.lesson.repository.LessonRepository;
 import geumjeongyahak.domain.classroom.repository.ClassroomRepository;
 import geumjeongyahak.domain.department.repository.DepartmentRepository;
+import geumjeongyahak.domain.event.repository.EventRepository;
 import geumjeongyahak.domain.purchase_request.enums.PurchaseRequestStatus;
 import geumjeongyahak.domain.purchase_request.repository.PurchaseRequestRepository;
 import geumjeongyahak.domain.request.enums.RequestStatus;
@@ -34,6 +35,7 @@ public class AdminDashboardService {
     private final LessonRepository lessonRepository;
     private final SubjectRepository subjectRepository;
     private final TeacherApplicationRepository teacherApplicationRepository;
+    private final EventRepository eventRepository;
 
     public AdminDashboardSummary getSummary() {
         LocalDate today = LocalDate.now();
@@ -52,6 +54,7 @@ public class AdminDashboardService {
             lessonRepository.countByIsDeletedFalse(),
             lessonRepository.countByIsDeletedFalseAndDate(today),
             lessonRepository.countByStatusAndIsDeletedFalseAndDateBetween(LessonStatus.SCHEDULED, weekStart, weekEnd),
+            eventRepository.countByIsDeletedFalseAndEventDateGreaterThanEqual(today),
             today,
             weekStart,
             weekEnd
@@ -70,6 +73,7 @@ public class AdminDashboardService {
         long lessonCount,
         long todayLessonCount,
         long weeklyScheduledLessonCount,
+        long upcomingEventCount,
         LocalDate today,
         LocalDate weekStart,
         LocalDate weekEnd

--- a/src/main/java/geumjeongyahak/domain/event/exception/EventFormValidationException.java
+++ b/src/main/java/geumjeongyahak/domain/event/exception/EventFormValidationException.java
@@ -1,0 +1,11 @@
+package geumjeongyahak.domain.event.exception;
+
+import geumjeongyahak.common.exception.BadRequestException;
+import geumjeongyahak.common.exception.CommonErrorCode;
+
+public class EventFormValidationException extends BadRequestException {
+
+    public EventFormValidationException(String message) {
+        super(CommonErrorCode.VALIDATION_ERROR, message);
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/event/repository/EventRepository.java
+++ b/src/main/java/geumjeongyahak/domain/event/repository/EventRepository.java
@@ -1,6 +1,7 @@
 package geumjeongyahak.domain.event.repository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -21,6 +22,9 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     @EntityGraph(attributePaths = {"createdBy", "updatedBy"})
     Page<Event> findAllByIsDeletedFalse(Pageable pageable);
+
+    @EntityGraph(attributePaths = {"createdBy", "updatedBy"})
+    List<Event> findAllByIsDeletedFalseOrderByEventDateAscStartTimeAscIdAsc();
 
     @EntityGraph(attributePaths = {"createdBy", "updatedBy"})
     Optional<Event> findByIdAndIsDeletedFalse(Long id);

--- a/src/main/java/geumjeongyahak/domain/event/repository/EventRepository.java
+++ b/src/main/java/geumjeongyahak/domain/event/repository/EventRepository.java
@@ -13,6 +13,8 @@ import geumjeongyahak.domain.event.entity.Event;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
 
+    long countByIsDeletedFalseAndEventDateGreaterThanEqual(LocalDate eventDate);
+
     @EntityGraph(attributePaths = {"createdBy", "updatedBy"})
     Page<Event> findAllByIsDeletedFalseAndEventDateBetween(
         LocalDate startDate,

--- a/src/main/java/geumjeongyahak/domain/event/service/EventAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/event/service/EventAdminViewService.java
@@ -6,6 +6,7 @@ import java.time.LocalTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,8 +14,13 @@ import org.springframework.transaction.annotation.Transactional;
 import geumjeongyahak.domain.base.dto.response.AdminPage;
 import geumjeongyahak.domain.base.dto.response.AdminSorts;
 import geumjeongyahak.domain.event.entity.Event;
+import geumjeongyahak.domain.event.exception.EventFormValidationException;
 import geumjeongyahak.domain.event.exception.EventNotFoundException;
 import geumjeongyahak.domain.event.repository.EventRepository;
+import geumjeongyahak.domain.event.v1.dto.request.CreateEventRequest;
+import geumjeongyahak.domain.event.v1.dto.request.UpdateEventRequest;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -23,6 +29,8 @@ import lombok.RequiredArgsConstructor;
 public class EventAdminViewService {
 
     private final EventRepository eventRepository;
+    private final EventService eventService;
+    private final Validator validator;
 
     public AdminPage<AdminEventRow> getEvents(EventFilter filter) {
         List<AdminEventRow> rows = eventRepository.findAllByIsDeletedFalseOrderByEventDateAscStartTimeAscIdAsc()
@@ -40,12 +48,40 @@ public class EventAdminViewService {
             .orElseThrow(() -> new EventNotFoundException(eventId));
     }
 
+    @Transactional
+    public Long createEvent(Long requesterId, CreateEventRequest request) {
+        validate(request);
+        return eventService.createEvent(requesterId, request).id();
+    }
+
+    @Transactional
+    public void updateEvent(Long requesterId, Long eventId, UpdateEventRequest request) {
+        validate(request);
+        eventService.updateEvent(requesterId, eventId, request);
+    }
+
+    @Transactional
+    public void deleteEvent(Long requesterId, Long eventId) {
+        eventService.deleteEvent(requesterId, eventId);
+    }
+
     private boolean matchesDateRange(Event event, LocalDate startDate, LocalDate endDate) {
         LocalDate eventDate = event.getEventDate();
         if (startDate != null && eventDate.isBefore(startDate)) {
             return false;
         }
         return endDate == null || !eventDate.isAfter(endDate);
+    }
+
+    private <T> void validate(T request) {
+        Set<ConstraintViolation<T>> violations = validator.validate(request);
+        if (!violations.isEmpty()) {
+            String message = violations.stream()
+                .findFirst()
+                .map(ConstraintViolation::getMessage)
+                .orElse("행사 입력값이 올바르지 않습니다.");
+            throw new EventFormValidationException(message);
+        }
     }
 
     private List<AdminEventRow> sortEvents(List<AdminEventRow> rows, String sort) {

--- a/src/main/java/geumjeongyahak/domain/event/service/EventAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/event/service/EventAdminViewService.java
@@ -1,0 +1,120 @@
+package geumjeongyahak.domain.event.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import geumjeongyahak.domain.base.dto.response.AdminPage;
+import geumjeongyahak.domain.base.dto.response.AdminSorts;
+import geumjeongyahak.domain.event.entity.Event;
+import geumjeongyahak.domain.event.exception.EventNotFoundException;
+import geumjeongyahak.domain.event.repository.EventRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EventAdminViewService {
+
+    private final EventRepository eventRepository;
+
+    public AdminPage<AdminEventRow> getEvents(EventFilter filter) {
+        List<AdminEventRow> rows = eventRepository.findAllByIsDeletedFalseOrderByEventDateAscStartTimeAscIdAsc()
+            .stream()
+            .filter(event -> matchesDateRange(event, filter.startDate(), filter.endDate()))
+            .map(AdminEventRow::from)
+            .toList();
+
+        return AdminPage.from(sortEvents(rows, filter.sort()), filter.page(), filter.size());
+    }
+
+    public AdminEventDetail getEvent(Long eventId) {
+        return eventRepository.findByIdAndIsDeletedFalse(eventId)
+            .map(AdminEventDetail::from)
+            .orElseThrow(() -> new EventNotFoundException(eventId));
+    }
+
+    private boolean matchesDateRange(Event event, LocalDate startDate, LocalDate endDate) {
+        LocalDate eventDate = event.getEventDate();
+        if (startDate != null && eventDate.isBefore(startDate)) {
+            return false;
+        }
+        return endDate == null || !eventDate.isAfter(endDate);
+    }
+
+    private List<AdminEventRow> sortEvents(List<AdminEventRow> rows, String sort) {
+        return AdminSorts.sort(rows, sort, Map.of(
+            "id", Comparator.comparing(AdminEventRow::id, Comparator.nullsLast(Long::compareTo)),
+            "eventDate", Comparator.comparing(AdminEventRow::eventDate, Comparator.nullsLast(LocalDate::compareTo)),
+            "startTime", Comparator.comparing(AdminEventRow::startTime, Comparator.nullsLast(LocalTime::compareTo)),
+            "title", Comparator.comparing(AdminEventRow::title, Comparator.nullsLast(String::compareToIgnoreCase)),
+            "lastModifiedByName", Comparator.comparing(AdminEventRow::lastModifiedByName, Comparator.nullsLast(String::compareToIgnoreCase)),
+            "updatedAt", Comparator.comparing(AdminEventRow::updatedAt, Comparator.nullsLast(LocalDateTime::compareTo))
+        ), "eventDate,ASC;startTime,ASC;id,ASC");
+    }
+
+    public record EventFilter(
+        LocalDate startDate,
+        LocalDate endDate,
+        Integer page,
+        Integer size,
+        String sort
+    ) {
+    }
+
+    public record AdminEventRow(
+        Long id,
+        String title,
+        LocalDate eventDate,
+        LocalTime startTime,
+        LocalTime endTime,
+        String lastModifiedByName,
+        LocalDateTime updatedAt
+    ) {
+        private static AdminEventRow from(Event event) {
+            return new AdminEventRow(
+                event.getId(),
+                event.getTitle(),
+                event.getEventDate(),
+                event.getStartTime(),
+                event.getEndTime(),
+                event.getUpdatedBy().getName(),
+                event.getUpdatedAt()
+            );
+        }
+    }
+
+    public record AdminEventDetail(
+        Long id,
+        String title,
+        String description,
+        LocalDate eventDate,
+        LocalTime startTime,
+        LocalTime endTime,
+        String createdByName,
+        String lastModifiedByName,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+    ) {
+        private static AdminEventDetail from(Event event) {
+            return new AdminEventDetail(
+                event.getId(),
+                event.getTitle(),
+                event.getDescription(),
+                event.getEventDate(),
+                event.getStartTime(),
+                event.getEndTime(),
+                event.getCreatedBy().getName(),
+                event.getUpdatedBy().getName(),
+                event.getCreatedAt(),
+                event.getUpdatedAt()
+            );
+        }
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/event/v1/controller/EventViewController.java
+++ b/src/main/java/geumjeongyahak/domain/event/v1/controller/EventViewController.java
@@ -3,19 +3,27 @@ package geumjeongyahak.domain.event.v1.controller;
 import static org.springframework.format.annotation.DateTimeFormat.ISO.DATE;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 
+import geumjeongyahak.common.exception.BusinessException;
+import geumjeongyahak.common.security.service.CustomUserDetails;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import geumjeongyahak.domain.event.service.EventAdminViewService;
 import geumjeongyahak.domain.event.service.EventAdminViewService.EventFilter;
+import geumjeongyahak.domain.event.v1.dto.request.CreateEventRequest;
+import geumjeongyahak.domain.event.v1.dto.request.UpdateEventRequest;
 import lombok.RequiredArgsConstructor;
 
 @Controller
@@ -49,9 +57,40 @@ public class EventViewController {
     @PreAuthorize(EVENT_MANAGE_ACCESS)
     @GetMapping("/new")
     public String newEvent(Model model, Authentication authentication) {
-        model.addAttribute("active", "events");
-        model.addAttribute("adminName", authentication.getName());
+        addBaseAttributes(model, authentication);
         return "admin/event/events-form";
+    }
+
+    @PreAuthorize(EVENT_MANAGE_ACCESS)
+    @PostMapping
+    public String createEvent(
+        @RequestParam String title,
+        @RequestParam(required = false) String description,
+        @RequestParam @DateTimeFormat(iso = DATE) LocalDate eventDate,
+        @RequestParam(required = false) String startTime,
+        @RequestParam(required = false) String endTime,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        RedirectAttributes redirectAttributes,
+        Model model,
+        Authentication authentication
+    ) {
+        CreateEventRequest request = new CreateEventRequest(
+            title,
+            description,
+            eventDate,
+            parseOptionalTime(startTime),
+            parseOptionalTime(endTime)
+        );
+        try {
+            Long eventId = eventAdminViewService.createEvent(userDetails.getUserId(), request);
+            redirectAttributes.addFlashAttribute("message", "행사를 등록했습니다.");
+            return "redirect:/admin/event/events/" + eventId + "/edit";
+        } catch (BusinessException | IllegalArgumentException exception) {
+            addBaseAttributes(model, authentication);
+            model.addAttribute("errorMessage", exception.getMessage());
+            model.addAttribute("form", request);
+            return "admin/event/events-form";
+        }
     }
 
     @PreAuthorize(EVENT_MANAGE_ACCESS)
@@ -66,4 +105,63 @@ public class EventViewController {
         model.addAttribute("event", eventAdminViewService.getEvent(eventId));
         return "admin/event/events-edit";
     }
+
+    @PreAuthorize(EVENT_MANAGE_ACCESS)
+    @PostMapping("/{eventId}")
+    public String updateEvent(
+        @PathVariable Long eventId,
+        @RequestParam String title,
+        @RequestParam(required = false) String description,
+        @RequestParam @DateTimeFormat(iso = DATE) LocalDate eventDate,
+        @RequestParam(required = false) String startTime,
+        @RequestParam(required = false) String endTime,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        RedirectAttributes redirectAttributes,
+        Model model,
+        Authentication authentication
+    ) {
+        UpdateEventRequest request = new UpdateEventRequest(
+            title,
+            description,
+            eventDate,
+            parseOptionalTime(startTime),
+            parseOptionalTime(endTime)
+        );
+        try {
+            eventAdminViewService.updateEvent(userDetails.getUserId(), eventId, request);
+            redirectAttributes.addFlashAttribute("message", "행사를 수정했습니다.");
+            return "redirect:/admin/event/events/" + eventId + "/edit";
+        } catch (BusinessException | IllegalArgumentException exception) {
+            addBaseAttributes(model, authentication);
+            model.addAttribute("errorMessage", exception.getMessage());
+            model.addAttribute("event", eventAdminViewService.getEvent(eventId));
+            model.addAttribute("form", request);
+            return "admin/event/events-edit";
+        }
+    }
+
+    @PreAuthorize(EVENT_MANAGE_ACCESS)
+    @PostMapping("/{eventId}/delete")
+    public String deleteEvent(
+        @PathVariable Long eventId,
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        RedirectAttributes redirectAttributes
+    ) {
+        eventAdminViewService.deleteEvent(userDetails.getUserId(), eventId);
+        redirectAttributes.addFlashAttribute("message", "행사를 삭제했습니다.");
+        return "redirect:/admin/event/events";
+    }
+
+    private void addBaseAttributes(Model model, Authentication authentication) {
+        model.addAttribute("active", "events");
+        model.addAttribute("adminName", authentication.getName());
+    }
+
+    private LocalTime parseOptionalTime(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return LocalTime.parse(value);
+    }
+
 }

--- a/src/main/java/geumjeongyahak/domain/event/v1/controller/EventViewController.java
+++ b/src/main/java/geumjeongyahak/domain/event/v1/controller/EventViewController.java
@@ -1,0 +1,69 @@
+package geumjeongyahak.domain.event.v1.controller;
+
+import static org.springframework.format.annotation.DateTimeFormat.ISO.DATE;
+
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import geumjeongyahak.domain.event.service.EventAdminViewService;
+import geumjeongyahak.domain.event.service.EventAdminViewService.EventFilter;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequestMapping("/admin/event/events")
+@RequiredArgsConstructor
+public class EventViewController {
+
+    private static final String EVENT_MANAGE_ACCESS = "hasRole('ADMIN') or hasAuthority('event:manage:*')";
+
+    private final EventAdminViewService eventAdminViewService;
+
+    @PreAuthorize(EVENT_MANAGE_ACCESS)
+    @GetMapping
+    public String events(
+        @RequestParam(required = false) @DateTimeFormat(iso = DATE) LocalDate startDate,
+        @RequestParam(required = false) @DateTimeFormat(iso = DATE) LocalDate endDate,
+        @RequestParam(required = false) Integer page,
+        @RequestParam(required = false) Integer size,
+        @RequestParam(required = false) String sort,
+        Model model,
+        Authentication authentication
+    ) {
+        EventFilter filter = new EventFilter(startDate, endDate, page, size, sort);
+        model.addAttribute("active", "events");
+        model.addAttribute("adminName", authentication.getName());
+        model.addAttribute("filter", filter);
+        model.addAttribute("eventsPage", eventAdminViewService.getEvents(filter));
+        return "admin/event/events";
+    }
+
+    @PreAuthorize(EVENT_MANAGE_ACCESS)
+    @GetMapping("/new")
+    public String newEvent(Model model, Authentication authentication) {
+        model.addAttribute("active", "events");
+        model.addAttribute("adminName", authentication.getName());
+        return "admin/event/events-form";
+    }
+
+    @PreAuthorize(EVENT_MANAGE_ACCESS)
+    @GetMapping("/{eventId}/edit")
+    public String editEvent(
+        @PathVariable Long eventId,
+        Model model,
+        Authentication authentication
+    ) {
+        model.addAttribute("active", "events");
+        model.addAttribute("adminName", authentication.getName());
+        model.addAttribute("event", eventAdminViewService.getEvent(eventId));
+        return "admin/event/events-edit";
+    }
+}

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -56,6 +56,10 @@
                 <span>이번 주 예정 수업</span>
                 <strong th:text="${summary.weeklyScheduledLessonCount}">0</strong>
             </a>
+            <a class="metric" th:href="@{/admin/event/events(startDate=${summary.today})}">
+                <span>예정된 행사</span>
+                <strong th:text="${summary.upcomingEventCount}">0</strong>
+            </a>
         </section>
 
         <div class="dashboard-grid">
@@ -103,6 +107,10 @@
                     <a class="metric" th:href="@{/admin/lesson/lessons}">
                         <span>수업 관리</span>
                         <p style="font-size: 13px; margin: 4px 0 0;">수업 일정과 운영 상태 조회</p>
+                    </a>
+                    <a class="metric" th:href="@{/admin/event/events}">
+                        <span>행사 일정 관리</span>
+                        <p style="font-size: 13px; margin: 4px 0 0;">캘린더 행사 일정 등록/수정</p>
                     </a>
                     <a class="metric" th:href="@{/admin/daily-schedule/daily-schedules}">
                         <span>하루 일정 관리</span>

--- a/src/main/resources/templates/admin/event/events-edit.html
+++ b/src/main/resources/templates/admin/event/events-edit.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/layout :: head('행사 수정')}"></head>
+<body>
+<div th:replace="~{admin/fragments/layout :: shell(~{::main})}">
+    <main class="stack">
+        <div class="page-title">
+            <div>
+                <h1>행사 수정</h1>
+                <p th:text="${event.title}">문학의 밤</p>
+            </div>
+            <a class="reset-link" th:href="@{/admin/event/events}">목록으로</a>
+        </div>
+
+        <section class="panel">
+            <h2>기본 정보</h2>
+            <div class="detail-grid">
+                <div class="detail-item">
+                    <span>ID</span>
+                    <strong th:text="${event.id}">1</strong>
+                </div>
+                <div class="detail-item">
+                    <span>생성자</span>
+                    <strong th:text="${event.createdByName}">관리자</strong>
+                </div>
+                <div class="detail-item">
+                    <span>마지막 수정자</span>
+                    <strong th:text="${event.lastModifiedByName}">관리자</strong>
+                </div>
+                <div class="detail-item">
+                    <span>수정일</span>
+                    <strong th:text="${event.updatedAt != null ? #temporals.format(event.updatedAt, 'yyyy.MM.dd HH:mm') : '-'}">2026.05.01 10:00</strong>
+                </div>
+            </div>
+        </section>
+
+        <form class="panel form-grid" method="post">
+            <label>제목
+                <input name="title" maxlength="100" required th:value="${event.title}">
+            </label>
+            <label>행사일
+                <input name="eventDate" type="date" required th:value="${event.eventDate}">
+            </label>
+            <label>시작 시간
+                <input name="startTime" type="time" th:value="${event.startTime}">
+            </label>
+            <label>종료 시간
+                <input name="endTime" type="time" th:value="${event.endTime}">
+            </label>
+            <label>설명
+                <textarea name="description" th:text="${event.description}"></textarea>
+            </label>
+            <button class="button" type="submit" disabled>수정</button>
+        </form>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/event/events-edit.html
+++ b/src/main/resources/templates/admin/event/events-edit.html
@@ -12,6 +12,13 @@
             <a class="reset-link" th:href="@{/admin/event/events}">목록으로</a>
         </div>
 
+        <p class="flash"
+           style="margin: 0; background: #fff0ed; color: var(--danger);"
+           th:if="${errorMessage}"
+           th:text="${errorMessage}">
+            요청을 처리할 수 없습니다.
+        </p>
+
         <section class="panel">
             <h2>기본 정보</h2>
             <div class="detail-grid">
@@ -34,24 +41,33 @@
             </div>
         </section>
 
-        <form class="panel form-grid" method="post">
+        <form class="panel form-grid" th:action="@{/admin/event/events/{eventId}(eventId=${event.id})}" method="post">
             <label>제목
-                <input name="title" maxlength="100" required th:value="${event.title}">
+                <input name="title" maxlength="100" required th:value="${form != null ? form.title : event.title}">
             </label>
             <label>행사일
-                <input name="eventDate" type="date" required th:value="${event.eventDate}">
+                <input name="eventDate" type="date" required th:value="${form != null ? form.eventDate : event.eventDate}">
             </label>
             <label>시작 시간
-                <input name="startTime" type="time" th:value="${event.startTime}">
+                <input name="startTime" type="time" th:value="${form != null ? form.startTime : event.startTime}">
             </label>
             <label>종료 시간
-                <input name="endTime" type="time" th:value="${event.endTime}">
+                <input name="endTime" type="time" th:value="${form != null ? form.endTime : event.endTime}">
             </label>
             <label>설명
-                <textarea name="description" th:text="${event.description}"></textarea>
+                <textarea name="description" th:text="${form != null ? form.description : event.description}"></textarea>
             </label>
-            <button class="button" type="submit" disabled>수정</button>
+            <button class="button" type="submit">수정</button>
         </form>
+
+        <section class="panel">
+            <h2>삭제</h2>
+            <form th:action="@{/admin/event/events/{eventId}/delete(eventId=${event.id})}"
+                  method="post"
+                  onsubmit="return confirm('이 행사를 삭제할까요?');">
+                <button class="button danger" type="submit">행사 삭제</button>
+            </form>
+        </section>
     </main>
 </div>
 </body>

--- a/src/main/resources/templates/admin/event/events-form.html
+++ b/src/main/resources/templates/admin/event/events-form.html
@@ -12,23 +12,30 @@
             <a class="reset-link" th:href="@{/admin/event/events}">목록으로</a>
         </div>
 
-        <form class="panel form-grid" method="post">
+        <p class="flash"
+           style="margin: 0; background: #fff0ed; color: var(--danger);"
+           th:if="${errorMessage}"
+           th:text="${errorMessage}">
+            요청을 처리할 수 없습니다.
+        </p>
+
+        <form class="panel form-grid" th:action="@{/admin/event/events}" method="post">
             <label>제목
-                <input name="title" maxlength="100" required>
+                <input name="title" maxlength="100" required th:value="${form != null ? form.title : ''}">
             </label>
             <label>행사일
-                <input name="eventDate" type="date" required>
+                <input name="eventDate" type="date" required th:value="${form != null ? form.eventDate : ''}">
             </label>
             <label>시작 시간
-                <input name="startTime" type="time">
+                <input name="startTime" type="time" th:value="${form != null ? form.startTime : ''}">
             </label>
             <label>종료 시간
-                <input name="endTime" type="time">
+                <input name="endTime" type="time" th:value="${form != null ? form.endTime : ''}">
             </label>
             <label>설명
-                <textarea name="description"></textarea>
+                <textarea name="description" th:text="${form != null ? form.description : ''}"></textarea>
             </label>
-            <button class="button" type="submit" disabled>등록</button>
+            <button class="button" type="submit">등록</button>
         </form>
     </main>
 </div>

--- a/src/main/resources/templates/admin/event/events-form.html
+++ b/src/main/resources/templates/admin/event/events-form.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/layout :: head('행사 등록')}"></head>
+<body>
+<div th:replace="~{admin/fragments/layout :: shell(~{::main})}">
+    <main class="stack">
+        <div class="page-title">
+            <div>
+                <h1>행사 등록</h1>
+                <p>캘린더에 표시할 행사 일정을 등록합니다.</p>
+            </div>
+            <a class="reset-link" th:href="@{/admin/event/events}">목록으로</a>
+        </div>
+
+        <form class="panel form-grid" method="post">
+            <label>제목
+                <input name="title" maxlength="100" required>
+            </label>
+            <label>행사일
+                <input name="eventDate" type="date" required>
+            </label>
+            <label>시작 시간
+                <input name="startTime" type="time">
+            </label>
+            <label>종료 시간
+                <input name="endTime" type="time">
+            </label>
+            <label>설명
+                <textarea name="description"></textarea>
+            </label>
+            <button class="button" type="submit" disabled>등록</button>
+        </form>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/event/events.html
+++ b/src/main/resources/templates/admin/event/events.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/layout :: head('행사 일정 관리')}"></head>
+<body>
+<div th:replace="~{admin/fragments/layout :: shell(~{::main})}">
+    <main class="stack">
+        <div class="page-title">
+            <div>
+                <h1>행사 일정</h1>
+                <p>캘린더에 표시되는 행사 일정을 날짜 기준으로 조회합니다.</p>
+            </div>
+            <a class="button" th:href="@{/admin/event/events/new}">행사 등록</a>
+        </div>
+
+        <form class="panel filter-grid" th:action="@{/admin/event/events}" method="get">
+            <label>시작일
+                <input name="startDate" type="date" th:value="${filter.startDate}">
+            </label>
+            <label>종료일
+                <input name="endDate" type="date" th:value="${filter.endDate}">
+            </label>
+            <label>페이지 크기
+                <select name="size">
+                    <option value="10" th:selected="${eventsPage.size == 10}">10</option>
+                    <option value="20" th:selected="${eventsPage.size == 20}">20</option>
+                    <option value="50" th:selected="${eventsPage.size == 50}">50</option>
+                    <option value="100" th:selected="${eventsPage.size == 100}">100</option>
+                </select>
+            </label>
+            <label>정렬
+                <select name="sort">
+                    <option value="eventDate,ASC;startTime,ASC;id,ASC" th:selected="${filter.sort == null || filter.sort == 'eventDate,ASC;startTime,ASC;id,ASC'}">날짜 오름차순</option>
+                    <option value="eventDate,DESC;startTime,ASC;id,ASC" th:selected="${filter.sort == 'eventDate,DESC;startTime,ASC;id,ASC'}">날짜 내림차순</option>
+                    <option value="title,ASC" th:selected="${filter.sort == 'title,ASC'}">제목 오름차순</option>
+                    <option value="updatedAt,DESC" th:selected="${filter.sort == 'updatedAt,DESC'}">수정일 최신순</option>
+                </select>
+            </label>
+            <button class="button" type="submit">조회</button>
+            <a class="reset-link" th:href="@{/admin/event/events}">초기화</a>
+        </form>
+
+        <section class="panel table-panel">
+            <div class="table-scroll">
+                <table>
+                    <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>행사일</th>
+                        <th>시간</th>
+                        <th>제목</th>
+                        <th>마지막 수정자</th>
+                        <th>수정일</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="event : ${eventsPage.content}">
+                        <td th:text="${event.id}">1</td>
+                        <td th:text="${event.eventDate}">2026-05-13</td>
+                        <td th:text="${event.startTime != null && event.endTime != null ? event.startTime + ' - ' + event.endTime : '-'}">19:00 - 21:00</td>
+                        <td><a class="link" th:href="@{/admin/event/events/{eventId}/edit(eventId=${event.id})}" th:text="${event.title}">문학의 밤</a></td>
+                        <td th:text="${event.lastModifiedByName}">관리자</td>
+                        <td th:text="${event.updatedAt != null ? #temporals.format(event.updatedAt, 'yyyy.MM.dd HH:mm') : '-'}">2026.05.01 10:00</td>
+                    </tr>
+                    <tr th:if="${#lists.isEmpty(eventsPage.content)}">
+                        <td colspan="6" class="empty">조회된 행사가 없습니다.</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+            <div class="pager">
+                <span th:text="|총 ${eventsPage.totalElements}건 · ${eventsPage.page + 1}/${eventsPage.totalPages == 0 ? 1 : eventsPage.totalPages} 페이지|">총 0건</span>
+                <div>
+                    <a class="reset-link" th:classappend="${!eventsPage.hasPrevious()} ? 'disabled'" th:href="@{/admin/event/events(startDate=${filter.startDate},endDate=${filter.endDate},size=${eventsPage.size},sort=${filter.sort},page=${eventsPage.previousPage()})}">이전</a>
+                    <a class="reset-link" th:classappend="${!eventsPage.hasNext()} ? 'disabled'" th:href="@{/admin/event/events(startDate=${filter.startDate},endDate=${filter.endDate},size=${eventsPage.size},sort=${filter.sort},page=${eventsPage.nextPage()})}">다음</a>
+                </div>
+            </div>
+        </section>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/fragments/layout.html
+++ b/src/main/resources/templates/admin/fragments/layout.html
@@ -497,6 +497,7 @@
             <a th:href="@{/admin/classroom/classrooms}" th:classappend="${active == 'classrooms'} ? 'active'">분반</a>
             <a th:href="@{/admin/subject/subjects}" th:classappend="${active == 'subjects'} ? 'active'">과목</a>
             <a th:href="@{/admin/lesson/lessons}" th:classappend="${active == 'lessons'} ? 'active'">수업</a>
+            <a th:href="@{/admin/event/events}" th:classappend="${active == 'events'} ? 'active'">행사</a>
             <a th:href="@{/admin/daily-schedule/daily-schedules}" th:classappend="${active == 'dailySchedules'} ? 'active'">하루 일정</a>
             <a th:href="@{/admin/request/absence/absence-requests}" th:classappend="${active == 'absenceRequests'} ? 'active'">결석 요청</a>
             <a th:href="@{/admin/request/lesson-exchange}" th:classappend="${active == 'lessonExchangeRequests'} ? 'active'">수업 교환</a>

--- a/src/test/java/geumjeongyahak/e2e/event/EventAdminViewTest.java
+++ b/src/test/java/geumjeongyahak/e2e/event/EventAdminViewTest.java
@@ -1,0 +1,165 @@
+package geumjeongyahak.e2e.event;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import io.restassured.http.ContentType;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+@DisplayName("E2E: 행사 일정 관리자 화면 테스트")
+@ResourceLock("event-e2e-shared-state")
+class EventAdminViewTest extends BaseEventTest {
+
+    @Test
+    @DisplayName("관리자 행사 목록 화면을 조회할 수 있다")
+    void eventsPage_asAdmin_rendersList() {
+        insertEvent(200L, "관리자 화면 행사", "2026-06-01", "18:00:00", "20:00:00", false);
+
+        given()
+            .basePath("")
+            .cookie("JSESSIONID", loginAdminSession())
+        .when()
+            .get("/admin/event/events")
+        .then()
+            .statusCode(200)
+            .contentType(containsString("text/html"))
+            .body(containsString("행사 일정"))
+            .body(containsString("관리자 화면 행사"))
+            .body(containsString("/admin/event/events/new"));
+    }
+
+    @Test
+    @DisplayName("관리자 화면에서 행사를 등록할 수 있다")
+    void createEventFromAdminPage_redirectsAndCreates() {
+        String sessionId = loginAdminSession();
+
+        String location = given()
+            .basePath("")
+            .cookie("JSESSIONID", sessionId)
+            .contentType(ContentType.URLENC)
+            .formParam("title", "admin-created-event")
+            .formParam("description", "created-from-admin-page")
+            .formParam("eventDate", "2026-06-02")
+            .formParam("startTime", "18:00")
+            .formParam("endTime", "20:00")
+            .redirects()
+            .follow(false)
+        .when()
+            .post("/admin/event/events")
+        .then()
+            .statusCode(302)
+            .header("Location", containsString("/admin/event/events/"))
+            .extract()
+            .header("Location");
+
+        Long eventId = extractEventId(location);
+        String title = jdbcTemplate.queryForObject("SELECT title FROM events WHERE id = ?", String.class, eventId);
+        Long createdById = jdbcTemplate.queryForObject(
+            "SELECT created_by_id FROM events WHERE id = ?",
+            Long.class,
+            eventId
+        );
+
+        assertThat(title).isEqualTo("admin-created-event");
+        assertThat(createdById).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("관리자 화면에서 행사를 수정할 수 있다")
+    void updateEventFromAdminPage_redirectsAndUpdates() {
+        insertEvent(210L, "수정 전 행사", "2026-06-03", "18:00:00", "20:00:00", false);
+
+        given()
+            .basePath("")
+            .cookie("JSESSIONID", loginAdminSession())
+            .contentType(ContentType.URLENC)
+            .formParam("title", "admin-updated-event")
+            .formParam("description", "")
+            .formParam("eventDate", "2026-06-04")
+            .formParam("startTime", "19:00")
+            .formParam("endTime", "21:00")
+            .redirects()
+            .follow(false)
+        .when()
+            .post("/admin/event/events/{eventId}", 210L)
+        .then()
+            .statusCode(302)
+            .header("Location", containsString("/admin/event/events/210/edit"));
+
+        String title = jdbcTemplate.queryForObject("SELECT title FROM events WHERE id = 210", String.class);
+        String description = jdbcTemplate.queryForObject("SELECT description FROM events WHERE id = 210", String.class);
+        String eventDate = jdbcTemplate.queryForObject("SELECT event_date FROM events WHERE id = 210", String.class);
+
+        assertThat(title).isEqualTo("admin-updated-event");
+        assertThat(description).isEqualTo("");
+        assertThat(eventDate).isEqualTo("2026-06-04");
+    }
+
+    @Test
+    @DisplayName("관리자 화면에서 행사를 삭제할 수 있다")
+    void deleteEventFromAdminPage_redirectsAndDeletes() {
+        insertEvent(220L, "삭제 대상 행사", "2026-06-05", "18:00:00", "20:00:00", false);
+
+        given()
+            .basePath("")
+            .cookie("JSESSIONID", loginAdminSession())
+            .redirects()
+            .follow(false)
+        .when()
+            .post("/admin/event/events/{eventId}/delete", 220L)
+        .then()
+            .statusCode(302)
+            .header("Location", containsString("/admin/event/events"));
+
+        Boolean isDeleted = jdbcTemplate.queryForObject("SELECT is_deleted FROM events WHERE id = 220", Boolean.class);
+        assertThat(isDeleted).isTrue();
+    }
+
+    @Test
+    @DisplayName("관리자 대시보드에서 행사 일정 진입점과 예정된 행사 수를 확인할 수 있다")
+    void dashboard_asAdmin_rendersEventEntryAndUpcomingCount() {
+        LocalDate today = LocalDate.now();
+        insertEvent(230L, "예정된 행사", today.plusDays(1).toString(), "18:00:00", "20:00:00", false);
+        insertEvent(231L, "지난 행사", today.minusDays(1).toString(), "18:00:00", "20:00:00", false);
+
+        given()
+            .basePath("")
+            .cookie("JSESSIONID", loginAdminSession())
+        .when()
+            .get("/admin")
+        .then()
+            .statusCode(200)
+            .contentType(containsString("text/html"))
+            .body(containsString("예정된 행사"))
+            .body(containsString("/admin/event/events?startDate=" + today))
+            .body(containsString("행사 일정 관리"))
+            .body(containsString("/admin/event/events"));
+    }
+
+    private String loginAdminSession() {
+        return given()
+            .basePath("")
+            .contentType(ContentType.URLENC)
+            .formParam("username", TEST_ADMIN_EMAIL)
+            .formParam("password", TEST_ADMIN_PASSWORD)
+            .redirects()
+            .follow(false)
+        .when()
+            .post("/admin/auth/login")
+        .then()
+            .statusCode(302)
+            .extract()
+            .cookie("JSESSIONID");
+    }
+
+    private Long extractEventId(String location) {
+        String prefix = "/admin/event/events/";
+        int startIndex = location.indexOf(prefix) + prefix.length();
+        int endIndex = location.indexOf("/edit", startIndex);
+        return Long.valueOf(location.substring(startIndex, endIndex));
+    }
+}


### PR DESCRIPTION
## 개요

행사 일정 도메인을 관리자 화면에서 조회, 등록, 수정, 삭제할 수 있도록 관리자 페이지를 구현했습니다.

## 변경 유형

- [x] 새 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [x] 테스트 (test)
- [ ] 기타 (chore)

## 변경 내용

- 관리자 사이드바와 대시보드에 행사 일정 관리 진입점을 추가했습니다.
- 행사 일정 목록, 등록, 수정 화면을 추가했습니다.
- 관리자 화면에서 행사 등록/수정/삭제 요청을 처리하도록 View Controller와 View Service를 구현했습니다.
- 대시보드에 오늘 이후 예정된 행사 수 카드를 추가했습니다.
- 행사 관리자 화면 E2E 테스트를 추가했습니다.

## 관련 이슈

Closes #112

## 스크린샷 (선택)

<!-- 행사 목록/등록/수정 화면, 대시보드 행사 카드 캡처를 첨부하면 좋습니다. -->
- 관리자 대시보드
<img width="1920" height="921" alt="image" src="https://github.com/user-attachments/assets/88535a28-9261-45ba-9a90-5fbcf484d7f8" />

- 행사 등록
<img width="1919" height="914" alt="image" src="https://github.com/user-attachments/assets/216f9201-6bc8-4d53-9b00-1c2a6231ce81" />
<img width="1920" height="915" alt="image" src="https://github.com/user-attachments/assets/8b5075db-2762-4209-8585-426622ac6005" />
<img width="1920" height="919" alt="image" src="https://github.com/user-attachments/assets/34657405-0ea3-4073-8665-831f6676a6c7" />

- 행사 수정
<img width="1920" height="919" alt="image" src="https://github.com/user-attachments/assets/e1515e22-8eef-46c2-a74b-554d287d0197" />
<img width="1920" height="918" alt="image" src="https://github.com/user-attachments/assets/087f1da5-d26e-451c-952e-7209cc3fb93a" />

- 행사 삭제
<img width="1920" height="917" alt="image" src="https://github.com/user-attachments/assets/eba01173-3e8a-4e8f-9c23-288c219133a8" />
<img width="1919" height="987" alt="image" src="https://github.com/user-attachments/assets/09b3705b-838b-460a-aa7b-57c94388ed21" />

## 체크리스트

- [x] 코드 컨벤션을 준수했습니다
- [x] 테스트 코드를 작성/수정했습니다
- [x] 모든 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)

## 리뷰어에게

- 행사 관리 권한은 `ADMIN` 또는 `event:manage:*` 기준으로 처리했습니다.
- 대시보드의 예정된 행사 수는 오늘 포함 이후 날짜의 삭제되지 않은 행사 기준입니다.
- 관리자 화면 입력 검증은 API DTO의 Bean Validation 규칙을 재사용하도록 구성했습니다.