### PR TITLE
FIX: 공지/행사 게시글 비로그인 상세 조회 허용

### DIFF
--- a/docs/Domain/User/Permissions.md
+++ b/docs/Domain/User/Permissions.md
@@ -208,7 +208,7 @@ permission code로는 표현되지 않습니다.
 |-----|---------|
 | `GET /api/v1/posts` (전체 게시글) | 인증만 |
 | `GET /api/v1/channels/{channelId}/posts` | `channel:read:{channelId}` \| `channel:read:*` \| accessLevel ≥ READ_ONLY |
-| `GET /api/v1/channels/{channelId}/posts/{postId}` | 인증만 |
+| `GET /api/v1/channels/{channelId}/posts/{postId}` | `channel:read:{channelId}` \| `channel:read:*` \| accessLevel ≥ READ_ONLY \| allowGuestRead |
 | `POST /api/v1/channels/{channelId}/posts` (게시) | `channel:write:{channelId}` \| `channel:write:*` \| accessLevel ≥ READ_WRITE |
 | `POST /api/v1/channels/{channelId}/posts/drafts` | 채널 write 권한 동일 |
 | `PUT /api/v1/channels/{channelId}/posts/{postId}/publish` | 채널 write 권한 동일 |

--- a/docs/api/Posts.md
+++ b/docs/api/Posts.md
@@ -40,7 +40,7 @@
 
 | API | 권한 | 설명 |
 |---|---|---|
-| 조회 (Query) | `channel.can('read')` | 채널 읽기 권한 필요 |
+| 조회 (Query) | `channel.can('read')` | 채널 읽기 권한 필요. `allowGuestRead=true` 채널은 비로그인 조회 가능 |
 | 초안/발행 (Draft/Publish) | `channel.can('write')` + 소유권 | 작성 권한 및 본인 글 확인 |
 | 수정/삭제 (Write) | `channel.can('manage')` or 소유권 | 관리자 또는 본인 |
 | 고정 (Pin) | `channel.can('manage')` | 관리자 전용 |
@@ -107,6 +107,7 @@
 
 #### 4.4.2 게시글 상세 조회
 - **URL**: `GET /api/v1/channels/{channelId}/posts/{postId}`
+- `allowGuestRead=true` 채널의 발행 게시글은 비로그인 사용자도 조회할 수 있습니다.
 
 #### 4.4.3 통합 게시판 조회
 - **URL**: `GET /api/v1/posts`

--- a/src/main/java/geumjeongyahak/domain/channel/service/SystemChannelService.java
+++ b/src/main/java/geumjeongyahak/domain/channel/service/SystemChannelService.java
@@ -66,7 +66,8 @@ public class SystemChannelService {
                         ChannelType.NOTICE,
                         null,
                         isDefault,
-                        ChannelAccessLevel.READ_ONLY
+                        ChannelAccessLevel.READ_ONLY,
+                        true
                 ));
     }
 
@@ -79,7 +80,8 @@ public class SystemChannelService {
                         ChannelType.EVENT,
                         null,
                         isDefault,
-                        ChannelAccessLevel.READ_ONLY
+                        ChannelAccessLevel.READ_ONLY,
+                        true
                 ));
     }
 
@@ -92,7 +94,8 @@ public class SystemChannelService {
                         ChannelType.RESOURCE,
                         null,
                         isDefault,
-                        ChannelAccessLevel.READ_ONLY
+                        ChannelAccessLevel.READ_ONLY,
+                        false
                 ));
     }
 
@@ -125,7 +128,8 @@ public class SystemChannelService {
             ChannelType channelType,
             Long refId,
             boolean isDefault,
-            ChannelAccessLevel accessLevel
+            ChannelAccessLevel accessLevel,
+            boolean allowGuestRead
     ) {
         Channel channel = channelRepository.save(Channel.builder()
                 .name(name)
@@ -134,6 +138,7 @@ public class SystemChannelService {
                 .bindingType(ChannelBindingType.STANDALONE)
                 .refId(refId)
                 .accessLevel(accessLevel)
+                .allowGuestRead(allowGuestRead)
                 .isDefault(isDefault)
                 .isActive(true)
                 .build());

--- a/src/main/java/geumjeongyahak/domain/post/service/PostCrudService.java
+++ b/src/main/java/geumjeongyahak/domain/post/service/PostCrudService.java
@@ -111,12 +111,28 @@ public class PostCrudService {
     }
 
     @Transactional
-    public PostDetailResponse getPost(Long channelId, Long postId) {
+    public PostDetailResponse getPost(Long channelId, Long postId, CustomUserDetails userDetails) {
+        if (!channelAccessChecker.can("read", channelId, userDetails)) {
+            throw new AccessDeniedException("게시글 상세 조회 권한이 없습니다.");
+        }
+
         Post post = postRepository.findWithAttachmentsByIdAndChannelId(postId, channelId)
                 .filter(p -> !p.isDeleted())
                 .orElseThrow(() -> new ResourceNotFoundException(PostErrorCode.POST_NOT_FOUND));
+
+        if (post.getStatus() != PostStatus.PUBLISHED && !canReadUnpublishedPost(post, userDetails)) {
+            throw new AccessDeniedException("미발행 게시글 상세 조회 권한이 없습니다.");
+        }
+
         post.incrementViewCount();
         return PostDetailResponse.from(post);
+    }
+
+    private boolean canReadUnpublishedPost(Post post, CustomUserDetails userDetails) {
+        if (userDetails == null) {
+            return false;
+        }
+        return userDetails.isAdmin() || post.getAuthor().getId().equals(userDetails.getUserId());
     }
 
     @Transactional

--- a/src/main/java/geumjeongyahak/domain/post/v1/controller/PostQueryController.java
+++ b/src/main/java/geumjeongyahak/domain/post/v1/controller/PostQueryController.java
@@ -6,7 +6,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import geumjeongyahak.common.security.service.CustomUserDetails;
@@ -46,7 +45,6 @@ public class PostQueryController {
         return ResponseEntity.ok(postCrudService.getPosts(channelId, userDetails, request));
     }
 
-    @PreAuthorize("isAuthenticated() && @channelAccess.can('read', #channelId, principal)")
     @Operation(
             summary = "게시글 상세 조회",
             description = """
@@ -59,8 +57,9 @@ public class PostQueryController {
     @GetMapping("/{postId}")
     public ResponseEntity<PostDetailResponse> getPost(
             @PathVariable Long channelId,
-            @PathVariable Long postId
+            @PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        return ResponseEntity.ok(postCrudService.getPost(channelId, postId));
+        return ResponseEntity.ok(postCrudService.getPost(channelId, postId, userDetails));
     }
 }

--- a/src/test/java/geumjeongyahak/e2e/post/BasePostTest.java
+++ b/src/test/java/geumjeongyahak/e2e/post/BasePostTest.java
@@ -57,6 +57,7 @@ public abstract class BasePostTest extends BaseE2ETest {
                 .channelType(ChannelType.NOTICE)
                 .bindingType(ChannelBindingType.STANDALONE)
                 .accessLevel(ChannelAccessLevel.READ_ONLY)
+                .allowGuestRead(true)
                 .refId(null)
                 .isDefault(false)
                 .isActive(true)

--- a/src/test/java/geumjeongyahak/e2e/post/PostBoardQueryTest.java
+++ b/src/test/java/geumjeongyahak/e2e/post/PostBoardQueryTest.java
@@ -42,6 +42,42 @@ public class PostBoardQueryTest extends BasePostTest {
     }
 
     @Test
+    @DisplayName("비인증 사용자는 공개 공지와 행사 게시글 상세를 조회할 수 있다")
+    void getPost_WithoutAuth_AllowsGuestReadableNoticeAndEventDetails() {
+        Long noticePostId = createPost(noticeChannelId, "비로그인 공지 상세");
+
+        Channel eventChannel = channelRepository.save(Channel.builder()
+                .name("행사안내")
+                .description("비로그인 행사 상세 조회 테스트")
+                .channelType(ChannelType.EVENT)
+                .bindingType(ChannelBindingType.STANDALONE)
+                .accessLevel(ChannelAccessLevel.READ_ONLY)
+                .allowGuestRead(true)
+                .isActive(true)
+                .build());
+        testChannelHelper.registerChannel(eventChannel.getId());
+        Long eventPostId = createPost(eventChannel.getId(), "비로그인 행사 상세");
+
+        given()
+                .when()
+                .get("/api/v1/channels/{channelId}/posts/{postId}", noticeChannelId, noticePostId)
+                .then()
+                .statusCode(200)
+                .body("id", equalTo(noticePostId.intValue()))
+                .body("title", equalTo("비로그인 공지 상세"))
+                .body("viewCount", equalTo(1));
+
+        given()
+                .when()
+                .get("/api/v1/channels/{channelId}/posts/{postId}", eventChannel.getId(), eventPostId)
+                .then()
+                .statusCode(200)
+                .body("id", equalTo(eventPostId.intValue()))
+                .body("title", equalTo("비로그인 행사 상세"))
+                .body("viewCount", equalTo(1));
+    }
+
+    @Test
     @DisplayName("통합 게시판은 공지, 반별, 부서별 필터로 조회할 수 있다")
     void getBoardPosts_WithBoardFilters_Success() {
         Channel classroomChannel = channelRepository.save(Channel.builder()
@@ -105,8 +141,8 @@ public class PostBoardQueryTest extends BasePostTest {
     }
 
     @Test
-    @DisplayName("비인증 사용자는 게시글 목록을 조회할 수 있지만 본문 검색과 상세 조회는 제한된다")
-    void getBoardPosts_WithoutAuth_AllowsListButRestrictsContentSearchAndDetail() {
+    @DisplayName("비인증 사용자는 게시글 목록을 조회할 수 있지만 본문 검색과 비공개 상세 조회는 제한된다")
+    void getBoardPosts_WithoutAuth_AllowsListButRestrictsContentSearchAndPrivateDetail() {
         Channel closedChannel = channelRepository.save(Channel.builder()
                 .name("닫힌 운영 채널")
                 .description("목록 노출 테스트")
@@ -136,6 +172,18 @@ public class PostBoardQueryTest extends BasePostTest {
         given()
                 .when()
                 .get("/api/v1/channels/{channelId}/posts/{postId}", closedChannel.getId(), postId)
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    @DisplayName("비인증 사용자는 공개 채널의 초안 게시글 상세를 조회할 수 없다")
+    void getPost_WithoutAuth_RejectsDraftEvenInGuestReadableChannel() {
+        Long draftId = testPostHelper.createDraftAndRegister(noticeChannelId, adminAccessToken);
+
+        given()
+                .when()
+                .get("/api/v1/channels/{channelId}/posts/{postId}", noticeChannelId, draftId)
                 .then()
                 .statusCode(403);
     }

--- a/src/test/java/geumjeongyahak/unit/channel/SystemChannelServiceTest.java
+++ b/src/test/java/geumjeongyahak/unit/channel/SystemChannelServiceTest.java
@@ -1,0 +1,64 @@
+package geumjeongyahak.unit.channel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+import geumjeongyahak.domain.channel.entity.Channel;
+import geumjeongyahak.domain.channel.enums.ChannelType;
+import geumjeongyahak.domain.channel.repository.ChannelRepository;
+import geumjeongyahak.domain.channel.service.SystemChannelService;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SystemChannelServiceTest {
+
+    @Mock
+    private ChannelRepository channelRepository;
+
+    @InjectMocks
+    private SystemChannelService systemChannelService;
+
+    @Test
+    void ensureNoticeChannel_createsGuestReadableChannel() {
+        when(channelRepository.findByChannelTypeAndRefIdAndIsDeletedFalse(eq(ChannelType.NOTICE), isNull()))
+                .thenReturn(Optional.empty());
+        when(channelRepository.save(any(Channel.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Channel channel = systemChannelService.ensureNoticeChannel("공지사항", "기관 공지", true);
+
+        assertThat(channel.isAllowGuestRead()).isTrue();
+    }
+
+    @Test
+    void ensureEventChannel_createsGuestReadableChannel() {
+        when(channelRepository.findByChannelTypeAndRefIdAndIsDeletedFalse(eq(ChannelType.EVENT), isNull()))
+                .thenReturn(Optional.empty());
+        when(channelRepository.save(any(Channel.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Channel channel = systemChannelService.ensureEventChannel("행사안내", "기관 행사", true);
+
+        assertThat(channel.isAllowGuestRead()).isTrue();
+    }
+
+    @Test
+    void ensureResourceChannel_createsAuthenticatedReadChannel() {
+        ArgumentCaptor<Channel> channelCaptor = ArgumentCaptor.forClass(Channel.class);
+        when(channelRepository.findByChannelTypeAndRefIdAndIsDeletedFalse(eq(ChannelType.RESOURCE), isNull()))
+                .thenReturn(Optional.empty());
+        when(channelRepository.save(channelCaptor.capture())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Channel channel = systemChannelService.ensureResourceChannel("자료실", "기관 자료", true);
+
+        assertThat(channel.isAllowGuestRead()).isFalse();
+        assertThat(channelCaptor.getValue().isAllowGuestRead()).isFalse();
+    }
+}

--- a/src/test/resources/sql/init_data.sql
+++ b/src/test/resources/sql/init_data.sql
@@ -60,7 +60,7 @@ ALTER TABLE classrooms ALTER COLUMN id RESTART WITH 4;
 INSERT INTO channels (id, name, description, channel_type, binding_type, ref_id, access_level, allow_guest_read, is_default, is_active)
 VALUES
     (1, '공지사항', '기관 전체 공지사항 채널', 'NOTICE', 'STANDALONE', NULL, 'READ_ONLY', TRUE, TRUE, TRUE),
-    (2, '이벤트', '기관 전체 이벤트 채널', 'EVENT', 'STANDALONE', NULL, 'READ_ONLY', TRUE, TRUE, TRUE),
+    (2, '행사안내', '주요 행사 및 일정 안내', 'EVENT', 'STANDALONE', NULL, 'READ_ONLY', TRUE, TRUE, TRUE),
     (3, '자료실', '기관 공용 자료실 채널', 'RESOURCE', 'STANDALONE', NULL, 'READ_ONLY', FALSE, TRUE, TRUE),
     (4, '벚꽃반', '벚꽃반 게시판', 'CLASSROOM', 'DOMAIN_LINKED', 1, 'READ_WRITE', FALSE, TRUE, TRUE),
     (5, '장미반', '장미반 게시판', 'CLASSROOM', 'DOMAIN_LINKED', 2, 'READ_WRITE', FALSE, TRUE, TRUE),


### PR DESCRIPTION
## Summary
- 게시글 상세 조회에서 isAuthenticated 강제 조건을 제거하고 채널 읽기 정책으로 접근을 판단합니다.
- allowGuestRead=true인 공지/행사 채널의 발행 게시글을 비로그인 사용자도 조회할 수 있게 했습니다.
- SystemChannelService와 init_data의 공지/행사 채널 공개 읽기 설정을 맞췄습니다.

## Verification
- source /home/min/.sdkman/bin/sdkman-init.sh && ./gradlew test --tests '*Post*' --tests '*SystemChannelServiceTest'

Fixes #114