### PR TITLE
[BUG] 교환형 제안에서 요청 수업 시간대 충돌 검증 누락

### DIFF
--- a/src/main/java/geumjeongyahak/domain/request/service/LessonExchangeProposalService.java
+++ b/src/main/java/geumjeongyahak/domain/request/service/LessonExchangeProposalService.java
@@ -60,6 +60,7 @@ public class LessonExchangeProposalService {
 
         String classroomName = null;
         DailySchedule proposalDailySchedule = null;
+        List<Lesson> requestLessons = getRequestLessons(exchangeRequest);
 
         // 교환형 제안과 대체형 제안을 구분
         if (proposalType == LessonExchangeProposalType.EXCHANGE) {
@@ -69,15 +70,9 @@ public class LessonExchangeProposalService {
                 proposalDailySchedule
             );
             classroomName = proposalDailySchedule.getClassroom().getName();
-        } else {
-            List<Lesson> requestLessons = getRequestLessons(exchangeRequest);
-
-            validateNoScheduleConflict(
-                proposerId,
-                exchangeRequest.getLessonDate(),
-                requestLessons
-            );
         }
+
+        validateNoScheduleConflict(proposerId, exchangeRequest.getLessonDate(), requestLessons);
 
         User proposer = userProxyService.getById(proposerId);
 
@@ -136,6 +131,7 @@ public class LessonExchangeProposalService {
 
         String classroomName = null;
         DailySchedule proposalDailySchedule = null;
+        List<Lesson> requestLessons = getRequestLessons(exchangeRequest);
 
         if (proposalType == LessonExchangeProposalType.EXCHANGE) {
             proposalDailySchedule = getProposalDailySchedule(proposerId, request.lessonDate());
@@ -144,10 +140,9 @@ public class LessonExchangeProposalService {
                 proposalDailySchedule
             );
             classroomName = proposalDailySchedule.getClassroom().getName();
-        } else {
-            List<Lesson> requestLessons = getRequestLessons(exchangeRequest);
-            validateNoScheduleConflict(proposerId, exchangeRequest.getLessonDate(), requestLessons);
         }
+
+        validateNoScheduleConflict(proposerId, exchangeRequest.getLessonDate(), requestLessons);
 
         // 수정 이후에도 제안 화면에는 최신 수정 기준의 반 이름이 유지되도록 snapshot을 함께 갱신
         proposal.update(

--- a/src/test/java/geumjeongyahak/e2e/request/lessonexchange/LessonExchangeProposalCreateTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/lessonexchange/LessonExchangeProposalCreateTest.java
@@ -304,6 +304,31 @@ class LessonExchangeProposalCreateTest extends RequestBaseTest {
             .statusCode(404);
     }
 
+    @Test
+    @DisplayName("요청 수업 시간대에 기존 수업이 있으면 교환형 제안 생성 -> 409")
+    void createExchangeProposal_withScheduleConflict_returns409() {
+        LocalDate requestDate = LocalDate.now().plusDays(16);
+        LocalDate proposalDate = LocalDate.now().plusDays(17);
+        Long requestId = createApprovedRequest(requestDate);
+
+        Long proposerSubjectId = registerSubject(2L, TEACHER2_ID);
+        registerLesson(proposerSubjectId, TEACHER2_ID, requestDate, "09:00:00", "10:00:00", 1);
+        registerLesson(proposerSubjectId, TEACHER2_ID, proposalDate, "11:00:00", "11:50:00", 3);
+
+        given()
+            .basePath("/api/v1/lesson-exchange-requests")
+            .header(AUTH_HEADER, getAuthHeader(volunteer2Token))
+            .contentType(ContentType.JSON)
+            .body(Map.of(
+                "lessonDate", proposalDate.toString(),
+                "content", "다른 날짜 수업으로 교환 가능합니다."
+            ))
+            .post("/{requestId}/proposals", requestId)
+            .then()
+            .statusCode(409)
+            .body("code", equalTo("REQ-07-016"));
+    }
+
     private Long createApprovedRequest(LocalDate lessonDate) {
         Long requestId = createPendingRequest(VOLUNTEER_USERNAME, TEACHER_ID, lessonDate);
 

--- a/src/test/java/geumjeongyahak/e2e/request/lessonexchange/LessonExchangeProposalUpdateTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/lessonexchange/LessonExchangeProposalUpdateTest.java
@@ -252,7 +252,6 @@ class LessonExchangeProposalUpdateTest extends RequestBaseTest {
 
         Long proposerSubjectId = registerSubject(CLASSROOM_ID, TEACHER2_ID);
         registerLesson(proposerSubjectId, TEACHER2_ID, LocalDate.now().plusDays(15), "11:00:00", "11:50:00", 3);
-        registerLesson(proposerSubjectId, TEACHER2_ID, requestDate, "09:00:00", "09:50:00", 1);
 
         Long proposalId = createProposal(
             requestId,
@@ -324,6 +323,41 @@ class LessonExchangeProposalUpdateTest extends RequestBaseTest {
             .patch("/{requestId}/proposals/{proposalId}", requestId, proposalId)
             .then()
             .statusCode(409);
+    }
+
+    @Test
+    @DisplayName("요청 수업 시간대에 기존 수업이 있으면 교환형 제안 수정 -> 409")
+    void updateExchangeProposal_withScheduleConflict_returns409() {
+        LocalDate requestDate = LocalDate.now().plusDays(22);
+        LocalDate originalProposalDate = LocalDate.now().plusDays(23);
+        LocalDate updatedProposalDate = LocalDate.now().plusDays(24);
+        Long requestId = createApprovedRequest(requestDate);
+
+        Long proposerSubjectId = registerSubject(2L, TEACHER2_ID);
+        registerLesson(proposerSubjectId, TEACHER2_ID, originalProposalDate, "11:00:00", "11:50:00", 3);
+
+        Long proposalId = createProposal(
+            requestId,
+            getAuthHeader(volunteer2Token),
+            Map.of("lessonDate", originalProposalDate.toString(), "content", "기존 교환형 제안")
+        );
+        proposalIds.add(proposalId);
+
+        registerLesson(proposerSubjectId, TEACHER2_ID, requestDate, "09:00:00", "10:00:00", 1);
+        registerLesson(proposerSubjectId, TEACHER2_ID, updatedProposalDate, "11:00:00", "11:50:00", 3);
+
+        given()
+            .basePath("/api/v1/lesson-exchange-requests")
+            .header(AUTH_HEADER, getAuthHeader(volunteer2Token))
+            .contentType(ContentType.JSON)
+            .body(Map.of(
+                "lessonDate", updatedProposalDate.toString(),
+                "content", "충돌 상태의 교환형 제안 수정"
+            ))
+            .patch("/{requestId}/proposals/{proposalId}", requestId, proposalId)
+            .then()
+            .statusCode(409)
+            .body("code", equalTo("REQ-07-016"));
     }
 
     private Long createApprovedRequest(LocalDate lessonDate) {


### PR DESCRIPTION
## 개요

교환형 수업 교환 제안 생성/수정 시 요청 수업 시간대에 제안자의 기존 수업이 있는 경우에도 제안이 가능하던 문제를 수정했습니다.

## 변경 유형

- [ ] 새 기능 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [x] 테스트 (test)
- [ ] 기타 (chore)

## 변경 내용

- 교환형/대체형 제안 모두 요청 수업 시간대 충돌 검증을 공통으로 수행하도록 수정
- 교환형 제안 생성 시 시간대 충돌이 있으면 `REQ-07-016`으로 거부하는 E2E 테스트 추가
- 교환형 제안 수정 시 시간대 충돌이 있으면 `REQ-07-016`으로 거부하는 E2E 테스트 추가
- 새 검증 정책에 맞게 기존 수정 테스트 데이터를 조정

## 관련 이슈

Closes #166

## 스크린샷 (선택)



## 체크리스트

- [x] 코드 컨벤션을 준수했습니다
- [x] 테스트 코드를 작성/수정했습니다
- [x] 모든 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)

## 리뷰어에게

