### PR TITLE
[FEAT] Apps Script API 연동 기반 구축

### DIFF
--- a/src/main/java/geumjeongyahak/domain/purchase_request/service/PurchaseRequestService.java
+++ b/src/main/java/geumjeongyahak/domain/purchase_request/service/PurchaseRequestService.java
@@ -208,7 +208,7 @@ public class PurchaseRequestService {
     ) {
         log.debug("구매 완료 보고 (requestId={})", requestId);
         PurchaseRequest purchaseRequest = findById(requestId);
-        checkAccess(purchaseRequest, requesterId, false);
+        checkAccess(purchaseRequest, requesterId, isAdmin);
 
         if (purchaseRequest.getStatus() != PurchaseRequestStatus.APPROVED) {
             throw new BusinessException(PurchaseRequestErrorCode.INVALID_STATUS);

--- a/src/main/java/geumjeongyahak/domain/purchase_request/service/PurchaseRequestService.java
+++ b/src/main/java/geumjeongyahak/domain/purchase_request/service/PurchaseRequestService.java
@@ -28,6 +28,7 @@ import geumjeongyahak.domain.purchase_request.entity.PurchaseRequestPaymentTrans
 import geumjeongyahak.domain.purchase_request.enums.PurchaseRequestStatus;
 import geumjeongyahak.domain.purchase_request.exception.PurchaseRequestErrorCode;
 import geumjeongyahak.domain.purchase_request.repository.PurchaseRequestRepository;
+import geumjeongyahak.domain.purchase_request.v1.dto.request.CreatePurchaseRequestByAdminRequest;
 import geumjeongyahak.domain.purchase_request.v1.dto.request.CreatePurchaseRequestRequest;
 import geumjeongyahak.domain.purchase_request.v1.dto.request.ReportPurchaseRequest;
 import geumjeongyahak.domain.purchase_request.v1.dto.response.PurchaseRequestDetailResponse;
@@ -68,18 +69,33 @@ public class PurchaseRequestService {
             ))
             .toList();
 
-        PurchaseRequest saved = purchaseRequestRepository.save(
-            new PurchaseRequest(
-                classroom,
-                requester,
-                request.title(),
-                request.content(),
-                items
-            )
+        return createPurchaseRequest(requester, classroom, request.title(), request.content(), items);
+    }
+
+    @Transactional
+    public PurchaseRequestDetailResponse createPurchaseRequestByAdmin(
+        Long actorId, CreatePurchaseRequestByAdminRequest request
+    ) {
+        log.debug(
+            "관리자 구입 요청 대리 생성 (actorId={}, requestedById={}, classroomId={})",
+            actorId,
+            request.requestedById(),
+            request.classroomId()
         );
 
-        log.debug("구입 요청 생성 완료 (id={})", saved.getId());
-        return toDetailResponse(saved);
+        Classroom classroom = classroomProxyService.getActiveById(request.classroomId());
+        User requester = userProxyService.getById(request.requestedById());
+
+        List<PurchaseRequestItem> items = request.items().stream()
+            .map(item -> new PurchaseRequestItem(
+                item.name(),
+                item.reason(),
+                item.quantity(),
+                item.paymentType()
+            ))
+            .toList();
+
+        return createPurchaseRequest(requester, classroom, request.title(), request.content(), items);
     }
 
     public List<PurchaseRequestSummaryResponse> getPurchaseRequests(Long requesterId, PurchaseRequestStatus status) {
@@ -322,6 +338,27 @@ public class PurchaseRequestService {
 
     private PurchaseRequestDetailResponse toDetailResponse(PurchaseRequest purchaseRequest) {
         return PurchaseRequestDetailResponse.from(purchaseRequest, vendorService.getVendors(null));
+    }
+
+    private PurchaseRequestDetailResponse createPurchaseRequest(
+        User requester,
+        Classroom classroom,
+        String title,
+        String content,
+        List<PurchaseRequestItem> items
+    ) {
+        PurchaseRequest saved = purchaseRequestRepository.save(
+            new PurchaseRequest(
+                classroom,
+                requester,
+                title,
+                content,
+                items
+            )
+        );
+
+        log.debug("구입 요청 생성 완료 (id={})", saved.getId());
+        return toDetailResponse(saved);
     }
 
     private void checkAccess(PurchaseRequest purchaseRequest, Long requesterId, boolean isAdmin) {

--- a/src/main/java/geumjeongyahak/domain/purchase_request/v1/controller/PurchaseRequestAdminController.java
+++ b/src/main/java/geumjeongyahak/domain/purchase_request/v1/controller/PurchaseRequestAdminController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 import geumjeongyahak.common.security.service.CustomUserDetails;
 import geumjeongyahak.domain.purchase_request.enums.PurchaseRequestStatus;
 import geumjeongyahak.domain.purchase_request.service.PurchaseRequestService;
+import geumjeongyahak.domain.purchase_request.v1.dto.request.CreatePurchaseRequestByAdminRequest;
 import geumjeongyahak.domain.purchase_request.v1.dto.request.ReviewPurchaseRequestRequest;
 import geumjeongyahak.domain.purchase_request.v1.dto.response.PurchaseRequestDetailResponse;
 import geumjeongyahak.domain.purchase_request.v1.dto.response.PurchaseRequestSummaryResponse;
@@ -32,6 +35,21 @@ import geumjeongyahak.domain.purchase_request.v1.dto.response.PurchaseRequestSum
 public class PurchaseRequestAdminController {
 
     private final PurchaseRequestService purchaseRequestService;
+
+    @Operation(
+        summary = "구입 요청 대리 생성",
+        description = "관리자 또는 purchase-request:manage:* 권한자가 requestedById 사용자를 실제 요청자로 지정해 구입 요청을 생성합니다."
+    )
+    @PreAuthorize("hasRole('ADMIN') or hasAuthority('purchase-request:manage:*')")
+    @PostMapping
+    public ResponseEntity<PurchaseRequestDetailResponse> createPurchaseRequest(
+        @Valid @RequestBody CreatePurchaseRequestByAdminRequest request,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        log.debug("POST /api/v1/admin/purchase-requests (requestedById={})", request.requestedById());
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(purchaseRequestService.createPurchaseRequestByAdmin(userDetails.getUserId(), request));
+    }
 
     @Operation(
         summary = "구입 요청 전체 목록 조회",

--- a/src/main/java/geumjeongyahak/domain/purchase_request/v1/controller/PurchaseRequestAdminController.java
+++ b/src/main/java/geumjeongyahak/domain/purchase_request/v1/controller/PurchaseRequestAdminController.java
@@ -24,6 +24,7 @@ import geumjeongyahak.domain.purchase_request.enums.PurchaseRequestStatus;
 import geumjeongyahak.domain.purchase_request.service.PurchaseRequestService;
 import geumjeongyahak.domain.purchase_request.v1.dto.request.CreatePurchaseRequestByAdminRequest;
 import geumjeongyahak.domain.purchase_request.v1.dto.request.CreatePurchaseRequestRequest;
+import geumjeongyahak.domain.purchase_request.v1.dto.request.ReportPurchaseRequest;
 import geumjeongyahak.domain.purchase_request.v1.dto.request.ReviewPurchaseRequestRequest;
 import geumjeongyahak.domain.purchase_request.v1.dto.request.UpdatePurchaseRequestByAdminRequest;
 import geumjeongyahak.domain.purchase_request.v1.dto.response.PurchaseRequestDetailResponse;
@@ -168,12 +169,30 @@ public class PurchaseRequestAdminController {
         );
     }
 
+    @Operation(
+        summary = "구매 완료 보고",
+        description = "관리자 또는 purchase-request:manage:* 권한자가 APPROVED 상태의 구입 요청에 구매 거래와 영수증을 등록합니다. "
+            + "상태가 PURCHASED 로 변경됩니다."
+    )
+    @PreAuthorize("hasRole('ADMIN') or hasAuthority('purchase-request:manage:*')")
+    @PostMapping("/{requestId}/report")
+    public ResponseEntity<PurchaseRequestDetailResponse> reportPurchase(
+        @PathVariable Long requestId,
+        @Valid @RequestBody ReportPurchaseRequest request,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        log.debug("POST /api/v1/admin/purchase-requests/{}/report", requestId);
+        return ResponseEntity.ok(
+            purchaseRequestService.reportPurchase(userDetails.getUserId(), requestId, request, true)
+        );
+    }
+
     @Operation(summary = "구매 완료 거래 수정")
     @PreAuthorize("hasRole('ADMIN') or hasAuthority('purchase-request:manage:*')")
     @PatchMapping("/{requestId}/item-receipts")
     public ResponseEntity<PurchaseRequestDetailResponse> updateItemReceipts(
         @PathVariable Long requestId,
-        @Valid @RequestBody geumjeongyahak.domain.purchase_request.v1.dto.request.ReportPurchaseRequest request,
+        @Valid @RequestBody ReportPurchaseRequest request,
         @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         log.debug("PATCH /api/v1/admin/purchase-requests/{}/item-receipts", requestId);

--- a/src/main/java/geumjeongyahak/domain/purchase_request/v1/controller/PurchaseRequestAdminController.java
+++ b/src/main/java/geumjeongyahak/domain/purchase_request/v1/controller/PurchaseRequestAdminController.java
@@ -23,7 +23,9 @@ import geumjeongyahak.common.security.service.CustomUserDetails;
 import geumjeongyahak.domain.purchase_request.enums.PurchaseRequestStatus;
 import geumjeongyahak.domain.purchase_request.service.PurchaseRequestService;
 import geumjeongyahak.domain.purchase_request.v1.dto.request.CreatePurchaseRequestByAdminRequest;
+import geumjeongyahak.domain.purchase_request.v1.dto.request.CreatePurchaseRequestRequest;
 import geumjeongyahak.domain.purchase_request.v1.dto.request.ReviewPurchaseRequestRequest;
+import geumjeongyahak.domain.purchase_request.v1.dto.request.UpdatePurchaseRequestByAdminRequest;
 import geumjeongyahak.domain.purchase_request.v1.dto.response.PurchaseRequestDetailResponse;
 import geumjeongyahak.domain.purchase_request.v1.dto.response.PurchaseRequestSummaryResponse;
 
@@ -74,6 +76,28 @@ public class PurchaseRequestAdminController {
         log.debug("GET /api/v1/admin/purchase-requests/{}", requestId);
         return ResponseEntity.ok(
             purchaseRequestService.getPurchaseRequest(userDetails.getUserId(), requestId, true)
+        );
+    }
+
+    @Operation(
+        summary = "구입 요청 수정",
+        description = "관리자 또는 purchase-request:manage:* 권한자가 PENDING 상태의 구입 요청 제목, 내용, 품목을 수정합니다."
+    )
+    @PreAuthorize("hasRole('ADMIN') or hasAuthority('purchase-request:manage:*')")
+    @PatchMapping("/{requestId}")
+    public ResponseEntity<PurchaseRequestDetailResponse> updatePurchaseRequest(
+        @PathVariable Long requestId,
+        @Valid @RequestBody UpdatePurchaseRequestByAdminRequest request,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        log.debug("PATCH /api/v1/admin/purchase-requests/{}", requestId);
+        return ResponseEntity.ok(
+            purchaseRequestService.updatePurchaseRequest(
+                userDetails.getUserId(),
+                requestId,
+                new CreatePurchaseRequestRequest(request.title(), request.content(), null, request.items()),
+                true
+            )
         );
     }
 

--- a/src/main/java/geumjeongyahak/domain/purchase_request/v1/dto/request/CreatePurchaseRequestByAdminRequest.java
+++ b/src/main/java/geumjeongyahak/domain/purchase_request/v1/dto/request/CreatePurchaseRequestByAdminRequest.java
@@ -1,0 +1,54 @@
+package geumjeongyahak.domain.purchase_request.v1.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+import geumjeongyahak.domain.purchase_request.enums.PurchasePaymentType;
+
+public record CreatePurchaseRequestByAdminRequest(
+
+    @NotNull
+    @Schema(description = "실제 구입 요청자 사용자 ID", example = "3")
+    Long requestedById,
+
+    @NotBlank
+    @Schema(description = "구입 요청 제목", example = "교재 구입")
+    String title,
+
+    @NotBlank
+    @Schema(description = "구입 요청 내용", example = "수업에 필요한 교재를 구입합니다.")
+    String content,
+
+    @NotNull
+    @Schema(description = "구입 요청 대상 분반 ID", example = "1")
+    Long classroomId,
+
+    @Valid
+    @NotEmpty
+    @Schema(description = "결제 항목 목록")
+    List<Item> items
+) {
+    public record Item(
+
+        @NotBlank
+        @Schema(description = "품명", example = "국어 교재")
+        String name,
+
+        @Schema(description = "구입 사유", example = "수업 교재 부족")
+        String reason,
+
+        @NotNull
+        @Min(1)
+        @Schema(description = "수량", example = "2")
+        Integer quantity,
+
+        @NotNull
+        @Schema(description = "결제 유형", example = "PREPAID")
+        PurchasePaymentType paymentType
+    ) {}
+}

--- a/src/main/java/geumjeongyahak/domain/purchase_request/v1/dto/request/UpdatePurchaseRequestByAdminRequest.java
+++ b/src/main/java/geumjeongyahak/domain/purchase_request/v1/dto/request/UpdatePurchaseRequestByAdminRequest.java
@@ -1,0 +1,24 @@
+package geumjeongyahak.domain.purchase_request.v1.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record UpdatePurchaseRequestByAdminRequest(
+
+    @NotBlank
+    @Schema(description = "구입 요청 제목", example = "교재 구입")
+    String title,
+
+    @NotBlank
+    @Schema(description = "구입 요청 내용", example = "수업에 필요한 교재를 구입합니다.")
+    String content,
+
+    @Valid
+    @NotEmpty
+    @Schema(description = "결제 항목 목록")
+    List<CreatePurchaseRequestRequest.Item> items
+) {
+}

--- a/src/main/java/geumjeongyahak/domain/purchase_request/v1/dto/response/PurchaseRequestSummaryResponse.java
+++ b/src/main/java/geumjeongyahak/domain/purchase_request/v1/dto/response/PurchaseRequestSummaryResponse.java
@@ -10,8 +10,14 @@ public record PurchaseRequestSummaryResponse(
     @Schema(description = "요청 ID", example = "1")
     Long id,
 
+    @Schema(description = "분반 ID", example = "1")
+    Long classroomId,
+
     @Schema(description = "분반 이름", example = "한글반")
     String classroomName,
+
+    @Schema(description = "요청자 ID", example = "3")
+    Long requestedById,
 
     @Schema(description = "요청자 이름", example = "홍길동")
     String requestedByName,
@@ -31,7 +37,9 @@ public record PurchaseRequestSummaryResponse(
     public static PurchaseRequestSummaryResponse from(PurchaseRequest r) {
         return new PurchaseRequestSummaryResponse(
             r.getId(),
+            r.getClassroom().getId(),
             r.getClassroom().getName(),
+            r.getRequestedBy().getId(),
             r.getRequestedBy().getName(),
             r.getTitle(),
             r.getTotalPrice(),

--- a/src/main/resources/sql/init_data.sql
+++ b/src/main/resources/sql/init_data.sql
@@ -61,7 +61,10 @@ INSERT INTO users (id, name, primary_email, role, department_id, classroom_id, r
 INSERT INTO users (id, name, primary_email, role, department_id, classroom_id, resident_registration_number_prefix, teacher_start_at, teacher_end_at) VALUES
     (9, '한취소', 'cancelled-applicant01@test.com', 'GUEST', NULL, NULL, NULL, NULL, NULL);
 
-ALTER SEQUENCE users_id_seq RESTART WITH 10;
+INSERT INTO users (id, name, primary_email, role, department_id, classroom_id, resident_registration_number_prefix, teacher_start_at, teacher_end_at) VALUES
+    (10, 'Apps Script Bot', 'geumjeongyahak-apps-script-bot@gmail.com', 'VOLUNTEER', NULL, NULL, NULL, NULL, NULL);
+
+ALTER SEQUENCE users_id_seq RESTART WITH 11;
 
 -- 3. User Credentials
 INSERT INTO user_credentials (id, user_id, provider, credential_email, password_hash, email_verified) VALUES
@@ -73,14 +76,16 @@ INSERT INTO user_credentials (id, user_id, provider, credential_email, password_
     (6, 6, 'LOCAL', 'approved-teacher01@test.com', '$2a$12$nsaiXXxEBMV9vNwh23WInekm2WisaINtbtLsP1JXlgHnt9eDqnaRu', TRUE),
     (7, 7, 'LOCAL', 'rejected-applicant01@test.com', '$2a$12$nsaiXXxEBMV9vNwh23WInekm2WisaINtbtLsP1JXlgHnt9eDqnaRu', TRUE),
     (8, 8, 'LOCAL', 'direct-assign-edge01@test.com', '$2a$12$nsaiXXxEBMV9vNwh23WInekm2WisaINtbtLsP1JXlgHnt9eDqnaRu', TRUE),
-    (9, 9, 'LOCAL', 'cancelled-applicant01@test.com', '$2a$12$nsaiXXxEBMV9vNwh23WInekm2WisaINtbtLsP1JXlgHnt9eDqnaRu', TRUE);
+    (9, 9, 'LOCAL', 'cancelled-applicant01@test.com', '$2a$12$nsaiXXxEBMV9vNwh23WInekm2WisaINtbtLsP1JXlgHnt9eDqnaRu', TRUE),
+    (10, 10, 'LOCAL', 'geumjeongyahak-apps-script-bot@gmail.com', '$2a$10$6w/cCD2l06.TF3GK7FuCv.uMBX7gqIvgMdwkuSe3D3F6WYbgctibW', TRUE);
 
-ALTER SEQUENCE user_credentials_id_seq RESTART WITH 10;
+ALTER SEQUENCE user_credentials_id_seq RESTART WITH 11;
 
 -- 4. User Permissions
 INSERT INTO user_permissions (user_id, permission_code) VALUES
     (2, 'lesson:write:*'),
-    (6, 'channel:write:6');
+    (6, 'channel:write:6'),
+    (10, 'daily-schedule:manage:*');
 
 -- 5. Department Permissions
 INSERT INTO department_permissions (department_id, role_type, permission_code) VALUES

--- a/src/main/resources/sql/init_data.sql
+++ b/src/main/resources/sql/init_data.sql
@@ -85,7 +85,11 @@ ALTER SEQUENCE user_credentials_id_seq RESTART WITH 11;
 INSERT INTO user_permissions (user_id, permission_code) VALUES
     (2, 'lesson:write:*'),
     (6, 'channel:write:6'),
-    (10, 'daily-schedule:manage:*');
+    (10, 'daily-schedule:manage:*'),
+    (10, 'user:read:*'),
+    (10, 'purchase-request:read:*'),
+    (10, 'purchase-request:manage:*'),
+    (10, 'vendor:read:*');
 
 -- 5. Department Permissions
 INSERT INTO department_permissions (department_id, role_type, permission_code) VALUES

--- a/src/test/java/geumjeongyahak/e2e/auth/AuthLoginTest.java
+++ b/src/test/java/geumjeongyahak/e2e/auth/AuthLoginTest.java
@@ -92,7 +92,20 @@ class AuthLoginTest extends AuthBaseTest {
         .then()
             .statusCode(200)
             .body("email", equalTo(APPS_SCRIPT_BOT_EMAIL))
-            .body("permissions.find { it.code == 'daily-schedule:manage:*' }.source", equalTo("MANUAL"));
+            .body("permissions.find { it.code == 'daily-schedule:manage:*' }.source", equalTo("MANUAL"))
+            .body("permissions.find { it.code == 'user:read:*' }.source", equalTo("MANUAL"))
+            .body("permissions.find { it.code == 'purchase-request:read:*' }.source", equalTo("MANUAL"))
+            .body("permissions.find { it.code == 'purchase-request:manage:*' }.source", equalTo("MANUAL"))
+            .body("permissions.find { it.code == 'vendor:read:*' }.source", equalTo("MANUAL"));
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(response.accessToken()))
+            .queryParam("size", 20)
+        .when()
+            .get("/api/v1/users")
+        .then()
+            .statusCode(200)
+            .body("content.find { it.email == 'teacher02@test.com' }.name", equalTo("김철수"));
 
         RestAssured.basePath = originalBasePath;
     }

--- a/src/test/java/geumjeongyahak/e2e/auth/AuthLoginTest.java
+++ b/src/test/java/geumjeongyahak/e2e/auth/AuthLoginTest.java
@@ -16,6 +16,9 @@ import static org.hamcrest.Matchers.*;
 @DisplayName("E2E: 로그인 테스트")
 class AuthLoginTest extends AuthBaseTest {
 
+    private static final String APPS_SCRIPT_BOT_EMAIL = "geumjeongyahak-apps-script-bot@gmail.com";
+    private static final String APPS_SCRIPT_BOT_PASSWORD = "apps-script-bot123!";
+
     @Autowired
     private UserRepository userRepository;
 
@@ -53,6 +56,43 @@ class AuthLoginTest extends AuthBaseTest {
             .get("/api/v1/users/me")
         .then()
             .statusCode(200);
+
+        RestAssured.basePath = originalBasePath;
+    }
+
+    @Test
+    @DisplayName("Apps Script Bot 계정으로 로그인하면 수업일지 관리 권한을 가진다")
+    void login_AppsScriptBot_Success() {
+        LocalLoginRequest req = new LocalLoginRequest(
+            APPS_SCRIPT_BOT_EMAIL,
+            APPS_SCRIPT_BOT_PASSWORD
+        );
+
+        var response = given()
+            .contentType(ContentType.JSON)
+            .body(req)
+        .when()
+            .post("/login")
+        .then()
+            .statusCode(200)
+            .body("accessToken", notNullValue())
+            .body("refreshToken", notNullValue())
+            .body("tokenType", equalTo("Bearer"))
+            .log().all()
+            .extract()
+            .as(TokenResponse.class);
+
+        String originalBasePath = RestAssured.basePath;
+        RestAssured.basePath = "";
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(response.accessToken()))
+        .when()
+            .get("/api/v1/users/me")
+        .then()
+            .statusCode(200)
+            .body("email", equalTo(APPS_SCRIPT_BOT_EMAIL))
+            .body("permissions.find { it.code == 'daily-schedule:manage:*' }.source", equalTo("MANUAL"));
 
         RestAssured.basePath = originalBasePath;
     }

--- a/src/test/java/geumjeongyahak/e2e/daily_schedule/DailyScheduleReadTest.java
+++ b/src/test/java/geumjeongyahak/e2e/daily_schedule/DailyScheduleReadTest.java
@@ -5,10 +5,12 @@ import static java.util.Map.entry;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
+import geumjeongyahak.domain.auth.v1.dto.request.LocalLoginRequest;
 import geumjeongyahak.e2e.BaseE2ETest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,6 +24,8 @@ public class DailyScheduleReadTest extends BaseE2ETest {
 
     private static final long CLASSROOM_ID = 1L;
     private static final long TEACHER_ID = 2L;
+    private static final String APPS_SCRIPT_BOT_EMAIL = "geumjeongyahak-apps-script-bot@gmail.com";
+    private static final String APPS_SCRIPT_BOT_PASSWORD = "apps-script-bot123!";
     private static final LocalDate BASE_DATE = LocalDate.of(2051, 1, 1);
     private static final AtomicLong SEQUENCE = new AtomicLong();
 
@@ -97,13 +101,87 @@ public class DailyScheduleReadTest extends BaseE2ETest {
             .statusCode(403);
     }
 
+    @Test
+    @DisplayName("Apps Script Bot은 날짜와 분반 ID로 DailySchedule 상세를 조회할 수 있다")
+    void getDailyScheduleByClassroomAndDate_asAppsScriptBot_success() {
+        LocalDate lessonDate = nextLessonDate();
+        String subjectName = "Bot상세조회-" + SEQUENCE.get();
+        createDailyScheduleSource(subjectName, lessonDate);
+        String botAccessToken = loginAppsScriptBot();
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(botAccessToken))
+            .queryParam("classroomId", CLASSROOM_ID)
+            .queryParam("lessonDate", lessonDate.toString())
+            .when()
+            .get("/detail")
+            .then()
+            .statusCode(200)
+            .body("dailyScheduleId", notNullValue())
+            .body("classroomId", is((int) CLASSROOM_ID))
+            .body("teacherId", is((int) TEACHER_ID))
+            .body("lessons[0].lessonId", notNullValue())
+            .body("lessons[0].subjectName", is(subjectName));
+    }
+
+    @Test
+    @DisplayName("Apps Script Bot은 수업 일지를 최초 작성하고 수정할 수 있다")
+    void createAndUpdateJournal_asAppsScriptBot_success() {
+        LocalDate lessonDate = nextLessonDate();
+        Long lessonId = createDailyScheduleSource("Bot일지작성-" + SEQUENCE.get(), lessonDate);
+        String botAccessToken = loginAppsScriptBot();
+
+        Long dailyScheduleId = given()
+            .header(AUTH_HEADER, getAuthHeader(botAccessToken))
+            .contentType(ContentType.JSON)
+            .body(Map.of(
+                "lessonDate", lessonDate.toString(),
+                "classroomId", CLASSROOM_ID,
+                "personalInfoConsent", true,
+                "residentRegistrationNumberPrefix", "900101",
+                "lessonJournals", List.of(Map.of(
+                    "lessonId", lessonId,
+                    "note", "Apps Script Bot이 최초 작성한 수업 내용입니다."
+                ))
+            ))
+            .post("/journal")
+            .then()
+            .statusCode(200)
+            .body("dailyScheduleId", notNullValue())
+            .body("residentRegistrationNumberPrefix", is("900101"))
+            .body("personalInfoConsent", is(true))
+            .body("lessons[0].lessonId", is(lessonId.intValue()))
+            .body("lessons[0].note", is("Apps Script Bot이 최초 작성한 수업 내용입니다."))
+            .extract()
+            .jsonPath()
+            .getLong("dailyScheduleId");
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(botAccessToken))
+            .contentType(ContentType.JSON)
+            .body(Map.of(
+                "personalInfoConsent", true,
+                "residentRegistrationNumberPrefix", "900101",
+                "lessonJournals", List.of(Map.of(
+                    "lessonId", lessonId,
+                    "note", "Apps Script Bot이 수정한 수업 내용입니다."
+                ))
+            ))
+            .patch("/{dailyScheduleId}/journal", dailyScheduleId)
+            .then()
+            .statusCode(200)
+            .body("dailyScheduleId", is(dailyScheduleId.intValue()))
+            .body("lessons[0].lessonId", is(lessonId.intValue()))
+            .body("lessons[0].note", is("Apps Script Bot이 수정한 수업 내용입니다."));
+    }
+
     private LocalDate nextLessonDate() {
         return BASE_DATE.plusDays(SEQUENCE.incrementAndGet());
     }
 
-    private void createDailyScheduleSource(String name, LocalDate lessonDate) {
+    private Long createDailyScheduleSource(String name, LocalDate lessonDate) {
         Long subjectId = createSubject(name, lessonDate);
-        createLesson(subjectId, lessonDate);
+        return createLesson(subjectId, lessonDate);
     }
 
     private Long createSubject(String name, LocalDate lessonDate) {
@@ -132,7 +210,7 @@ public class DailyScheduleReadTest extends BaseE2ETest {
             .getLong("id");
     }
 
-    private void createLesson(Long subjectId, LocalDate lessonDate) {
+    private Long createLesson(Long subjectId, LocalDate lessonDate) {
         Map<String, Object> request = Map.ofEntries(
             entry("subjectId", subjectId),
             entry("teacherId", TEACHER_ID),
@@ -142,13 +220,29 @@ public class DailyScheduleReadTest extends BaseE2ETest {
             entry("period", 1)
         );
 
-        given()
+        return given()
             .basePath("/api/v1/lessons")
             .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
             .contentType(ContentType.JSON)
             .body(request)
             .post()
             .then()
-            .statusCode(201);
+            .statusCode(201)
+            .extract()
+            .jsonPath()
+            .getLong("lessonId");
+    }
+
+    private String loginAppsScriptBot() {
+        return given()
+            .basePath("/api/v1/auth")
+            .contentType(ContentType.JSON)
+            .body(new LocalLoginRequest(APPS_SCRIPT_BOT_EMAIL, APPS_SCRIPT_BOT_PASSWORD))
+            .post("/login")
+            .then()
+            .statusCode(200)
+            .extract()
+            .jsonPath()
+            .getString("accessToken");
     }
 }

--- a/src/test/java/geumjeongyahak/e2e/request/purchase/PurchaseRequestCreateTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/purchase/PurchaseRequestCreateTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import geumjeongyahak.domain.auth.enums.RoleType;
+import geumjeongyahak.domain.auth.v1.dto.request.LocalLoginRequest;
 import geumjeongyahak.domain.purchase_request.repository.PurchaseRequestRepository;
 import geumjeongyahak.e2e.request.RequestBaseTest;
 
@@ -27,6 +28,9 @@ import geumjeongyahak.e2e.request.RequestBaseTest;
 @Tag("purchase-request")
 @DisplayName("E2E: 기자재 구입 요청 생성 테스트")
 class PurchaseRequestCreateTest extends RequestBaseTest {
+
+    private static final String APPS_SCRIPT_BOT_EMAIL = "geumjeongyahak-apps-script-bot@gmail.com";
+    private static final String APPS_SCRIPT_BOT_PASSWORD = "apps-script-bot123!";
 
     @Autowired
     private PurchaseRequestRepository purchaseRequestRepository;
@@ -176,6 +180,37 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
     }
 
     @Test
+    @DisplayName("Apps Script Bot이 실제 요청자를 지정해 구입 요청 대리 생성 → 201")
+    void createRequestByAdmin_withAppsScriptBot_returns201() {
+        String botAccessToken = loginAppsScriptBot();
+
+        createdRequestIds.add(given()
+            .basePath("/api/v1/admin/purchase-requests")
+            .header(AUTH_HEADER, getAuthHeader(botAccessToken))
+            .contentType(ContentType.JSON)
+            .body(Map.ofEntries(
+                entry("requestedById", TEACHER2_ID),
+                entry("title", "Bot 대리 구입 요청"),
+                entry("content", "Apps Script Bot이 시트 값을 동기화합니다."),
+                entry("classroomId", CLASSROOM_ID),
+                entry("items", List.of(Map.ofEntries(
+                    entry("name", "복사용지"),
+                    entry("reason", "수업 자료 인쇄"),
+                    entry("quantity", 2),
+                    entry("paymentType", "ACTUAL")
+                )))
+            ))
+            .post()
+            .then()
+            .statusCode(201)
+            .body("requestedById", equalTo((int) TEACHER2_ID))
+            .body("requestedByName", equalTo("김철수"))
+            .extract()
+            .jsonPath()
+            .getLong("id"));
+    }
+
+    @Test
     @DisplayName("권한 없는 사용자의 구입 요청 대리 생성 → 403")
     void createRequestByAdmin_withoutPermission_returns403() {
         given()
@@ -221,6 +256,19 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
             .post()
             .then()
             .statusCode(404);
+    }
+
+    private String loginAppsScriptBot() {
+        return given()
+            .basePath("/api/v1/auth")
+            .contentType(ContentType.JSON)
+            .body(new LocalLoginRequest(APPS_SCRIPT_BOT_EMAIL, APPS_SCRIPT_BOT_PASSWORD))
+            .post("/login")
+            .then()
+            .statusCode(200)
+            .extract()
+            .jsonPath()
+            .getString("accessToken");
     }
 
     // ── 인증 오류 ─────────────────────────────────────────

--- a/src/test/java/geumjeongyahak/e2e/request/purchase/PurchaseRequestCreateTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/purchase/PurchaseRequestCreateTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 
 import io.restassured.http.ContentType;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import geumjeongyahak.domain.auth.enums.RoleType;
 import geumjeongyahak.domain.purchase_request.repository.PurchaseRequestRepository;
 import geumjeongyahak.e2e.request.RequestBaseTest;
 
@@ -30,9 +32,12 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
     private PurchaseRequestRepository purchaseRequestRepository;
 
     private Long createdRequestId;
+    private final List<Long> createdRequestIds = new ArrayList<>();
 
     @AfterEach
     void cleanup() {
+        createdRequestIds.forEach(purchaseRequestRepository::deleteById);
+        createdRequestIds.clear();
         if (createdRequestId != null) {
             purchaseRequestRepository.deleteById(createdRequestId);
             createdRequestId = null;
@@ -101,6 +106,121 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
             .extract()
             .jsonPath()
             .getLong("id");
+    }
+
+    @Test
+    @DisplayName("관리자가 실제 요청자를 지정해 구입 요청 대리 생성 → 201")
+    void createRequestByAdmin_withRequestedById_returns201() {
+        createdRequestIds.add(given()
+            .basePath("/api/v1/admin/purchase-requests")
+            .header(AUTH_HEADER, getAuthHeader(adminToken))
+            .contentType(ContentType.JSON)
+            .body(Map.ofEntries(
+                entry("requestedById", TEACHER2_ID),
+                entry("title", "시트 구입 요청"),
+                entry("content", "Apps Script에서 등록한 구입 요청입니다."),
+                entry("classroomId", CLASSROOM_ID),
+                entry("items", List.of(Map.ofEntries(
+                    entry("name", "프린터 토너"),
+                    entry("reason", "수업 자료 출력"),
+                    entry("quantity", 1),
+                    entry("paymentType", "ACTUAL")
+                )))
+            ))
+            .post()
+            .then()
+            .statusCode(201)
+            .body("id", notNullValue())
+            .body("requestedById", equalTo((int) TEACHER2_ID))
+            .body("requestedByName", equalTo("김철수"))
+            .body("title", equalTo("시트 구입 요청"))
+            .body("status", equalTo("PENDING"))
+            .extract()
+            .jsonPath()
+            .getLong("id"));
+    }
+
+    @Test
+    @DisplayName("purchase-request:manage:* 권한자가 구입 요청 대리 생성 → 201")
+    void createRequestByAdmin_withManagePermission_returns201() {
+        String manageToken = createAccessTokenWithPermission(
+            "purchase-delegate",
+            RoleType.VOLUNTEER,
+            "purchase-request:manage:*"
+        );
+
+        createdRequestIds.add(given()
+            .basePath("/api/v1/admin/purchase-requests")
+            .header(AUTH_HEADER, getAuthHeader(manageToken))
+            .contentType(ContentType.JSON)
+            .body(Map.ofEntries(
+                entry("requestedById", TEACHER_ID),
+                entry("title", "권한자 대리 요청"),
+                entry("content", "구입 요청 관리 권한자가 등록합니다."),
+                entry("classroomId", CLASSROOM_ID),
+                entry("items", List.of(Map.ofEntries(
+                    entry("name", "마커"),
+                    entry("reason", "수업 판서"),
+                    entry("quantity", 3),
+                    entry("paymentType", "PREPAID")
+                )))
+            ))
+            .post()
+            .then()
+            .statusCode(201)
+            .body("requestedById", equalTo((int) TEACHER_ID))
+            .body("requestedByName", equalTo("홍길동"))
+            .extract()
+            .jsonPath()
+            .getLong("id"));
+    }
+
+    @Test
+    @DisplayName("권한 없는 사용자의 구입 요청 대리 생성 → 403")
+    void createRequestByAdmin_withoutPermission_returns403() {
+        given()
+            .basePath("/api/v1/admin/purchase-requests")
+            .header(AUTH_HEADER, getAuthHeader(managerToken))
+            .contentType(ContentType.JSON)
+            .body(Map.ofEntries(
+                entry("requestedById", TEACHER2_ID),
+                entry("title", "권한 없는 요청"),
+                entry("content", "권한 없는 사용자는 대리 생성할 수 없습니다."),
+                entry("classroomId", CLASSROOM_ID),
+                entry("items", List.of(Map.ofEntries(
+                    entry("name", "교재"),
+                    entry("reason", "수업 준비"),
+                    entry("quantity", 1),
+                    entry("paymentType", "ACTUAL")
+                )))
+            ))
+            .post()
+            .then()
+            .statusCode(403);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 요청자 ID로 구입 요청 대리 생성 → 404")
+    void createRequestByAdmin_nonExistentRequester_returns404() {
+        given()
+            .basePath("/api/v1/admin/purchase-requests")
+            .header(AUTH_HEADER, getAuthHeader(adminToken))
+            .contentType(ContentType.JSON)
+            .body(Map.ofEntries(
+                entry("requestedById", 99999L),
+                entry("title", "없는 요청자"),
+                entry("content", "존재하지 않는 사용자로 대리 생성할 수 없습니다."),
+                entry("classroomId", CLASSROOM_ID),
+                entry("items", List.of(Map.ofEntries(
+                    entry("name", "교재"),
+                    entry("reason", "수업 준비"),
+                    entry("quantity", 1),
+                    entry("paymentType", "ACTUAL")
+                )))
+            ))
+            .post()
+            .then()
+            .statusCode(404);
     }
 
     // ── 인증 오류 ─────────────────────────────────────────

--- a/src/test/java/geumjeongyahak/e2e/request/purchase/PurchaseRequestStatusTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/purchase/PurchaseRequestStatusTest.java
@@ -9,11 +9,14 @@ import static org.hamcrest.Matchers.notNullValue;
 import io.restassured.http.ContentType;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import geumjeongyahak.domain.auth.v1.dto.request.LocalLoginRequest;
+import geumjeongyahak.domain.file.repository.FileRepository;
 import geumjeongyahak.domain.purchase_request.repository.PurchaseRequestRepository;
 import geumjeongyahak.domain.vendor.repository.VendorBalanceHistoryRepository;
 import geumjeongyahak.domain.vendor.repository.VendorRepository;
@@ -27,8 +30,14 @@ import geumjeongyahak.e2e.request.RequestBaseTest;
 @DisplayName("E2E: 기자재 구입 요청 승인·반려·조회 테스트")
 class PurchaseRequestStatusTest extends RequestBaseTest {
 
+    private static final String APPS_SCRIPT_BOT_EMAIL = "geumjeongyahak-apps-script-bot@gmail.com";
+    private static final String APPS_SCRIPT_BOT_PASSWORD = "apps-script-bot123!";
+
     @Autowired
     private PurchaseRequestRepository purchaseRequestRepository;
+
+    @Autowired
+    private FileRepository fileRepository;
 
     @Autowired
     private VendorRepository vendorRepository;
@@ -38,6 +47,7 @@ class PurchaseRequestStatusTest extends RequestBaseTest {
 
     private Long currentRequestId;
     private Long createdVendorId;
+    private UUID registeredDriveFileId;
 
     @AfterEach
     void cleanup() {
@@ -49,6 +59,10 @@ class PurchaseRequestStatusTest extends RequestBaseTest {
                 purchaseRequestRepository.deleteById(currentRequestId);
             }
             currentRequestId = null;
+        }
+        if (registeredDriveFileId != null && fileRepository.existsById(registeredDriveFileId)) {
+            fileRepository.deleteById(registeredDriveFileId);
+            registeredDriveFileId = null;
         }
         if (createdVendorId != null) {
             if (vendorRepository.existsById(createdVendorId)) {
@@ -345,6 +359,74 @@ class PurchaseRequestStatusTest extends RequestBaseTest {
         currentRequestId = null;
     }
 
+    // ── 관리자 수정 (update) ─────────────────────────────
+
+    @Test
+    @DisplayName("Apps Script Bot이 PENDING 구입 요청 수정 → 200, 기본 정보와 품목 교체")
+    void update_asAppsScriptBotAndPending_returns200() {
+        currentRequestId = setupPendingRequest();
+        String botAccessToken = loginAppsScriptBot();
+
+        given()
+            .basePath("/api/v1/admin/purchase-requests")
+            .header(AUTH_HEADER, getAuthHeader(botAccessToken))
+            .contentType(ContentType.JSON)
+            .body(Map.of(
+                "title", "시트 수정 구입 요청",
+                "content", "Apps Script에서 수정한 내용입니다.",
+                "items", List.of(Map.of(
+                    "name", "수정된 품목",
+                    "reason", "시트 수정 반영",
+                    "quantity", 3,
+                    "paymentType", "PREPAID"
+                ))
+            ))
+            .patch("/{requestId}", currentRequestId)
+            .then()
+            .statusCode(200)
+            .body("title", equalTo("시트 수정 구입 요청"))
+            .body("content", equalTo("Apps Script에서 수정한 내용입니다."))
+            .body("status", equalTo("PENDING"))
+            .body("items", hasSize(1))
+            .body("items[0].name", equalTo("수정된 품목"))
+            .body("items[0].quantity", equalTo(3))
+            .body("items[0].paymentType", equalTo("PREPAID"));
+    }
+
+    @Test
+    @DisplayName("APPROVED 구입 요청 수정 → 409")
+    void update_approvedRequest_returns409() {
+        currentRequestId = setupPendingRequest();
+        String botAccessToken = loginAppsScriptBot();
+
+        given()
+            .basePath("/api/v1/admin/purchase-requests")
+            .header(AUTH_HEADER, getAuthHeader(adminToken))
+            .contentType(ContentType.JSON)
+            .body(Map.of("note", "수정 불가 상태 전환"))
+            .patch("/{requestId}/approve", currentRequestId)
+            .then()
+            .statusCode(200);
+
+        given()
+            .basePath("/api/v1/admin/purchase-requests")
+            .header(AUTH_HEADER, getAuthHeader(botAccessToken))
+            .contentType(ContentType.JSON)
+            .body(Map.of(
+                "title", "승인 후 수정",
+                "content", "승인 후에는 수정할 수 없습니다.",
+                "items", List.of(Map.of(
+                    "name", "수정 시도 품목",
+                    "reason", "상태 검증",
+                    "quantity", 1,
+                    "paymentType", "ACTUAL"
+                ))
+            ))
+            .patch("/{requestId}", currentRequestId)
+            .then()
+            .statusCode(409);
+    }
+
     // ── 구매 보고 (report) ────────────────────────────────
 
     @Test
@@ -376,6 +458,63 @@ class PurchaseRequestStatusTest extends RequestBaseTest {
             .body("transactions", hasSize(1))
             .body("transactions[0].itemNames", hasSize(2))
             .body("transactions[0].receiptFileId", equalTo(receiptFileId));
+    }
+
+    @Test
+    @DisplayName("Apps Script Bot이 Drive 영수증으로 구매 완료 보고 → 200, PURCHASED")
+    void reportByAdmin_withAppsScriptBotAndDriveReceipt_returns200() {
+        createdVendorId = createVendorAndCharge(100000L);
+        currentRequestId = setupPendingRequest();
+        String botAccessToken = loginAppsScriptBot();
+
+        given()
+            .basePath("/api/v1/admin/purchase-requests")
+            .header(AUTH_HEADER, getAuthHeader(adminToken))
+            .contentType(ContentType.JSON)
+            .body(Map.of("note", "Bot 구매 보고 테스트 승인"))
+            .patch("/{requestId}/approve", currentRequestId)
+            .then()
+            .statusCode(200);
+
+        String receiptFileId = registerDriveReceipt(botAccessToken);
+
+        given()
+            .basePath("/api/v1/admin/purchase-requests")
+            .header(AUTH_HEADER, getAuthHeader(botAccessToken))
+            .contentType(ContentType.JSON)
+            .body(reportBody(createdVendorId, 20000L, receiptFileId))
+            .post("/{requestId}/report", currentRequestId)
+            .then()
+            .statusCode(200)
+            .body("status", equalTo("PURCHASED"))
+            .body("transactions", hasSize(1))
+            .body("transactions[0].receiptFileId", equalTo(receiptFileId))
+            .body("transactions[0].receiptFileUrl", equalTo("https://drive.google.com/file/d/apps-script-receipt/view?usp=sharing"));
+    }
+
+    @Test
+    @DisplayName("권한 없는 사용자의 관리자 구매 완료 보고 → 403")
+    void reportByAdmin_withoutManagePermission_returns403() {
+        createdVendorId = createVendorAndCharge(100000L);
+        currentRequestId = setupPendingRequest();
+
+        given()
+            .basePath("/api/v1/admin/purchase-requests")
+            .header(AUTH_HEADER, getAuthHeader(adminToken))
+            .contentType(ContentType.JSON)
+            .body(Map.of("note", "권한 검증용 승인"))
+            .patch("/{requestId}/approve", currentRequestId)
+            .then()
+            .statusCode(200);
+
+        given()
+            .basePath("/api/v1/admin/purchase-requests")
+            .header(AUTH_HEADER, getAuthHeader(managerToken))
+            .contentType(ContentType.JSON)
+            .body(reportBody(createdVendorId, 20000L, null))
+            .post("/{requestId}/report", currentRequestId)
+            .then()
+            .statusCode(403);
     }
 
     // ── 재확인 요청 (reconfirmation) ───────────────────────
@@ -658,6 +797,41 @@ class PurchaseRequestStatusTest extends RequestBaseTest {
             transaction.put("receiptFileId", receiptFileId);
         }
         return Map.of("transactions", List.of(transaction));
+    }
+
+    private String loginAppsScriptBot() {
+        return given()
+            .basePath("/api/v1/auth")
+            .contentType(ContentType.JSON)
+            .body(new LocalLoginRequest(APPS_SCRIPT_BOT_EMAIL, APPS_SCRIPT_BOT_PASSWORD))
+            .post("/login")
+            .then()
+            .statusCode(200)
+            .extract()
+            .jsonPath()
+            .getString("accessToken");
+    }
+
+    private String registerDriveReceipt(String accessToken) {
+        String fileId = given()
+            .basePath("/api/v1/files")
+            .header(AUTH_HEADER, getAuthHeader(accessToken))
+            .contentType(ContentType.JSON)
+            .body(Map.of(
+                "driveUrl", "https://drive.google.com/file/d/apps-script-receipt/view?usp=sharing",
+                "originalName", "apps-script-receipt.png",
+                "mimeType", "image/png",
+                "fileSize", 1024L
+            ))
+            .post("/drive")
+            .then()
+            .statusCode(201)
+            .body("isGoogleDrive", equalTo(true))
+            .body("url", equalTo("https://drive.google.com/file/d/apps-script-receipt/view?usp=sharing"))
+            .extract()
+            .path("fileId");
+        registeredDriveFileId = UUID.fromString(fileId);
+        return fileId;
     }
 
     private String uploadPurchaseReceipt() {

--- a/src/test/java/geumjeongyahak/e2e/request/purchase/PurchaseRequestStatusTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/purchase/PurchaseRequestStatusTest.java
@@ -663,6 +663,15 @@ class PurchaseRequestStatusTest extends RequestBaseTest {
                 .extract().jsonPath().getList("id", Long.class);
             assertThat(adminIds).contains(request1Id, request2Id);
 
+            given()
+                .basePath("/api/v1/admin/purchase-requests")
+                .header(AUTH_HEADER, getAuthHeader(adminToken))
+                .get()
+                .then()
+                .statusCode(200)
+                .body("find { it.id == " + request1Id + " }.classroomId", equalTo((int) CLASSROOM_ID))
+                .body("find { it.id == " + request1Id + " }.requestedById", equalTo((int) TEACHER_ID));
+
             List<Long> v1Ids = given()
                 .basePath("/api/v1/purchase-requests")
                 .header(AUTH_HEADER, getAuthHeader(volunteerToken))

--- a/src/test/resources/sql/init_data.sql
+++ b/src/test/resources/sql/init_data.sql
@@ -42,7 +42,11 @@ ALTER TABLE user_credentials ALTER COLUMN id RESTART WITH 6;
 -- 4. User Permissions
 INSERT INTO user_permissions (user_id, permission_code) VALUES
     (2, 'channel:write:1'),
-    (5, 'daily-schedule:manage:*');
+    (5, 'daily-schedule:manage:*'),
+    (5, 'user:read:*'),
+    (5, 'purchase-request:read:*'),
+    (5, 'purchase-request:manage:*'),
+    (5, 'vendor:read:*');
 
 -- 5. Department Permissions
 INSERT INTO department_permissions (department_id, role_type, permission_code) VALUES

--- a/src/test/resources/sql/init_data.sql
+++ b/src/test/resources/sql/init_data.sql
@@ -25,19 +25,24 @@ INSERT INTO users (id, name, primary_email, role, department_id, teacher_start_a
 INSERT INTO users (id, name, primary_email, role, department_id, teacher_start_at, teacher_end_at) VALUES
     (4, '이영희', 'guest01@test.com', 'GUEST', NULL, NULL, NULL);
 
-ALTER TABLE users ALTER COLUMN id RESTART WITH 5;
+INSERT INTO users (id, name, primary_email, role, department_id, teacher_start_at, teacher_end_at) VALUES
+    (5, 'Apps Script Bot', 'geumjeongyahak-apps-script-bot@gmail.com', 'VOLUNTEER', NULL, NULL, NULL);
+
+ALTER TABLE users ALTER COLUMN id RESTART WITH 6;
 
 -- 3. User Credentials
 INSERT INTO user_credentials (id, user_id, provider, credential_email, password_hash, email_verified) VALUES
     (1, 1, 'LOCAL', 'admin@test.com', '$2a$10$A0Av/dPBUz5uoDmp0Z/2S.dsMzOWFL5gLK7CrXmQp6Rw2vqWulapi', TRUE),
     (2, 2, 'LOCAL', 'teacher01@test.com', '$2a$12$nsaiXXxEBMV9vNwh23WInekm2WisaINtbtLsP1JXlgHnt9eDqnaRu', TRUE),
     (3, 3, 'LOCAL', 'teacher02@test.com', '$2a$12$jNEpPdWPB8WX6kOR/t9cru3Lz7WwZRw3KHfgoRJBg0ddWUFnymr/O', TRUE),
-    (4, 4, 'LOCAL', 'guest01@test.com', '$2a$12$nsaiXXxEBMV9vNwh23WInekm2WisaINtbtLsP1JXlgHnt9eDqnaRu', TRUE);
-ALTER TABLE user_credentials ALTER COLUMN id RESTART WITH 5;
+    (4, 4, 'LOCAL', 'guest01@test.com', '$2a$12$nsaiXXxEBMV9vNwh23WInekm2WisaINtbtLsP1JXlgHnt9eDqnaRu', TRUE),
+    (5, 5, 'LOCAL', 'geumjeongyahak-apps-script-bot@gmail.com', '$2a$10$6w/cCD2l06.TF3GK7FuCv.uMBX7gqIvgMdwkuSe3D3F6WYbgctibW', TRUE);
+ALTER TABLE user_credentials ALTER COLUMN id RESTART WITH 6;
 
 -- 4. User Permissions
 INSERT INTO user_permissions (user_id, permission_code) VALUES
-    (2, 'channel:write:1');
+    (2, 'channel:write:1'),
+    (5, 'daily-schedule:manage:*');
 
 -- 5. Department Permissions
 INSERT INTO department_permissions (department_id, role_type, permission_code) VALUES


### PR DESCRIPTION
## 개요

Apps Script에서 구글 시트의 결재내역/수업일지를 백엔드 API와 연동할 수 있도록 Bot 계정, 권한, 구매 요청 API, 응답 필드, E2E 테스트를 보강했습니다.

## 변경 유형

- [x] 새 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [x] 테스트 (test)
- [ ] 기타 (chore)

## 변경 내용

- Apps Script Bot 초기 계정 및 권한 추가
- 관리자용 구입신청 대리 생성 API 추가
- 관리자용 구입신청 수정 API 추가
- 관리자용 구매완료 보고 API 추가
- 구매 요청 목록 응답에 `classroomId`, `requestedById` 추가
- 결재내역 Apps Script Bot 연동 E2E 테스트 추가
- 수업일지 Apps Script Bot 조회/작성/수정 E2E 테스트 추가

## 관련 이슈

Closes #156

## 스크린샷 (선택)



## 체크리스트

- [x] 코드 컨벤션을 준수했습니다
- [x] 테스트 코드를 작성/수정했습니다
- [ ] 모든 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)

## 리뷰어에게

Apps Script 연동 범위는 결재내역 생성/수정/구매완료 보고와 수업일지 조회/작성/수정까지입니다.

승인/반려/최종 결재 확인은 이번 Apps Script 연동 범위에서 제외하고 기존 사이트 관리자 화면에서 처리하는 전제로 작업했습니다.

관련 테스트는 통과했습니다.

```bash
./gradlew.bat test --tests geumjeongyahak.e2e.request.purchase.PurchaseRequestStatusTest
./gradlew.bat test --tests geumjeongyahak.e2e.daily_schedule.DailyScheduleReadTest