### PR TITLE
[FIX] 수업 관리 기능에서 DailySchedule 동기화 및 요청 상태 검증 오류 수정

### DIFF
--- a/src/main/java/geumjeongyahak/domain/daily_schedule/service/event/LessonEventHandler.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/service/event/LessonEventHandler.java
@@ -4,9 +4,8 @@ import geumjeongyahak.domain.daily_schedule.service.DailyScheduleService;
 import geumjeongyahak.domain.lesson.event.LessonDailyScheduleSyncRequestedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Service
@@ -15,7 +14,7 @@ public class LessonEventHandler {
 
     private final DailyScheduleService dailyScheduleService;
 
-    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    @EventListener
     public void handleLessonDailyScheduleSyncRequested(LessonDailyScheduleSyncRequestedEvent event) {
         log.info(
             "수업 변경 이벤트 처리 - DailySchedule 동기화 (classroomId={}, lessonDate={})",

--- a/src/main/java/geumjeongyahak/domain/request/repository/AbsenceRequestRepository.java
+++ b/src/main/java/geumjeongyahak/domain/request/repository/AbsenceRequestRepository.java
@@ -49,8 +49,12 @@ public interface AbsenceRequestRepository extends JpaRepository<AbsenceRequest, 
                 and lesson.subject.classroom.id = absenceRequest.dailySchedule.classroom.id
                 and lesson.date = absenceRequest.dailySchedule.lessonDate
         )
+        and absenceRequest.status in :statuses
         """)
-    boolean existsByDailyScheduleMatchingLessonIds(@Param("lessonIds") List<Long> lessonIds);
+    boolean existsByDailyScheduleMatchingLessonIds(
+        @Param("lessonIds") List<Long> lessonIds,
+        @Param("statuses") List<RequestStatus> statuses
+    );
 
     List<AbsenceRequest> findAllByStatusInAndExpiresAtBefore(
         Collection<RequestStatus> statuses,

--- a/src/main/java/geumjeongyahak/domain/request/service/AbsenceRequestProxyService.java
+++ b/src/main/java/geumjeongyahak/domain/request/service/AbsenceRequestProxyService.java
@@ -1,5 +1,6 @@
 package geumjeongyahak.domain.request.service;
 
+import geumjeongyahak.domain.request.enums.RequestStatus;
 import geumjeongyahak.domain.request.repository.AbsenceRequestRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -13,10 +14,13 @@ public class AbsenceRequestProxyService {
     private final AbsenceRequestRepository absenceRequestRepository;
 
     @Transactional(readOnly = true)
-    public boolean existsAbsenceRequestByLessonIds(List<Long> lessonIds) {
+    public boolean existsActiveAbsenceRequestByLessonIds(List<Long> lessonIds) {
         if (lessonIds == null || lessonIds.isEmpty()) {
             return false;
         }
-        return absenceRequestRepository.existsByDailyScheduleMatchingLessonIds(lessonIds);
+        return absenceRequestRepository.existsByDailyScheduleMatchingLessonIds(
+            lessonIds,
+            List.of(RequestStatus.PENDING, RequestStatus.APPROVED)
+        );
     }
 }

--- a/src/main/java/geumjeongyahak/domain/subject/service/SubjectService.java
+++ b/src/main/java/geumjeongyahak/domain/subject/service/SubjectService.java
@@ -364,7 +364,7 @@ public class SubjectService {
         if (lessonProxyService.existsUnchangeableFutureActiveLessonBySubjectId(subjectId, today)) {
             throw new SubjectTeacherAssignmentConflictException("운영 기록이 있는 미래 수업은 자동 변경할 수 없습니다.");
         }
-        if (absenceRequestProxyService.existsAbsenceRequestByLessonIds(
+        if (absenceRequestProxyService.existsActiveAbsenceRequestByLessonIds(
             lessonProxyService.getFutureActiveLessonIdsBySubjectId(subjectId, today)
         )) {
             throw new SubjectTeacherAssignmentConflictException("결석 요청이 연결된 미래 수업은 자동 변경할 수 없습니다.");

--- a/src/test/java/geumjeongyahak/e2e/subject/SubjectBaseTest.java
+++ b/src/test/java/geumjeongyahak/e2e/subject/SubjectBaseTest.java
@@ -59,6 +59,9 @@ public class SubjectBaseTest extends BaseE2ETest {
         jdbcTemplate.execute("TRUNCATE TABLE absence_requests");
         jdbcTemplate.execute("TRUNCATE TABLE lesson_exchange_proposals");
         jdbcTemplate.execute("TRUNCATE TABLE lesson_exchange_requests");
+        jdbcTemplate.execute("TRUNCATE TABLE daily_student_attendances");
+        jdbcTemplate.execute("TRUNCATE TABLE daily_teacher_attendances");
+        jdbcTemplate.execute("TRUNCATE TABLE daily_schedules");
         jdbcTemplate.execute("TRUNCATE TABLE lessons");
         jdbcTemplate.execute("TRUNCATE TABLE subjects");
 
@@ -66,6 +69,9 @@ public class SubjectBaseTest extends BaseE2ETest {
         jdbcTemplate.execute("ALTER TABLE absence_requests ALTER COLUMN id RESTART WITH 1");
         jdbcTemplate.execute("ALTER TABLE lesson_exchange_proposals ALTER COLUMN id RESTART WITH 1");
         jdbcTemplate.execute("ALTER TABLE lesson_exchange_requests ALTER COLUMN id RESTART WITH 1");
+        jdbcTemplate.execute("ALTER TABLE daily_student_attendances ALTER COLUMN id RESTART WITH 1");
+        jdbcTemplate.execute("ALTER TABLE daily_teacher_attendances ALTER COLUMN id RESTART WITH 1");
+        jdbcTemplate.execute("ALTER TABLE daily_schedules ALTER COLUMN id RESTART WITH 1");
         jdbcTemplate.execute("ALTER TABLE lessons ALTER COLUMN id RESTART WITH 1");
         jdbcTemplate.execute("ALTER TABLE subjects ALTER COLUMN id RESTART WITH 1");
 

--- a/src/test/java/geumjeongyahak/e2e/subject/SubjectCreateTest.java
+++ b/src/test/java/geumjeongyahak/e2e/subject/SubjectCreateTest.java
@@ -2,9 +2,11 @@ package geumjeongyahak.e2e.subject;
 
 import static io.restassured.RestAssured.given;
 import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
@@ -173,6 +175,61 @@ public class SubjectCreateTest extends SubjectBaseTest {
             subjectId
         );
         org.assertj.core.api.Assertions.assertThat(lessonCount).isZero();
+    }
+
+    @Test
+    @DisplayName("담당 교사가 있는 과목 생성 시 수업과 하루 일정을 자동 생성한다")
+    void createSubject_Success_WithTeacherCreatesLessonsAndDailySchedule() {
+        LocalDate lessonDate = LocalDate.now().plusWeeks(2);
+        while (lessonDate.getDayOfWeek() != DayOfWeek.MONDAY) {
+            lessonDate = lessonDate.plusDays(1);
+        }
+
+        Map<String, Object> request = createRequest(
+            "하루 일정 자동 생성 과목",
+            lessonDate.toString(),
+            lessonDate.toString(),
+            lessonDate.getDayOfWeek().name()
+        );
+
+        Integer subjectId = given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .contentType("application/json")
+            .body(request)
+            .when()
+            .post()
+            .then()
+            .statusCode(201)
+            .body("id", notNullValue())
+            .extract()
+            .path("id");
+
+        Integer lessonCount = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM lessons WHERE subject_id = ?",
+            Integer.class,
+            subjectId
+        );
+        Integer dailyScheduleCount = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM daily_schedules WHERE classroom_id = ? AND lesson_date = ? AND is_deleted = false",
+            Integer.class,
+            CLASSROOM_ID,
+            lessonDate
+        );
+        Integer teacherAttendanceCount = jdbcTemplate.queryForObject(
+            """
+                SELECT COUNT(*)
+                FROM daily_teacher_attendances dta
+                JOIN daily_schedules ds ON dta.daily_schedule_id = ds.id
+                WHERE ds.classroom_id = ? AND ds.lesson_date = ? AND dta.is_deleted = false
+                """,
+            Integer.class,
+            CLASSROOM_ID,
+            lessonDate
+        );
+
+        assertThat(lessonCount).isEqualTo(1);
+        assertThat(dailyScheduleCount).isEqualTo(1);
+        assertThat(teacherAttendanceCount).isEqualTo(1);
     }
 
     @Test

--- a/src/test/java/geumjeongyahak/e2e/teacher_assignment/TeacherAssignmentAdminTest.java
+++ b/src/test/java/geumjeongyahak/e2e/teacher_assignment/TeacherAssignmentAdminTest.java
@@ -26,6 +26,7 @@ class TeacherAssignmentAdminTest extends BaseE2ETest {
     private static final long WEEKEND_SUBJECT_ID = 182L;
     private static final long CONFLICT_SUBJECT_ID = 183L;
     private static final long PERMISSION_CLEANUP_SUBJECT_ID = 184L;
+    private static final long REJECTED_ABSENCE_SUBJECT_ID = 185L;
 
     private String adminToken;
 
@@ -43,6 +44,7 @@ class TeacherAssignmentAdminTest extends BaseE2ETest {
         insertSubject(WEEKEND_SUBJECT_ID, 3L, null, "주말 임의 배정 과목", "SATURDAY", "10:00:00", "11:00:00");
         insertSubject(CONFLICT_SUBJECT_ID, 1L, 2L, "충돌 기준 과목");
         insertSubject(PERMISSION_CLEANUP_SUBJECT_ID, 1L, 3L, "권한 정리 과목", "TUESDAY", "19:20:00", "20:00:00");
+        insertSubject(REJECTED_ABSENCE_SUBJECT_ID, 2L, 3L, "반려 결강 요청 과목");
         adminToken = userTestHelper.generateAccessTokenByUserKey(TEST_ADMIN_USERNAME);
     }
 
@@ -162,6 +164,34 @@ class TeacherAssignmentAdminTest extends BaseE2ETest {
             REPLACEMENT_SUBJECT_ID
         );
         assertThat(teacherId).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("반려된 결강 요청만 있으면 기존 담당 교사를 교체할 수 있다")
+    void assignTeacher_rejectedAbsenceRequest_allowsReplacement() {
+        insertLesson(REJECTED_ABSENCE_SUBJECT_ID, 3L, 1802L, "2099-03-02", "19:20:00", "20:00:00");
+        insertDailyScheduleWithRejectedAbsenceRequest(1900L, REJECTED_ABSENCE_SUBJECT_ID, 3L, "2099-03-02");
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(adminToken))
+            .contentType("application/json")
+            .body(Map.of(
+                "teacherId", 2,
+                "subjectIds", java.util.List.of(REJECTED_ABSENCE_SUBJECT_ID),
+                "confirmTeacherReplacement", true
+            ))
+        .when()
+            .patch()
+        .then()
+            .statusCode(200)
+            .body("[0].teacherId", equalTo(2));
+
+        Integer updatedLessonCount = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM lessons WHERE subject_id = ? AND teacher_id = 2",
+            Integer.class,
+            REJECTED_ABSENCE_SUBJECT_ID
+        );
+        assertThat(updatedLessonCount).isEqualTo(1);
     }
 
     @Test
@@ -294,22 +324,73 @@ class TeacherAssignmentAdminTest extends BaseE2ETest {
             """, lessonId, subjectId, teacherId, date, startTime, endTime);
     }
 
+    private void insertDailyScheduleWithRejectedAbsenceRequest(
+        long dailyScheduleId,
+        long subjectId,
+        long teacherId,
+        String lessonDate
+    ) {
+        Long classroomId = jdbcTemplate.queryForObject(
+            "SELECT class_id FROM subjects WHERE id = ?",
+            Long.class,
+            subjectId
+        );
+        jdbcTemplate.update("""
+            INSERT INTO daily_schedules (
+                id, classroom_id, teacher_id, lesson_date, activity_start_time,
+                activity_end_time, status, is_deleted
+            )
+            VALUES (?, ?, ?, ?, TIME '19:20:00', TIME '20:00:00', 'SCHEDULED', FALSE)
+            """, dailyScheduleId, classroomId, teacherId, lessonDate);
+        jdbcTemplate.update("""
+            INSERT INTO absence_requests (
+                daily_schedule_id, requested_by, title, reason, expires_at,
+                status, approval_at, approval_by, note
+            )
+            VALUES (?, ?, '반려된 결강 요청', '테스트', TIMESTAMP '2099-03-01 00:00:00',
+                    'REJECTED', CURRENT_TIMESTAMP, 1, '반려')
+            """, dailyScheduleId, teacherId);
+    }
+
     private void cleanupFixtures() {
+        jdbcTemplate.update("""
+            DELETE FROM absence_requests
+            WHERE daily_schedule_id IN (
+                SELECT id FROM daily_schedules WHERE lesson_date >= DATE '2099-01-01'
+            )
+            """);
+        jdbcTemplate.update("""
+            DELETE FROM daily_teacher_attendances
+            WHERE daily_schedule_id IN (
+                SELECT id FROM daily_schedules WHERE lesson_date >= DATE '2099-01-01'
+            )
+            """);
+        jdbcTemplate.update("""
+            DELETE FROM daily_student_attendances
+            WHERE daily_schedule_id IN (
+                SELECT id FROM daily_schedules WHERE lesson_date >= DATE '2099-01-01'
+            )
+            """);
+        jdbcTemplate.update("""
+            DELETE FROM daily_schedules WHERE lesson_date >= DATE '2099-01-01'
+            """);
         jdbcTemplate.update(
-            "DELETE FROM lessons WHERE subject_id IN (?, ?, ?, ?, ?)",
+            "DELETE FROM lessons WHERE subject_id IN (?, ?, ?, ?, ?, ?)",
             UNASSIGNED_SUBJECT_ID,
             REPLACEMENT_SUBJECT_ID,
             WEEKEND_SUBJECT_ID,
             CONFLICT_SUBJECT_ID,
-            PERMISSION_CLEANUP_SUBJECT_ID
+            PERMISSION_CLEANUP_SUBJECT_ID,
+            REJECTED_ABSENCE_SUBJECT_ID
         );
         jdbcTemplate.update(
-            "DELETE FROM subjects WHERE id IN (?, ?, ?, ?, ?)",
+            "DELETE FROM subjects WHERE id IN (?, ?, ?, ?, ?, ?)",
             UNASSIGNED_SUBJECT_ID,
             REPLACEMENT_SUBJECT_ID,
             WEEKEND_SUBJECT_ID,
             CONFLICT_SUBJECT_ID,
-            PERMISSION_CLEANUP_SUBJECT_ID
+            PERMISSION_CLEANUP_SUBJECT_ID,
+            REJECTED_ABSENCE_SUBJECT_ID
         );
     }
 


### PR DESCRIPTION
## 개요

수업 관리 섹션에서 과목 생성 시 DailySchedule이 누락되는 문제와, 반려된 결강 요청이 담당 교사 변경을 계속 차단하는 문제를 수정했습니다.

## 변경 유형

- [ ] 새 기능 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [x] 테스트 (test)
- [ ] 기타 (chore)

## 변경 내용

- 과목 생성으로 자동 생성된 Lesson에 대해 DailySchedule 동기화가 누락되지 않도록 수정
- `LessonDailyScheduleSyncRequestedEvent`를 즉시 처리하여 중첩 `BEFORE_COMMIT` 이벤트 누락 문제 해결
- 과목 생성 시 Lesson, DailySchedule, 교사 출석이 함께 생성되는 E2E 테스트 추가
- 종료된 결강 요청이 담당 교사 변경을 차단하지 않도록 상태 필터링 추가
- 결강 요청 차단 대상 상태를 `PENDING`, `APPROVED`로 제한
- 반려된 결강 요청만 있는 경우 담당 교사 변경이 가능한 E2E 테스트 추가

## 관련 이슈

Closes #145

## 스크린샷 (선택)



## 체크리스트

- [x] 코드 컨벤션을 준수했습니다
- [x] 테스트 코드를 작성/수정했습니다
- [x] 모든 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)

## 리뷰어에게

기존 운영 데이터 중 `lessons`는 존재하지만 `daily_schedules`가 누락된 데이터는 코드 배포만으로 자동 복구되지 않을 수 있습니다. 