### PR TITLE
fix(global): 조회 파라미터 바인딩 오류 처리

### DIFF
--- a/src/main/java/geumjeongyahak/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/geumjeongyahak/common/advice/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package geumjeongyahak.common.advice;
 import java.util.stream.Collectors;
 
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
@@ -10,11 +11,16 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import lombok.extern.slf4j.Slf4j;
@@ -149,6 +155,82 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problemDetail);
     }
 
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ProblemDetail> handleBindException(BindException ex) {
+        String errorMessages = ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+
+        log.warn("요청 바인딩 실패 - {}", errorMessages);
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+                HttpStatus.BAD_REQUEST,
+                CommonErrorCode.VALIDATION_ERROR.getMessage()
+        );
+        problemDetail.setTitle(CommonErrorCode.VALIDATION_ERROR.getCode());
+        problemDetail.setProperty("code", CommonErrorCode.VALIDATION_ERROR.getCode());
+        problemDetail.setProperty("errors", ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> new FieldError(error.getField(), error.getDefaultMessage()))
+                .toList());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problemDetail);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ProblemDetail> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException ex
+    ) {
+        String parameterName = ex.getName();
+        String value = ex.getValue() != null ? ex.getValue().toString() : null;
+        log.warn("요청 파라미터 타입 변환 실패 - parameter: {}, value: {}, requiredType: {}",
+                parameterName, value, ex.getRequiredType());
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+                HttpStatus.BAD_REQUEST,
+                CommonErrorCode.INVALID_INPUT.getMessage()
+        );
+        problemDetail.setTitle(CommonErrorCode.INVALID_INPUT.getCode());
+        problemDetail.setProperty("code", CommonErrorCode.INVALID_INPUT.getCode());
+        problemDetail.setProperty("parameter", parameterName);
+        problemDetail.setProperty("value", value);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problemDetail);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ProblemDetail> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
+        log.warn("요청 본문 파싱 실패 - {}", ex.getMessage());
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+                HttpStatus.BAD_REQUEST,
+                CommonErrorCode.INVALID_INPUT.getMessage()
+        );
+        problemDetail.setTitle(CommonErrorCode.INVALID_INPUT.getCode());
+        problemDetail.setProperty("code", CommonErrorCode.INVALID_INPUT.getCode());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problemDetail);
+    }
+
+    @ExceptionHandler({
+            MissingServletRequestParameterException.class,
+            MissingRequestHeaderException.class,
+            MissingServletRequestPartException.class
+    })
+    public ResponseEntity<ProblemDetail> handleMissingRequestValueException(Exception ex) {
+        String fieldName = getMissingRequestValueName(ex);
+        log.warn("필수 요청 값 누락 - field: {}, exception: {}", fieldName, ex.getClass().getSimpleName());
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+                HttpStatus.BAD_REQUEST,
+                CommonErrorCode.MISSING_REQUIRED_FIELD.getMessage()
+        );
+        problemDetail.setTitle(CommonErrorCode.MISSING_REQUIRED_FIELD.getCode());
+        problemDetail.setProperty("code", CommonErrorCode.MISSING_REQUIRED_FIELD.getCode());
+        problemDetail.setProperty("field", fieldName);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problemDetail);
+    }
+
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ProblemDetail> handleHttpRequestMethodNotSupportedException(
             HttpRequestMethodNotSupportedException ex
@@ -257,6 +339,19 @@ public class GlobalExceptionHandler {
     }
 
     // ============ 내부 클래스 ============
+
+    private String getMissingRequestValueName(Exception ex) {
+        if (ex instanceof MissingServletRequestParameterException missingParameter) {
+            return missingParameter.getParameterName();
+        }
+        if (ex instanceof MissingRequestHeaderException missingHeader) {
+            return missingHeader.getHeaderName();
+        }
+        if (ex instanceof MissingServletRequestPartException missingPart) {
+            return missingPart.getRequestPartName();
+        }
+        return null;
+    }
 
     private record FieldError(String field, String message) {}
 }

--- a/src/main/java/geumjeongyahak/common/security/config/WebSecurityConfig.java
+++ b/src/main/java/geumjeongyahak/common/security/config/WebSecurityConfig.java
@@ -55,6 +55,7 @@ public class WebSecurityConfig {
             .csrf(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/admin/auth/login").permitAll()
+                .requestMatchers("/admin/meeting-records/**").hasRole("ADMIN")
                 .anyRequest().hasAnyRole("ADMIN", "MANAGER")
             )
             .formLogin(form -> form
@@ -69,7 +70,7 @@ public class WebSecurityConfig {
                 .logoutSuccessUrl("/admin/auth/login?logout")
             )
             .exceptionHandling(exception -> exception
-                .accessDeniedPage("/admin/auth/login?denied")
+                .accessDeniedHandler(accessDeniedHandler)
             )
             .build();
     }
@@ -121,6 +122,7 @@ public class WebSecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/api/v1/channels").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/posts").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/channels/*/posts", "/api/v1/channels/*/posts/**").permitAll()
+                .requestMatchers("/api/v1/meeting-records/**").hasAnyRole("VOLUNTEER", "MANAGER", "ADMIN")
                 // 그 외는 인증 필요
                 .anyRequest().authenticated()
             )

--- a/src/test/java/geumjeongyahak/e2e/common/RequestBindingErrorTest.java
+++ b/src/test/java/geumjeongyahak/e2e/common/RequestBindingErrorTest.java
@@ -1,0 +1,119 @@
+package geumjeongyahak.e2e.common;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import geumjeongyahak.domain.auth.enums.RoleType;
+import geumjeongyahak.e2e.BaseE2ETest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("common")
+@DisplayName("E2E: 요청 바인딩 오류 공통 처리")
+class RequestBindingErrorTest extends BaseE2ETest {
+
+    private static final String VOLUNTEER = "binding-volunteer@test.com";
+
+    private String adminToken;
+    private String volunteerToken;
+
+    @BeforeEach
+    @Override
+    protected void setUp() {
+        super.setUp();
+        userTestHelper.createTestUser(VOLUNTEER, "바인딩 테스트 봉사자", "password", RoleType.VOLUNTEER);
+
+        adminToken = userTestHelper.generateAccessTokenByUserKey(TEST_ADMIN_EMAIL);
+        volunteerToken = userTestHelper.generateAccessTokenByUserKey(VOLUNTEER);
+    }
+
+    @Test
+    @DisplayName("@ModelAttribute 날짜 변환 실패는 400을 반환한다")
+    void modelAttributeDateConversionError_returns400() {
+        given()
+            .queryParam("from", "not-a-date")
+            .queryParam("to", "2026-06-03")
+        .when()
+            .get("/api/v1/lessons")
+        .then()
+            .statusCode(400)
+            .body("code", equalTo("VAL001"));
+    }
+
+    @Test
+    @DisplayName("필수 요청 파라미터 누락은 400을 반환한다")
+    void missingRequestParameter_returns400() {
+        given()
+            .header(AUTH_HEADER, getAuthHeader(volunteerToken))
+            .queryParam("classroomId", 1)
+        .when()
+            .get("/api/v1/daily-schedules/detail")
+        .then()
+            .statusCode(400)
+            .body("code", equalTo("VAL003"))
+            .body("field", equalTo("lessonDate"));
+    }
+
+    @Test
+    @DisplayName("요청 파라미터 타입 변환 실패는 400을 반환한다")
+    void requestParameterTypeMismatch_returns400() {
+        given()
+            .header(AUTH_HEADER, getAuthHeader(volunteerToken))
+            .queryParam("classroomId", "not-a-number")
+            .queryParam("lessonDate", "2026-06-03")
+        .when()
+            .get("/api/v1/daily-schedules/detail")
+        .then()
+            .statusCode(400)
+            .body("code", equalTo("VAL002"))
+            .body("parameter", equalTo("classroomId"));
+    }
+
+    @Test
+    @DisplayName("관리자 API enum 조회 파라미터 변환 실패는 400을 반환한다")
+    void adminEnumRequestParameterTypeMismatch_returns400() {
+        given()
+            .header(AUTH_HEADER, getAuthHeader(adminToken))
+            .queryParam("status", "invalid")
+        .when()
+            .get("/api/v1/admin/purchase-requests")
+        .then()
+            .statusCode(400)
+            .body("code", equalTo("VAL002"))
+            .body("parameter", equalTo("status"));
+    }
+
+    @Test
+    @DisplayName("경로 변수 타입 변환 실패는 400을 반환한다")
+    void pathVariableTypeMismatch_returns400() {
+        given()
+            .header(AUTH_HEADER, getAuthHeader(adminToken))
+        .when()
+            .get("/api/v1/admin/teacher-applications/not-a-number")
+        .then()
+            .statusCode(400)
+            .body("code", equalTo("VAL002"))
+            .body("parameter", equalTo("applicationId"));
+    }
+
+    @Test
+    @DisplayName("요청 본문 파싱 실패는 400을 반환한다")
+    void requestBodyParseError_returns400() {
+        given()
+            .header(AUTH_HEADER, getAuthHeader(adminToken))
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "status": "invalid"
+                }
+                """)
+        .when()
+            .patch("/api/v1/lessons/1/status")
+        .then()
+            .statusCode(400)
+            .body("code", equalTo("VAL002"));
+    }
+}

--- a/src/test/java/geumjeongyahak/e2e/meeting_record/MeetingRecordApiTest.java
+++ b/src/test/java/geumjeongyahak/e2e/meeting_record/MeetingRecordApiTest.java
@@ -97,6 +97,18 @@ class MeetingRecordApiTest extends BaseE2ETest {
     }
 
     @Test
+    @DisplayName("GUEST의 잘못된 회의록 status 조회 파라미터도 권한 없음으로 처리된다")
+    void getMeetingRecords_invalidStatusAsGuest_returns403() {
+        given()
+            .header(AUTH_HEADER, getAuthHeader(guestToken))
+            .queryParam("status", "before")
+        .when()
+            .get("/api/v1/meeting-records")
+        .then()
+            .statusCode(403);
+    }
+
+    @Test
     @DisplayName("목록 조회는 title 검색과 mineOnly 필터를 지원한다")
     void getMeetingRecords_filtersByKeywordAndMineOnly() {
         createRecord(authorToken, "나의 교학 회의", "안건");
@@ -115,6 +127,19 @@ class MeetingRecordApiTest extends BaseE2ETest {
             .body("content[0].title", equalTo("나의 교학 회의"))
             .body("content[0].authorId", not(equalTo(null)))
             .body("content[0].viewCount", equalTo(0));
+    }
+
+    @Test
+    @DisplayName("잘못된 회의록 status 조회 파라미터는 400을 반환한다")
+    void getMeetingRecords_invalidStatus_returns400() {
+        given()
+            .header(AUTH_HEADER, getAuthHeader(authorToken))
+            .queryParam("status", "before")
+        .when()
+            .get("/api/v1/meeting-records")
+        .then()
+            .statusCode(400)
+            .body("code", equalTo("VAL001"));
     }
 
     @Test
@@ -240,6 +265,62 @@ class MeetingRecordApiTest extends BaseE2ETest {
             .delete("/api/v1/meeting-records/{recordId}/absence-reports/{reportId}", recordId, reportId)
         .then()
             .statusCode(204);
+    }
+
+    @Test
+    @DisplayName("관리자는 관리자 화면에서 회의록 목록과 상세를 조회할 수 있다")
+    void adminView_listAndDetail_returns200() {
+        Long recordId = createRecord(authorToken, "관리자 조회 테스트", "안건");
+        createAbsenceReport(recordId, otherToken, "불참 사유", "의견");
+        String adminSessionId = loginAdminSession(TEST_ADMIN_EMAIL, TEST_ADMIN_PASSWORD);
+
+        given()
+            .cookie("JSESSIONID", adminSessionId)
+        .when()
+            .get("/admin/meeting-records")
+        .then()
+            .statusCode(200)
+            .body(containsString("관리자 조회 테스트"));
+
+        given()
+            .cookie("JSESSIONID", adminSessionId)
+        .when()
+            .get("/admin/meeting-records/{recordId}", recordId)
+        .then()
+            .statusCode(200)
+            .body(containsString("관리자 조회 테스트"))
+            .body(containsString("불참 사유"));
+    }
+
+    @Test
+    @DisplayName("관리자 회의록 목록의 잘못된 status 파라미터는 400을 반환한다")
+    void adminView_invalidStatus_returns400() {
+        String adminSessionId = loginAdminSession(TEST_ADMIN_EMAIL, TEST_ADMIN_PASSWORD);
+
+        given()
+            .cookie("JSESSIONID", adminSessionId)
+            .queryParam("status", "before")
+        .when()
+            .get("/admin/meeting-records")
+        .then()
+            .statusCode(400)
+            .body("code", equalTo("VAL002"));
+    }
+
+    @Test
+    @DisplayName("MANAGER의 잘못된 관리자 회의록 status 조회 파라미터도 권한 없음으로 처리된다")
+    void adminView_invalidStatusAsManager_returns403() {
+        String managerSessionId = loginAdminSession(MANAGER, "password");
+
+        given()
+            .cookie("JSESSIONID", managerSessionId)
+            .queryParam("status", "before")
+            .redirects()
+            .follow(false)
+        .when()
+            .get("/admin/meeting-records")
+        .then()
+            .statusCode(403);
     }
 
     @Test


### PR DESCRIPTION
## 개요

교학회의록 조회에서 잘못된 조회 파라미터가 들어올 때 Spring MVC 바인딩 예외가 전역 catch-all로 떨어져 500이 발생할 수 있는 문제를 수정했습니다. 같은 계열의 요청 바인딩 오류가 다른 경계에서도 500으로 처리되지 않도록 공통 예외 핸들러를 보강했고, 권한 없는 사용자가 잘못된 파라미터를 보냈을 때 400이 먼저 노출되는 회의록 권한 경계도 함께 닫았습니다.

## 변경 유형

- [ ] 새 기능 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [x] 테스트 (test)
- [ ] 기타 (chore)

## 변경 내용

- 문제: `@ModelAttribute` 검색 DTO의 enum/date 변환 실패, `@RequestParam`/`@PathVariable` 타입 변환 실패, JSON body 파싱 실패, 필수 요청 값 누락이 명시적으로 처리되지 않아 `GlobalExceptionHandler.handleException(Exception)`으로 떨어질 수 있었습니다. 이 경우 사용자 입력 오류임에도 500 `SYS001`로 응답할 수 있었습니다.
- 해결: `BindException`, `MethodArgumentTypeMismatchException`, `HttpMessageNotReadableException`, `MissingServletRequestParameterException`, `MissingRequestHeaderException`, `MissingServletRequestPartException`을 전역 예외 핸들러에 추가해 각각 400 계열 오류로 응답하도록 처리했습니다.
- 응답 기준: 모델 바인딩 검증/변환 실패는 400 `VAL001`, 단일 query/path 타입 변환 실패와 JSON body 파싱 실패는 400 `VAL002`, 필수 요청 param/header/part 누락은 400 `VAL003`으로 정리했습니다.
- 권한 경계: 회의록 API와 관리자 회의록 화면은 컨트롤러 `@PreAuthorize` 전에 파라미터 바인딩이 먼저 수행될 수 있어, 권한 없는 사용자가 잘못된 `status`를 보내면 403 대신 400을 받을 수 있었습니다. 해당 경로를 `SecurityFilterChain`에서 먼저 권한 검사하도록 보강했습니다.
- 테스트: 회의록 API/admin 조회의 정상 조회, 잘못된 `status`, 권한 없는 사용자 + 잘못된 `status` 케이스를 추가했습니다. 또한 enum, 날짜, 숫자, 경로 변수, 필수 파라미터, JSON body 파싱 실패 대표 경계를 공통 E2E로 추가했습니다.

## 관련 이슈

Closes #133

## 스크린샷 (선택)

없음. API/예외 응답 처리 변경입니다.

## 체크리스트

- [x] 코드 컨벤션을 준수했습니다
- [x] 테스트 코드를 작성/수정했습니다
- [x] 모든 테스트가 통과합니다
- [x] 문서를 업데이트했습니다 (필요한 경우)

## 리뷰어에게

중점적으로 볼 부분은 두 가지입니다. 첫째, 사용자 입력 오류가 더 이상 500으로 떨어지지 않고 의도한 400 코드(`VAL001`, `VAL002`, `VAL003`)로 분류되는지 확인 부탁드립니다. 둘째, 회의록 경로에서 권한 없는 사용자가 잘못된 파라미터를 보내도 컨트롤러 바인딩 전에 403으로 차단되는지 확인 부탁드립니다.

검증 명령:
`./gradlew test --tests geumjeongyahak.e2e.common.RequestBindingErrorTest --tests geumjeongyahak.e2e.meeting_record.MeetingRecordApiTest`