### PR TITLE
fix(meeting-record): 회의록 목록 검색 조건 처리 수정

### DIFF
--- a/src/main/java/geumjeongyahak/domain/meeting_record/repository/MeetingRecordRepository.java
+++ b/src/main/java/geumjeongyahak/domain/meeting_record/repository/MeetingRecordRepository.java
@@ -1,32 +1,18 @@
 package geumjeongyahak.domain.meeting_record.repository;
 
 import geumjeongyahak.domain.meeting_record.entity.MeetingRecord;
-import geumjeongyahak.domain.meeting_record.enums.MeetingRecordStatus;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface MeetingRecordRepository extends JpaRepository<MeetingRecord, Long> {
+public interface MeetingRecordRepository extends JpaRepository<MeetingRecord, Long>, JpaSpecificationExecutor<MeetingRecord> {
 
     @EntityGraph(attributePaths = "author")
-    @Query("""
-        select r
-        from MeetingRecord r
-        where r.isDeleted = false
-          and (:keyword is null or lower(r.title) like lower(concat('%', :keyword, '%')))
-          and (:authorId is null or r.author.id = :authorId)
-          and (:status is null or r.status = :status)
-        """)
-    Page<MeetingRecord> search(
-        @Param("keyword") String keyword,
-        @Param("authorId") Long authorId,
-        @Param("status") MeetingRecordStatus status,
-        Pageable pageable
-    );
+    Page<MeetingRecord> findAll(Specification<MeetingRecord> spec, Pageable pageable);
 
     @EntityGraph(attributePaths = {"author", "absenceReports", "absenceReports.author"})
     Optional<MeetingRecord> findByIdAndIsDeletedFalse(Long id);

--- a/src/main/java/geumjeongyahak/domain/meeting_record/repository/specification/MeetingRecordSpecs.java
+++ b/src/main/java/geumjeongyahak/domain/meeting_record/repository/specification/MeetingRecordSpecs.java
@@ -1,0 +1,35 @@
+package geumjeongyahak.domain.meeting_record.repository.specification;
+
+import geumjeongyahak.domain.meeting_record.entity.MeetingRecord;
+import geumjeongyahak.domain.meeting_record.enums.MeetingRecordStatus;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.util.StringUtils;
+
+public final class MeetingRecordSpecs {
+
+    private MeetingRecordSpecs() {
+    }
+
+    public static Specification<MeetingRecord> isNotDeleted() {
+        return (root, query, cb) -> cb.isFalse(root.get("isDeleted"));
+    }
+
+    public static Specification<MeetingRecord> containsTitle(String keyword) {
+        return (root, query, cb) -> {
+            if (!StringUtils.hasText(keyword)) {
+                return null;
+            }
+
+            String pattern = "%" + keyword.trim().toLowerCase() + "%";
+            return cb.like(cb.lower(root.get("title")), pattern);
+        };
+    }
+
+    public static Specification<MeetingRecord> hasAuthorId(Long authorId) {
+        return (root, query, cb) -> authorId == null ? null : cb.equal(root.get("author").get("id"), authorId);
+    }
+
+    public static Specification<MeetingRecord> hasStatus(MeetingRecordStatus status) {
+        return (root, query, cb) -> status == null ? null : cb.equal(root.get("status"), status);
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/meeting_record/service/MeetingRecordService.java
+++ b/src/main/java/geumjeongyahak/domain/meeting_record/service/MeetingRecordService.java
@@ -9,6 +9,7 @@ import geumjeongyahak.domain.meeting_record.enums.MeetingRecordStatus;
 import geumjeongyahak.domain.meeting_record.exception.MeetingRecordErrorCode;
 import geumjeongyahak.domain.meeting_record.repository.MeetingAbsenceReportRepository;
 import geumjeongyahak.domain.meeting_record.repository.MeetingRecordRepository;
+import geumjeongyahak.domain.meeting_record.repository.specification.MeetingRecordSpecs;
 import geumjeongyahak.domain.meeting_record.v1.dto.request.CreateAbsenceReportRequest;
 import geumjeongyahak.domain.meeting_record.v1.dto.request.CreateMeetingRecordRequest;
 import geumjeongyahak.domain.meeting_record.v1.dto.request.MeetingRecordSearchRequest;
@@ -20,6 +21,7 @@ import geumjeongyahak.domain.meeting_record.v1.dto.response.MeetingRecordSummary
 import geumjeongyahak.domain.users.entity.User;
 import geumjeongyahak.domain.users.service.UserProxyService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,14 +40,15 @@ public class MeetingRecordService {
     ) {
         User requester = getStaffUser(requesterId);
         Long authorId = Boolean.TRUE.equals(request.getMineOnly()) ? requester.getId() : null;
+        Specification<MeetingRecord> spec = Specification.allOf(
+            MeetingRecordSpecs.isNotDeleted(),
+            MeetingRecordSpecs.containsTitle(request.getKeyword()),
+            MeetingRecordSpecs.hasAuthorId(authorId),
+            MeetingRecordSpecs.hasStatus(request.getStatus())
+        );
 
         return PaginationResponse.from(
-            meetingRecordRepository.search(
-                normalizeKeyword(request.getKeyword()),
-                authorId,
-                request.getStatus(),
-                request.toRequest()
-            ),
+            meetingRecordRepository.findAll(spec, request.toRequest()),
             MeetingRecordSummaryResponse::from
         );
     }
@@ -196,10 +199,6 @@ public class MeetingRecordService {
         if (record.getStatus() == MeetingRecordStatus.AFTER_MEETING && nextStatus == MeetingRecordStatus.BEFORE_MEETING) {
             throw new BusinessException(MeetingRecordErrorCode.INVALID_STATUS);
         }
-    }
-
-    private String normalizeKeyword(String value) {
-        return value == null || value.isBlank() ? null : value.trim();
     }
 
     private String normalizeRequiredIfPresent(String value) {

--- a/src/test/java/geumjeongyahak/e2e/meeting_record/MeetingRecordApiTest.java
+++ b/src/test/java/geumjeongyahak/e2e/meeting_record/MeetingRecordApiTest.java
@@ -130,6 +130,39 @@ class MeetingRecordApiTest extends BaseE2ETest {
     }
 
     @Test
+    @DisplayName("목록 조회는 keyword 없이도 전체 회의록을 조회한다")
+    void getMeetingRecords_withoutKeyword_returnsRecords() {
+        createRecord(authorToken, "나의 교학 회의", "안건");
+        createRecord(otherToken, "다른 교학 회의", "안건");
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(authorToken))
+            .queryParam("size", 9)
+        .when()
+            .get("/api/v1/meeting-records")
+        .then()
+            .statusCode(200)
+            .body("content", hasSize(2));
+    }
+
+    @Test
+    @DisplayName("목록 조회는 공백 keyword를 검색 조건으로 사용하지 않는다")
+    void getMeetingRecords_blankKeyword_ignoresKeywordFilter() {
+        createRecord(authorToken, "나의 교학 회의", "안건");
+        createRecord(otherToken, "다른 교학 회의", "안건");
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(authorToken))
+            .queryParam("keyword", "   ")
+            .queryParam("size", 9)
+        .when()
+            .get("/api/v1/meeting-records")
+        .then()
+            .statusCode(200)
+            .body("content", hasSize(2));
+    }
+
+    @Test
     @DisplayName("잘못된 회의록 status 조회 파라미터는 400을 반환한다")
     void getMeetingRecords_invalidStatus_returns400() {
         given()
@@ -290,6 +323,21 @@ class MeetingRecordApiTest extends BaseE2ETest {
             .statusCode(200)
             .body(containsString("관리자 조회 테스트"))
             .body(containsString("불참 사유"));
+    }
+
+    @Test
+    @DisplayName("관리자 회의록 목록은 keyword 없이도 조회할 수 있다")
+    void adminView_withoutKeyword_returns200() {
+        createRecord(authorToken, "관리자 keyword 없음", "안건");
+        String adminSessionId = loginAdminSession(TEST_ADMIN_EMAIL, TEST_ADMIN_PASSWORD);
+
+        given()
+            .cookie("JSESSIONID", adminSessionId)
+        .when()
+            .get("/admin/meeting-records")
+        .then()
+            .statusCode(200)
+            .body(containsString("관리자 keyword 없음"));
     }
 
     @Test


### PR DESCRIPTION
## 변경 사항
- 회의록 목록 검색을 nullable JPQL 조건에서 Specification 조합으로 변경
- keyword, mineOnly, status 옵션 조건을 값이 있을 때만 predicate로 적용
- keyword 미지정/공백 keyword/관리자 목록 조회 회귀 테스트 추가

## 검증
- PASS: ./gradlew test --tests geumjeongyahak.e2e.meeting_record.MeetingRecordApiTest
- FAIL: ./gradlew test (기존 별도 실패 4건: FileUploadTest sample image 리소스 누락, LessonExchangeProposalWithdrawTest 2건, AdminDashboardServiceTest mock 누락)

Closes #133