### PR TITLE
feat(user): 관리자 사용자 분반 배정 기능 추가

### DIFF
--- a/src/main/java/geumjeongyahak/domain/users/service/UserAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/users/service/UserAdminViewService.java
@@ -2,6 +2,8 @@ package geumjeongyahak.domain.users.service;
 
 import geumjeongyahak.domain.base.dto.response.AdminPage;
 import geumjeongyahak.domain.base.dto.response.AdminSorts;
+import geumjeongyahak.domain.classroom.entity.Classroom;
+import geumjeongyahak.domain.classroom.service.ClassroomProxyService;
 import geumjeongyahak.domain.department.entity.Department;
 import geumjeongyahak.domain.department.repository.DepartmentRepository;
 import geumjeongyahak.domain.users.entity.User;
@@ -28,6 +30,7 @@ public class UserAdminViewService {
 
     private final UserRepository userRepository;
     private final DepartmentRepository departmentRepository;
+    private final ClassroomProxyService classroomProxyService;
     private final UserCrudService userCrudService;
     private final UserPermissionService userPermissionService;
 
@@ -38,6 +41,8 @@ public class UserAdminViewService {
             .filter(user -> isBlank(filter.role()) || user.getRole().name().equals(filter.role()))
             .filter(user -> filter.departmentId() == null
                 || (user.getDepartment() != null && user.getDepartment().getId().equals(filter.departmentId())))
+            .filter(user -> filter.classroomId() == null
+                || (user.getClassroom() != null && user.getClassroom().getId().equals(filter.classroomId())))
             .filter(user -> isBlank(filter.permissionCode())
                 || user.getPermissions().stream()
                     .anyMatch(permission -> permission.getPermissionCode().contains(filter.permissionCode().trim())))
@@ -54,6 +59,7 @@ public class UserAdminViewService {
             "email", Comparator.comparing(AdminUserRow::email, Comparator.nullsLast(String::compareToIgnoreCase)),
             "role", Comparator.comparing(AdminUserRow::role, Comparator.nullsLast(String::compareToIgnoreCase)),
             "departmentName", Comparator.comparing(AdminUserRow::departmentName, Comparator.nullsLast(String::compareToIgnoreCase)),
+            "classroomName", Comparator.comparing(AdminUserRow::classroomName, Comparator.nullsLast(String::compareToIgnoreCase)),
             "createdAt", Comparator.comparing(AdminUserRow::createdAt, Comparator.nullsLast(LocalDateTime::compareTo))
         ), "createdAt,DESC");
     }
@@ -83,6 +89,13 @@ public class UserAdminViewService {
             .toList();
     }
 
+    public List<ClassroomOption> getClassroomOptions() {
+        return classroomProxyService.getActiveClassroomsOrderByName()
+            .stream()
+            .map(ClassroomOption::from)
+            .toList();
+    }
+
     public UserDetailResponse getUser(Long userId) {
         return userCrudService.getUserById(userId);
     }
@@ -94,7 +107,8 @@ public class UserAdminViewService {
         String password,
         String phoneNumber,
         String role,
-        Long departmentId
+        Long departmentId,
+        Long classroomId
     ) {
         return userCrudService.createUser(new CreateUserRequest(
             email,
@@ -102,7 +116,8 @@ public class UserAdminViewService {
             password,
             phoneNumber,
             role,
-            departmentId
+            departmentId,
+            classroomId
         )).id();
     }
 
@@ -113,7 +128,8 @@ public class UserAdminViewService {
         String name,
         String phoneNumber,
         String role,
-        Long departmentId
+        Long departmentId,
+        Long classroomId
     ) {
         userCrudService.updateUser(userId, new UpdateUserRequest(
             name,
@@ -121,7 +137,8 @@ public class UserAdminViewService {
             email,
             null,
             role,
-            departmentId
+            departmentId,
+            classroomId
         ));
     }
 
@@ -133,6 +150,7 @@ public class UserAdminViewService {
             null,
             null,
             role,
+            null,
             null
         ));
     }
@@ -145,7 +163,21 @@ public class UserAdminViewService {
             null,
             null,
             null,
-            departmentId
+            departmentId,
+            null
+        ));
+    }
+
+    @Transactional
+    public void updateClassroom(Long userId, Long classroomId) {
+        userCrudService.updateUser(userId, new UpdateUserRequest(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            classroomId
         ));
     }
 
@@ -163,10 +195,20 @@ public class UserAdminViewService {
         }
     }
 
+    public record ClassroomOption(
+        Long id,
+        String name
+    ) {
+        private static ClassroomOption from(Classroom classroom) {
+            return new ClassroomOption(classroom.getId(), classroom.getName());
+        }
+    }
+
     public record UserFilter(
         String keyword,
         String role,
         Long departmentId,
+        Long classroomId,
         String permissionCode,
         Integer page,
         Integer size,
@@ -182,6 +224,8 @@ public class UserAdminViewService {
         String role,
         Long departmentId,
         String departmentName,
+        Long classroomId,
+        String classroomName,
         List<String> permissions,
         LocalDateTime createdAt
     ) {
@@ -194,6 +238,8 @@ public class UserAdminViewService {
                 user.getRole().name(),
                 user.getDepartment() != null ? user.getDepartment().getId() : null,
                 user.getDepartment() != null ? user.getDepartment().getName() : "-",
+                user.getClassroom() != null ? user.getClassroom().getId() : null,
+                user.getClassroom() != null ? user.getClassroom().getName() : "-",
                 user.getPermissions().stream()
                     .map(UserPermission::toAuthorityCode)
                     .sorted()

--- a/src/main/java/geumjeongyahak/domain/users/service/UserCrudService.java
+++ b/src/main/java/geumjeongyahak/domain/users/service/UserCrudService.java
@@ -1,6 +1,7 @@
 package geumjeongyahak.domain.users.service;
 
 import geumjeongyahak.domain.department.service.DepartmentProxyService;
+import geumjeongyahak.domain.classroom.service.ClassroomProxyService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -31,6 +32,7 @@ import java.util.Optional;
 public class UserCrudService {
     private final UserRepository userRepository;
     private final DepartmentProxyService departmentProxyService;
+    private final ClassroomProxyService classroomProxyService;
     private final PasswordEncoder passwordEncoder;
     private final UserCredentialService credentialService;
     private final UserProxyService userProxyService;
@@ -87,6 +89,9 @@ public class UserCrudService {
         if (request.departmentId() != null) {
             userBuilder.department(departmentProxyService.getById(request.departmentId()));
         }
+        if (request.classroomId() != null) {
+            userBuilder.classroom(classroomProxyService.getActiveById(request.classroomId()));
+        }
 
         User savedUser = userRepository.save(userBuilder.build());
 
@@ -115,7 +120,8 @@ public class UserCrudService {
             Optional.ofNullable(request.password()),
             Optional.ofNullable(request.email()),
             Optional.ofNullable(request.role()),
-            Optional.ofNullable(request.departmentId())
+            Optional.ofNullable(request.departmentId()),
+            Optional.ofNullable(request.classroomId())
         );
         log.info("사용자 수정 완료 - ID: {}, email: {}", user.getId(), user.getEmail());
         return UserDetailResponse.from(user);
@@ -136,7 +142,8 @@ public class UserCrudService {
                 Optional.ofNullable(request.password()),
                 Optional.ofNullable(request.email()),
                 Optional.empty(), // 본인 수정 시 역할 변경 불가
-                Optional.empty()  // 본인 수정 시 부서 변경 불가
+                Optional.empty(), // 본인 수정 시 부서 변경 불가
+                Optional.empty()  // 본인 수정 시 분반 변경 불가
         );
         log.debug("본인 사용자 수정 완료 - ID: {}, email: {}", user.getId(), user.getEmail());
         return UserDetailResponse.from(user);
@@ -149,7 +156,8 @@ public class UserCrudService {
             Optional<String> password,
             Optional<String> email,
             Optional<String> role,
-            Optional<Long> departmentId
+            Optional<Long> departmentId,
+            Optional<Long> classroomId
     ) {
         name.ifPresent(user::setName);
         phoneNumber.ifPresent(user::setPhoneNumber);
@@ -168,6 +176,9 @@ public class UserCrudService {
         role.map(RoleType::valueOf).ifPresent(user::setRole);
         departmentId.ifPresent(deptId -> {
             user.setDepartment(departmentProxyService.getById(deptId));
+        });
+        classroomId.ifPresent(classroomIdValue -> {
+            user.setClassroom(classroomProxyService.getActiveById(classroomIdValue));
         });
     }
 

--- a/src/main/java/geumjeongyahak/domain/users/v1/controller/UserViewController.java
+++ b/src/main/java/geumjeongyahak/domain/users/v1/controller/UserViewController.java
@@ -27,6 +27,7 @@ public class UserViewController {
         @RequestParam(required = false) String keyword,
         @RequestParam(required = false) String role,
         @RequestParam(required = false) Long departmentId,
+        @RequestParam(required = false) Long classroomId,
         @RequestParam(required = false) String permissionCode,
         @RequestParam(required = false) Integer page,
         @RequestParam(required = false) Integer size,
@@ -34,12 +35,13 @@ public class UserViewController {
         Model model,
         Authentication authentication
     ) {
-        UserFilter filter = new UserFilter(keyword, role, departmentId, permissionCode, page, size, sort);
+        UserFilter filter = new UserFilter(keyword, role, departmentId, classroomId, permissionCode, page, size, sort);
         model.addAttribute("active", "users");
         model.addAttribute("adminName", authentication.getName());
         model.addAttribute("filter", filter);
         model.addAttribute("usersPage", userAdminViewService.getUsers(filter));
         model.addAttribute("departments", userAdminViewService.getDepartmentOptions());
+        model.addAttribute("classrooms", userAdminViewService.getClassroomOptions());
         model.addAttribute("permissionOptions", permissionRegistryViewService.getAssignablePermissions());
         return "admin/user/users";
     }
@@ -49,6 +51,7 @@ public class UserViewController {
         model.addAttribute("active", "users");
         model.addAttribute("adminName", authentication.getName());
         model.addAttribute("departments", userAdminViewService.getDepartmentOptions());
+        model.addAttribute("classrooms", userAdminViewService.getClassroomOptions());
         return "admin/user/users-form";
     }
 
@@ -60,9 +63,10 @@ public class UserViewController {
         @RequestParam(required = false) String phoneNumber,
         @RequestParam String role,
         @RequestParam(required = false) Long departmentId,
+        @RequestParam(required = false) Long classroomId,
         RedirectAttributes redirectAttributes
     ) {
-        Long userId = userAdminViewService.createUser(email, name, password, phoneNumber, role, departmentId);
+        Long userId = userAdminViewService.createUser(email, name, password, phoneNumber, role, departmentId, classroomId);
         redirectAttributes.addFlashAttribute("message", "사용자를 등록했습니다.");
         return "redirect:/admin/user/users/" + userId;
     }
@@ -77,6 +81,7 @@ public class UserViewController {
         model.addAttribute("adminName", authentication.getName());
         model.addAttribute("user", userAdminViewService.getUser(userId));
         model.addAttribute("departments", userAdminViewService.getDepartmentOptions());
+        model.addAttribute("classrooms", userAdminViewService.getClassroomOptions());
         model.addAttribute("permissionOptions", permissionRegistryViewService.getAssignablePermissions());
         model.addAttribute("permissionScopeOptions", permissionRegistryViewService.getAssignableScopes());
         return "admin/user/users-detail";
@@ -92,6 +97,7 @@ public class UserViewController {
         model.addAttribute("adminName", authentication.getName());
         model.addAttribute("user", userAdminViewService.getUser(userId));
         model.addAttribute("departments", userAdminViewService.getDepartmentOptions());
+        model.addAttribute("classrooms", userAdminViewService.getClassroomOptions());
         return "admin/user/users-edit";
     }
 
@@ -103,9 +109,10 @@ public class UserViewController {
         @RequestParam(required = false) String phoneNumber,
         @RequestParam String role,
         @RequestParam(required = false) Long departmentId,
+        @RequestParam(required = false) Long classroomId,
         RedirectAttributes redirectAttributes
     ) {
-        userAdminViewService.updateUser(userId, email, name, phoneNumber, role, departmentId);
+        userAdminViewService.updateUser(userId, email, name, phoneNumber, role, departmentId, classroomId);
         redirectAttributes.addFlashAttribute("message", "사용자 정보를 수정했습니다.");
         return "redirect:/admin/user/users/" + userId;
     }
@@ -129,6 +136,17 @@ public class UserViewController {
     ) {
         userAdminViewService.updateDepartment(userId, departmentId);
         redirectAttributes.addFlashAttribute("message", "사용자 소속 부서를 변경했습니다.");
+        return "redirect:/admin/user/users/" + userId;
+    }
+
+    @PostMapping("/{userId}/classroom")
+    public String updateClassroom(
+        @PathVariable Long userId,
+        @RequestParam Long classroomId,
+        RedirectAttributes redirectAttributes
+    ) {
+        userAdminViewService.updateClassroom(userId, classroomId);
+        redirectAttributes.addFlashAttribute("message", "사용자 배정 분반을 변경했습니다.");
         return "redirect:/admin/user/users/" + userId;
     }
 

--- a/src/main/java/geumjeongyahak/domain/users/v1/dto/request/CreateUserRequest.java
+++ b/src/main/java/geumjeongyahak/domain/users/v1/dto/request/CreateUserRequest.java
@@ -31,7 +31,19 @@ public record CreateUserRequest(
     String role,
 
     @Schema(description = "초기 소속 부서 ID. 없으면 null로 둘 수 있습니다.", example = "1")
-    Long departmentId
-) {
+    Long departmentId,
 
+    @Schema(description = "초기 배정 분반 ID. 없으면 null로 둘 수 있습니다.", example = "1")
+    Long classroomId
+) {
+    public CreateUserRequest(
+        String email,
+        String name,
+        String password,
+        String phoneNumber,
+        String role,
+        Long departmentId
+    ) {
+        this(email, name, password, phoneNumber, role, departmentId, null);
+    }
 }

--- a/src/main/java/geumjeongyahak/domain/users/v1/dto/request/UpdateUserRequest.java
+++ b/src/main/java/geumjeongyahak/domain/users/v1/dto/request/UpdateUserRequest.java
@@ -28,6 +28,19 @@ public record UpdateUserRequest(
     String role,
 
     @Schema(description = "변경할 소속 부서 ID", example = "1")
-    Long departmentId
+    Long departmentId,
+
+    @Schema(description = "변경할 배정 분반 ID", example = "1")
+    Long classroomId
 ) {
+    public UpdateUserRequest(
+        String name,
+        String phoneNumber,
+        String email,
+        String password,
+        String role,
+        Long departmentId
+    ) {
+        this(name, phoneNumber, email, password, role, departmentId, null);
+    }
 }

--- a/src/main/java/geumjeongyahak/domain/users/v1/dto/response/UserDetailResponse.java
+++ b/src/main/java/geumjeongyahak/domain/users/v1/dto/response/UserDetailResponse.java
@@ -77,4 +77,20 @@ public record UserDetailResponse(
             user.getUpdatedAt()
         );
     }
+
+    public Long departmentId() {
+        return department != null ? department.id() : null;
+    }
+
+    public String departmentName() {
+        return department != null ? department.name() : null;
+    }
+
+    public Long classroomId() {
+        return classroom != null ? classroom.id() : null;
+    }
+
+    public String classroomName() {
+        return classroom != null ? classroom.name() : null;
+    }
 }

--- a/src/main/java/geumjeongyahak/domain/users/v1/dto/response/UserSimpleResponse.java
+++ b/src/main/java/geumjeongyahak/domain/users/v1/dto/response/UserSimpleResponse.java
@@ -23,8 +23,22 @@ public record UserSimpleResponse(
     String role,
 
     @Schema(description = "소속 부서 ID. 소속 부서가 없으면 null일 수 있습니다.", example = "2", nullable = true)
-    Long departmentId
+    Long departmentId,
+
+    @Schema(description = "배정 분반 ID. 배정 분반이 없으면 null일 수 있습니다.", example = "1", nullable = true)
+    Long classroomId
 ) {
+    public UserSimpleResponse(
+        Long id,
+        String name,
+        String email,
+        String phoneNumber,
+        String role,
+        Long departmentId
+    ) {
+        this(id, name, email, phoneNumber, role, departmentId, null);
+    }
+
     public static UserSimpleResponse from(User user) {
         return new UserSimpleResponse(
             user.getId(),
@@ -32,7 +46,8 @@ public record UserSimpleResponse(
             user.getEmail(),
             user.getPhoneNumber(),
             user.getRole().name(),
-            user.getDepartment() != null ? user.getDepartment().getId() : null
+            user.getDepartment() != null ? user.getDepartment().getId() : null,
+            user.getClassroom() != null ? user.getClassroom().getId() : null
         );
     }
 }

--- a/src/main/resources/templates/admin/user/users-detail.html
+++ b/src/main/resources/templates/admin/user/users-detail.html
@@ -12,7 +12,27 @@
         <div class="detail-item"><span>역할</span><strong th:text="${user.role}">VOLUNTEER</strong></div>
         <div class="detail-item"><span>이메일</span><strong th:text="${user.email}">email</strong></div>
         <div class="detail-item"><span>연락처</span><strong th:text="${user.phoneNumber ?: '-'}">-</strong></div>
-        <div class="detail-item"><span>부서</span><strong><a class="link" th:if="${user.departmentId != null}" th:href="@{/admin/department/departments/{departmentId}(departmentId=${user.departmentId})}" th:text="|#${user.departmentId}|">부서</a><span th:if="${user.departmentId == null}">-</span></strong></div>
+        <div class="detail-item"><span>부서</span><strong><a class="link" th:if="${user.departmentId != null}" th:href="@{/admin/department/departments/{departmentId}(departmentId=${user.departmentId})}" th:text="${user.departmentName}">부서</a><span th:if="${user.departmentId == null}">-</span></strong></div>
+        <div class="detail-item"><span>분반</span><strong><a class="link" th:if="${user.classroomId != null}" th:href="@{/admin/classroom/classrooms/{classroomId}(classroomId=${user.classroomId})}" th:text="${user.classroomName}">분반</a><span th:if="${user.classroomId == null}">-</span></strong></div>
+    </section>
+    <section class="panel stack">
+        <h2>소속 변경</h2>
+        <div class="inline-form">
+            <form class="inline-form" th:action="@{/admin/user/users/{userId}/department(userId=${user.id})}" method="post">
+                <select name="departmentId" required>
+                    <option value="">부서 선택</option>
+                    <option th:each="department : ${departments}" th:value="${department.id}" th:text="${department.name}" th:selected="${user.departmentId == department.id}">부서</option>
+                </select>
+                <button class="button secondary" type="submit">부서 변경</button>
+            </form>
+            <form class="inline-form" th:action="@{/admin/user/users/{userId}/classroom(userId=${user.id})}" method="post">
+                <select name="classroomId" required>
+                    <option value="">분반 선택</option>
+                    <option th:each="classroom : ${classrooms}" th:value="${classroom.id}" th:text="${classroom.name}" th:selected="${user.classroomId == classroom.id}">분반</option>
+                </select>
+                <button class="button secondary" type="submit">분반 변경</button>
+            </form>
+        </div>
     </section>
     <section class="panel stack">
         <h2>직접 권한</h2>

--- a/src/main/resources/templates/admin/user/users-edit.html
+++ b/src/main/resources/templates/admin/user/users-edit.html
@@ -22,6 +22,12 @@
                 <option th:each="department : ${departments}" th:value="${department.id}" th:text="${department.name}" th:selected="${user.departmentId == department.id}">부서</option>
             </select>
         </label>
+        <label>분반
+            <select name="classroomId">
+                <option value="">없음</option>
+                <option th:each="classroom : ${classrooms}" th:value="${classroom.id}" th:text="${classroom.name}" th:selected="${user.classroomId == classroom.id}">분반</option>
+            </select>
+        </label>
         <button class="button" type="submit">수정</button>
     </form>
 </main>

--- a/src/main/resources/templates/admin/user/users-form.html
+++ b/src/main/resources/templates/admin/user/users-form.html
@@ -23,6 +23,12 @@
                 <option th:each="department : ${departments}" th:value="${department.id}" th:text="${department.name}">부서</option>
             </select>
         </label>
+        <label>분반
+            <select name="classroomId">
+                <option value="">없음</option>
+                <option th:each="classroom : ${classrooms}" th:value="${classroom.id}" th:text="${classroom.name}">분반</option>
+            </select>
+        </label>
         <button class="button" type="submit">등록</button>
     </form>
 </main>

--- a/src/main/resources/templates/admin/user/users.html
+++ b/src/main/resources/templates/admin/user/users.html
@@ -30,6 +30,12 @@
                     <option th:each="department : ${departments}" th:value="${department.id}" th:text="${department.name}" th:selected="${filter.departmentId == department.id}">부서</option>
                 </select>
             </label>
+            <label>분반
+                <select name="classroomId">
+                    <option value="">전체</option>
+                    <option th:each="classroom : ${classrooms}" th:value="${classroom.id}" th:text="${classroom.name}" th:selected="${filter.classroomId == classroom.id}">분반</option>
+                </select>
+            </label>
             <label>권한 코드
                 <input name="permissionCode" th:value="${filter.permissionCode}" placeholder="user:manage">
             </label>
@@ -65,6 +71,7 @@
                         <th>연락처</th>
                         <th>역할</th>
                         <th>부서</th>
+                        <th>분반</th>
                         <th>직접 권한</th>
                         <th>운영</th>
                         <th>생성일</th>
@@ -80,6 +87,10 @@
                         <td>
                             <a class="link" th:if="${user.departmentId != null}" th:href="@{/admin/department/departments/{departmentId}(departmentId=${user.departmentId})}" th:text="${user.departmentName}">학사</a>
                             <span th:if="${user.departmentId == null}">-</span>
+                        </td>
+                        <td>
+                            <a class="link" th:if="${user.classroomId != null}" th:href="@{/admin/classroom/classrooms/{classroomId}(classroomId=${user.classroomId})}" th:text="${user.classroomName}">벚꽃반</a>
+                            <span th:if="${user.classroomId == null}">-</span>
                         </td>
                         <td>
                             <span th:if="${#lists.isEmpty(user.permissions)}">-</span>
@@ -99,8 +110,8 @@
             <div class="pager">
                 <span th:text="|총 ${usersPage.totalElements}명 · ${usersPage.page + 1}/${usersPage.totalPages == 0 ? 1 : usersPage.totalPages} 페이지|">총 0명</span>
                 <div>
-                    <a class="reset-link" th:classappend="${!usersPage.hasPrevious()} ? 'disabled'" th:href="@{/admin/user/users(keyword=${filter.keyword},role=${filter.role},departmentId=${filter.departmentId},permissionCode=${filter.permissionCode},size=${usersPage.size},sort=${filter.sort},page=${usersPage.previousPage()})}">이전</a>
-                    <a class="reset-link" th:classappend="${!usersPage.hasNext()} ? 'disabled'" th:href="@{/admin/user/users(keyword=${filter.keyword},role=${filter.role},departmentId=${filter.departmentId},permissionCode=${filter.permissionCode},size=${usersPage.size},sort=${filter.sort},page=${usersPage.nextPage()})}">다음</a>
+                    <a class="reset-link" th:classappend="${!usersPage.hasPrevious()} ? 'disabled'" th:href="@{/admin/user/users(keyword=${filter.keyword},role=${filter.role},departmentId=${filter.departmentId},classroomId=${filter.classroomId},permissionCode=${filter.permissionCode},size=${usersPage.size},sort=${filter.sort},page=${usersPage.previousPage()})}">이전</a>
+                    <a class="reset-link" th:classappend="${!usersPage.hasNext()} ? 'disabled'" th:href="@{/admin/user/users(keyword=${filter.keyword},role=${filter.role},departmentId=${filter.departmentId},classroomId=${filter.classroomId},permissionCode=${filter.permissionCode},size=${usersPage.size},sort=${filter.sort},page=${usersPage.nextPage()})}">다음</a>
                 </div>
             </div>
         </section>

--- a/src/test/java/geumjeongyahak/e2e/users/UserCreateTest.java
+++ b/src/test/java/geumjeongyahak/e2e/users/UserCreateTest.java
@@ -74,6 +74,36 @@ class UserCreateTest extends UserBaseTest {
     }
 
     @Test
+    @DisplayName("관리자 권한으로 User 생성 시 분반 배정 성공(201 Created)")
+    void createUser_WithClassroom_Success() {
+        String uniqueUsername = "classroom" + System.currentTimeMillis();
+        CreateUserRequest req = new CreateUserRequest(
+            uniqueUsername + "@test.com",
+            "Classroom User",
+            "password123!",
+            "010-4444-5555",
+            "VOLUNTEER",
+            null,
+            1L
+        );
+
+        var res = given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .contentType(ContentType.JSON)
+            .body(req)
+        .when()
+            .post()
+        .then()
+            .statusCode(201)
+            .body("classroom.id", equalTo(1))
+            .body("classroom.name", equalTo("벚꽃반"))
+            .extract()
+            .as(UserDetailResponse.class);
+
+        userTestHelper.setUser(res.email());
+    }
+
+    @Test
     @DisplayName("관리자 권한으로 User 생성 성공 - GUEST 역할(201 Created)")
     void createUser_Success_Guest() {
         String uniqueUsername = "guest" + System.currentTimeMillis();

--- a/src/test/java/geumjeongyahak/e2e/users/UserUpdateTest.java
+++ b/src/test/java/geumjeongyahak/e2e/users/UserUpdateTest.java
@@ -119,6 +119,50 @@ class UserUpdateTest extends UserBaseTest {
     }
 
     @Test
+    @DisplayName("관리자가 사용자의 분반을 변경 성공(200 OK)")
+    void updateUser_Classroom_Success() {
+        CreateUserRequest createReq = new CreateUserRequest(
+            "classroom-update@test.com",
+            "Classroom Update User",
+            "pw_classroom",
+            "010-1111-3333",
+            "VOLUNTEER",
+            null,
+            null
+        );
+
+        var createdUser = given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .contentType(ContentType.JSON)
+            .body(createReq)
+        .when()
+            .post()
+        .then()
+            .statusCode(201)
+            .body("classroom", nullValue())
+            .extract()
+            .as(UserDetailResponse.class);
+
+        userTestHelper.setUser(createdUser.email());
+
+        UpdateUserRequest updateReq = new UpdateUserRequest(
+            null, null, null, null, null, null, 2L
+        );
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .contentType(ContentType.JSON)
+            .body(updateReq)
+        .when()
+            .patch("/{userId}", createdUser.id())
+        .then()
+            .statusCode(200)
+            .body("classroom.id", equalTo(2))
+            .body("classroom.name", equalTo("장미반"))
+            .log().all();
+    }
+
+    @Test
     @DisplayName("일반 사용자 권한으로 다른 User 수정 실패(403 Forbidden)")
     void updateUser_Forbidden() {
         UpdateUserRequest updateReq = new UpdateUserRequest(


### PR DESCRIPTION
## Summary

- 관리자 사용자 생성/수정 API DTO에 `classroomId`를 추가하고 User.classroom에 반영합니다.
- 관리자 사용자 목록/상세/등록/수정 화면에 분반 표시, 필터, 선택 변경 UI를 추가합니다.
- 사용자 생성/수정 E2E에 분반 배정 검증을 추가합니다.

## Verification

- `./gradlew test --tests 'geumjeongyahak.e2e.users.UserCreateTest' --tests 'geumjeongyahak.e2e.users.UserUpdateTest'`

Closes #131
