### PR TITLE
[FIX] 구매 요청 상세 itemNames 직렬화 오류 수정

### DIFF
--- a/src/main/java/geumjeongyahak/domain/purchase_request/v1/dto/response/PurchaseRequestDetailResponse.java
+++ b/src/main/java/geumjeongyahak/domain/purchase_request/v1/dto/response/PurchaseRequestDetailResponse.java
@@ -95,7 +95,7 @@ public record PurchaseRequestDetailResponse(
                 transaction.getId(),
                 transaction.getVendor().getId(),
                 transaction.getVendor().getName(),
-                transaction.getItemNames(),
+                List.copyOf(transaction.getItemNames()),
                 transaction.getAmount(),
                 transaction.getReceiptFile() != null ? transaction.getReceiptFile().getId() : null,
                 transaction.getReceiptFile() != null ? transaction.getReceiptFile().getPublicUrl() : null

--- a/src/test/java/geumjeongyahak/e2e/request/purchase/PurchaseRequestStatusTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/purchase/PurchaseRequestStatusTest.java
@@ -571,6 +571,25 @@ class PurchaseRequestStatusTest extends RequestBaseTest {
     }
 
     @Test
+    @DisplayName("구매 완료 거래가 있는 단건 조회 → itemNames 직렬화")
+    void getDetail_withPurchasedTransactions_serializesItemNames() {
+        createdVendorId = createVendorAndCharge(100000L);
+        currentRequestId = setupPurchasedRequest(createdVendorId, 20000L, null);
+
+        given()
+            .basePath("/api/v1/purchase-requests")
+            .header(AUTH_HEADER, getAuthHeader(volunteerToken))
+            .get("/{requestId}", currentRequestId)
+            .then()
+            .statusCode(200)
+            .body("status", equalTo("PURCHASED"))
+            .body("transactions", hasSize(1))
+            .body("transactions[0].itemNames", hasSize(2))
+            .body("transactions[0].itemNames[0]", equalTo("교재"))
+            .body("transactions[0].itemNames[1]", equalTo("복사용지"));
+    }
+
+    @Test
     @DisplayName("인증 없이 목록 조회 → 401")
     void getList_unauthenticated_returns401() {
         given()


### PR DESCRIPTION
## 요약
- 구매 요청 상세 응답의 `transactions[].itemNames`가 Hibernate lazy collection을 그대로 노출하지 않도록 DTO 변환 시 `List.copyOf(...)`로 복사했습니다.
- 구매 완료 거래가 있는 구매 요청을 다시 단건 조회했을 때 `itemNames`가 정상 JSON 직렬화되는 E2E 회귀 테스트를 추가했습니다.

## 오류 원인
운영 로그의 핵심 예외는 아래입니다.

```text
HttpMessageNotWritableException: Could not write JSON
LazyInitializationException: failed to lazily initialize a collection of role: PurchaseRequestPaymentTransaction.itemNames: could not initialize proxy - no Session
```

구매 요청 상세 조회 자체가 실패한 것이 아니라, 컨트롤러가 반환한 `PurchaseRequestDetailResponse`를 Jackson이 JSON으로 쓰는 마지막 단계에서 실패했습니다.

기존 `PurchaseRequestDetailResponse.TransactionResponse.from()`은 `transaction.getItemNames()`를 그대로 응답 DTO에 담았습니다. `itemNames`는 `@ElementCollection`이고 Hibernate가 lazy collection으로 관리하므로, 이 시점에 실제 `List<String>` 값이 아니라 세션이 필요한 `PersistentList` 프록시가 DTO 안에 남을 수 있습니다.

서비스 트랜잭션 안에서 DTO 객체는 생성되지만, `itemNames`를 순회하거나 복사하지 않으면 컬렉션은 초기화되지 않습니다. 이후 Spring MVC/Jackson 직렬화는 트랜잭션 종료 후 수행되며, 이때 Jackson이 `itemNames`의 size/content를 읽으려 하면서 이미 닫힌 Hibernate Session에 접근해 500이 발생했습니다.

## 수정 방식
`TransactionResponse` 생성 시점에 다음처럼 컬렉션을 복사합니다.

```java
List.copyOf(transaction.getItemNames())
```

이 코드는 서비스 트랜잭션 안에서 `itemNames`를 실제로 읽어 일반 Java 불변 리스트로 만듭니다. 따라서 응답 DTO에는 Hibernate 프록시가 아닌 순수 값 리스트만 남고, Jackson 직렬화 단계에서 DB 세션이 필요하지 않습니다.

## 왜 이 방식인가
- API 응답 DTO가 영속성 컨텍스트에 의존하지 않도록 만듭니다.
- 엔티티 fetch 전략을 전역적으로 eager로 바꾸지 않아 불필요한 조회 확대를 피합니다.
- 조회 쿼리나 트랜잭션 경계를 넓히지 않고, 문제가 발생한 응답 변환 지점만 좁게 수정합니다.

## 회귀 테스트
추가한 테스트는 다음 경로를 검증합니다.

1. 구매 요청 생성
2. 관리자 승인
3. 구매 완료 보고로 거래 라인과 `itemNames` 저장
4. 구매 요청 단건 재조회
5. `transactions[0].itemNames`가 500 없이 JSON으로 직렬화되는지 확인

## 테스트
- `./gradlew test --tests geumjeongyahak.e2e.request.purchase.PurchaseRequestStatusTest`
- `git diff --check`

Closes #129