### PR TITLE
fix(global): 현재 변경사항 안정화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ infra/monitoring/caddy/*auth*
 
 # Local LLM harness run artifacts
 harness/runs/
+harness/tasks/issue-*-feature-task.md
 
 docs/issue/*
 docs/pr/*

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -2,7 +2,7 @@
 
 ## 목적
 
-이 하네스는 금정야학 백엔드에서 반복되는 모니터링, 동기화, 문서화 작업을 `issue -> branch -> commit -> PR` 흐름으로 고정하고, LLM 실행의 프롬프트와 결과를 artifact로 남기기 위한 repo-local 계약이다.
+이 하네스는 금정야학 백엔드에서 반복되는 기능 구현, 모니터링, 동기화, 문서화 작업을 `issue -> branch -> implementation -> commit -> PR` 흐름으로 고정하고, LLM 실행의 프롬프트와 결과를 artifact로 남기기 위한 repo-local 계약이다.
 
 LLM Wiki의 `Codex Harness Engineering`, `Codex 기반 Agent Harness Engineering 리서치`, `SW Maestro Harness Research`를 기준으로 한다. 핵심은 역할형 subagent tree가 아니라 다음 네 단위다.
 
@@ -49,6 +49,44 @@ retry = 실패 로그를 먹인 복구 loop
    - PR 본문에는 issue link, 변경 요약, 검증 증거, 남은 blocker를 포함한다.
    - PR 생성 후 URL과 실제 검증 명령 결과를 보고한다.
 
+## 기능 요청 자동화 플로우
+
+기능 요청이 들어오면 기존 issue/PR 양식을 먼저 수집하고, 그 결과를 task prompt에 넣어 구현/PR 문체가 저장소 관행에서 벗어나지 않게 한다.
+
+```mermaid
+flowchart LR
+    Request[기능 요청] --> Issue[GitHub Issue 작성/확정]
+    Issue --> Context[collect-github-context.sh\n템플릿 + 최근 issue/PR 수집]
+    Context --> Prepare[prepare-feature-task.sh\nbranch/task/pr-draft 준비]
+    Prepare --> Implement[run-task.sh\nCodex/Hermes 구현]
+    Implement --> Verify[focused test + scripts/harness/verify.sh]
+    Verify --> Commit[작은 논리 commit]
+    Commit --> PR[PR 생성\n기본 PR 구조 + 검증 증거]
+```
+
+권장 명령:
+
+```bash
+# 기존 GitHub issue를 기준으로 branch/task/pr draft 준비
+scripts/harness/prepare-feature-task.sh --issue 161
+
+# Codex 실행 전 prompt와 GitHub context artifact만 확인
+scripts/harness/run-task.sh --dry-run harness/tasks/issue-161-feature-task.md
+
+# PR 본문 초안만 재생성
+scripts/harness/draft-pr-body.sh 161 > /tmp/pr-161.md
+```
+
+시동어는 `harness/startup-words.md`를 따른다. `/plan`은 issue 수준 요구사항 구체화만 수행하고, `implement /goal ...` 또는 `implement --issue <number>`는 issue 확인, branch/task 준비, 구현, 검증, PR handoff까지 진행하는 구현 모드다.
+
+자동화 원칙:
+
+- issue 본문은 `.github/ISSUE_TEMPLATE`와 최근 issue를 참고해 기존 `기능 설명`, `배경`, `상세 요구사항`, `참고 자료`, `추가 정보` 구조를 유지한다.
+- PR 본문은 최근 PR 관행에 맞춰 `개요`, `변경 유형`, `변경 내용`, `관련 이슈`, `스크린샷 (선택)`, `체크리스트`, `리뷰어에게`, `검증` 기본 구조를 유지한다.
+- API/domain/data 흐름이 바뀌면 Mermaid `sequenceDiagram`, `erDiagram`, `classDiagram`, `flowchart` 중 필요한 것만 실제 변경 이름으로 추가한다.
+- 구현 agent는 먼저 유사 controller/service/repository/DTO/test를 찾고, 기존 예외/권한/transaction convention을 따른다.
+- commit/push/PR 생성은 실제 `git`/`gh` 출력으로 확인한다. 자동 merge/deploy는 하네스 범위 밖이다.
+
 ## Artifact 구조
 
 `harness/runs/`는 `.gitignore` 대상이다. 실행 결과는 재현/리뷰용 로컬 evidence이며 secrets를 넣지 않는다.
@@ -58,6 +96,7 @@ retry = 실패 로그를 먹인 복구 loop
 ```text
 harness/
 ├── README.md
+├── startup-words.md
 ├── v1/
 │   └── 2026-06-28/
 │       ├── README.md
@@ -76,6 +115,7 @@ harness/
 │   └── task-result.schema.json
 ├── tasks/
 │   └── monitoring-sync-docs-task.template.md
+│   └── issue-<number>-feature-task.md
 └── runs/
     └── <run-id>/
         ├── prompt.txt
@@ -105,6 +145,10 @@ Codex final output은 `harness/schemas/task-result.schema.json`을 따라야 한
 | --- | --- | --- |
 | `task.input` | task file 또는 `user-input.md` | 사용자/태스크 입력 수집 상태 기록 |
 | `prompt.rendered` | `prompt.txt` | task packet과 repo 규칙으로 실행 프롬프트 생성 |
+| `github.context` | `github-context.md` | 로컬 템플릿과 최근 issue/PR 양식 수집 |
+| `issue.snapshot` | `issue-<number>.json` | 구현 기준이 되는 GitHub issue 원문 저장 |
+| `task.prepared` | `harness/tasks/issue-<number>-feature-task.md` | issue 기반 구현 task packet 생성 |
+| `pr.drafted` | `pr-draft.md` | PR body 초안 생성 |
 | `codex.finished` | `result.json` | Codex structured result 생성 |
 | `verify.finished` | `verify-summary.txt` | runner 검증 결과 요약 |
 | `diff.summarized` | `diff-summary.md` | PR handoff용 diff summary 생성 |

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ LOCAL_SERVICES := app db
 	up-monitoring up-monitoring-alerts down-monitoring ps-monitoring logs-monitoring \
 	apply-monitoring-alert-env apply-monitoring-alert-env-central apply-monitoring-alert-env-all \
 	sync-monitoring-diff sync-monitoring-pull sync-monitoring-push \
-	harness-verify harness-dry-run harness-diff-summary
+	harness-verify harness-dry-run harness-diff-summary harness-github-context harness-prepare-feature
 
 up-local:
 	$(COMPOSE) $(LOCAL_FILES) up --build --remove-orphans $(LOCAL_SERVICES)
@@ -70,3 +70,10 @@ harness-dry-run:
 
 harness-diff-summary:
 	scripts/harness/summarize-diff.sh
+
+harness-github-context:
+	scripts/harness/collect-github-context.sh
+
+harness-prepare-feature:
+	@test -n "$(ISSUE)" || (echo "usage: make harness-prepare-feature ISSUE=<number>" >&2; exit 2)
+	scripts/harness/prepare-feature-task.sh --issue $(ISSUE)

--- a/harness/README.md
+++ b/harness/README.md
@@ -6,7 +6,7 @@
 
 | Version | Date | Path | Status | Summary |
 | --- | --- | --- | --- | --- |
-| `v1` | 2026-06-28 | `harness/v1/2026-06-28/` | active | Codex one-shot task runner, prompt/result hook monitoring, issue→branch→commit→PR workflow baseline |
+| `v1` | 2026-06-28 | `harness/v1/2026-06-28/` | active | Codex one-shot task runner, GitHub issue/PR context capture, prompt/result hook monitoring, issue→branch→implementation→commit→PR workflow baseline |
 
 ## Versioning rules
 
@@ -15,3 +15,20 @@
 - `v2`는 artifact DB, App Server, GitHub Action, worktree isolation처럼 실행 모델이 바뀔 때 만든다.
 - 작은 문구 수정은 active date folder 안에서 고치되, workflow state machine이나 artifact contract가 바뀌면 같은 major의 새 날짜 폴더 또는 새 major version을 만든다.
 - PR 본문에는 사용한 하네스 버전과 날짜를 함께 적는다. 예: `v1 (2026-06-28)`.
+
+## Feature request quick start
+
+시동어 규칙은 `harness/startup-words.md`를 본다. `/plan`은 issue draft/구현 계획만 만들고, `implement /goal ...` 또는 `implement --issue <번호>`는 하네스 구현 모드로 branch/task/PR handoff까지 진행한다.
+
+```bash
+# 최근 issue/PR/template 양식 확인
+make harness-github-context
+
+# GitHub issue에서 branch/task/pr-draft 준비
+make harness-prepare-feature ISSUE=161
+
+# 생성된 task packet을 Codex 실행 전 dry-run으로 검토
+scripts/harness/run-task.sh --dry-run harness/tasks/issue-161-feature-task.md
+```
+
+기능 구현 PR은 최근 PR 관행을 따라 기본 섹션, 검증 command/result, reviewer note를 유지하고, 복잡한 흐름에만 Mermaid 시각화를 추가한다.

--- a/harness/prompts/issue-branch-commit-pr.md
+++ b/harness/prompts/issue-branch-commit-pr.md
@@ -10,10 +10,13 @@ You are operating inside the GJLearn Backend repository. Treat the task file as 
 
 1. Read the task file completely.
 2. Read every file listed under `Read first`.
-3. Inspect current git state before editing.
-4. Modify only files allowed by the task packet.
-5. Run `scripts/harness/verify.sh` after changes unless the task explicitly narrows verification.
-6. Produce final JSON matching `harness/schemas/task-result.schema.json`.
+3. Inspect GitHub issue/PR/template context from `harness/runs/<run-id>/github-context.md` when present. Match the repository's observed issue/PR sections before inventing a new format.
+4. Inspect current git state before editing.
+5. Search for neighboring code and tests before changing code. Trace controller -> service -> repository -> DTO/test conventions rather than guessing imports or API shapes.
+6. Modify only files allowed by the task packet.
+7. Run focused tests for the touched domain, then `scripts/harness/verify.sh` after changes unless the task explicitly narrows verification.
+8. Update the PR handoff draft when the task creates a feature branch/PR: keep the repository's basic PR sections, include validation evidence, and add Mermaid only when it helps explain API/domain/data flow.
+9. Produce final JSON matching `harness/schemas/task-result.schema.json`.
 
 ## Completion rules
 
@@ -24,6 +27,9 @@ You are operating inside the GJLearn Backend repository. Treat the task file as 
 - Include the harness version in final `next_steps` or reviewer notes when relevant.
 - Treat the task packet `Guardrails` as mandatory. If a requested action violates them, stop and report a blocker.
 - Do not include raw secrets or private env values in final JSON.
+- Do not claim an issue or PR was created unless the `gh` command returned the number/URL.
+- Do not create broad commits. Stage small logical groups and use the repository conventional commit style when commit is explicitly permitted.
+- Mermaid diagrams, when used, must describe the actual implemented flow/entities. Replace placeholder node names before PR creation.
 
 ## Final JSON fields
 

--- a/harness/startup-words.md
+++ b/harness/startup-words.md
@@ -1,0 +1,135 @@
+# Harness Startup Words
+
+이 문서는 금정야학 백엔드에서 기능 요청을 하네스 흐름에 태우기 위한 시동어 규칙이다. 목표는 사용자가 짧게 `/plan` 또는 `implement(/goal)`을 말해도 agent가 기존 issue/PR 양식, 코드 컨벤션, 검증/PR handoff를 자동으로 따라가게 하는 것이다.
+
+## 시동어 요약
+
+| 시동어 | 목적 | 산출물 | 금지 |
+| --- | --- | --- | --- |
+| `/plan <요청>` | 기능 요청을 GitHub issue 수준으로 구체화 | issue draft, scope, acceptance, verification | 코드 수정, branch 생성, commit |
+| `/plan --issue <번호>` | 기존 issue를 구현 가능한 task packet으로 분해 | branch명 제안, task packet, PR draft skeleton | 코드 수정, commit |
+| `implement /goal <요청>` | 이미 충분히 구체화된 요청을 하네스에 맞게 구현 | issue 확인/생성, branch, 구현, 검증, commit/PR handoff | 양식 없는 임의 PR, 검증 없는 완료 주장 |
+| `implement --issue <번호>` | 기존 issue를 기준으로 구현 시작 | `prepare-feature-task.sh`, `run-task.sh`, tests, PR body | issue 요구사항 무시, 자동 merge/deploy |
+| `/goal <한 문장 목표>` | 구현 agent에게 넘길 목표 문장 | Goal 섹션/branch slug seed | 단독 실행 없음. `/plan` 또는 `implement`와 함께 사용 |
+
+## `/plan` 규칙
+
+사용자가 `/plan`으로 시작하면 implementation을 시작하지 않고 요구사항을 issue/PR-ready spec으로 만든다.
+
+### 입력 예시
+
+```text
+/plan 교학 회의록 첨부파일 업로드 기능
+```
+
+```text
+/plan --issue 161
+```
+
+### 수행 절차
+
+1. 기존 `.github/ISSUE_TEMPLATE`, 최근 issue, 최근 PR을 확인한다.
+2. 유사 도메인 코드와 문서를 search/read로 확인한다.
+3. 기본 issue 구조인 기능 설명, 배경, 상세 요구사항, 참고 자료, 추가 정보를 채운다.
+4. 구현 범위를 `Must / Should / Out of scope`로 나눈다.
+5. API/domain/data 흐름이 복잡하면 보조 Mermaid 초안을 작성한다.
+6. 사용자가 승인하면 GitHub issue 생성 또는 기존 issue 보강으로 넘어간다.
+
+### `/plan` 출력 템플릿
+
+```markdown
+# Plan: <기능명>
+
+## Issue draft
+
+## 기능 설명
+
+## 배경
+
+## 상세 요구사항
+- [ ] ...
+
+## 참고 자료
+- API 명세:
+- 기존 코드:
+- 관련 PR/Issue:
+
+## 추가 정보
+
+## Implementation slices
+1. Domain/API contract
+2. Persistence/schema
+3. Service/controller behavior
+4. Tests/docs
+
+## Optional Mermaid draft
+
+```mermaid
+flowchart LR
+    Request[요청] --> API[API]
+    API --> Service[Service]
+    Service --> DB[(DB)]
+```
+
+## Verification gates
+- `git diff --check`
+- focused Gradle tests
+- `scripts/harness/verify.sh`
+```
+
+## `implement /goal` 규칙
+
+사용자가 `implement`, `implement /goal`, 또는 `implement --issue`로 시작하면 하네스 구현 모드로 들어간다.
+
+### 입력 예시
+
+```text
+implement /goal 교학 회의록 첨부파일 업로드 기능을 구현하고 PR까지 준비해줘
+```
+
+```text
+implement --issue 161
+```
+
+### 수행 절차
+
+1. `gh auth status`, `git status --short --branch`, remote/base branch를 확인한다.
+2. issue가 없으면 `/plan` 산출물을 바탕으로 issue draft를 만들고 사용자 승인 후 `gh issue create`를 실행한다.
+3. issue가 있으면 다음을 실행한다.
+
+```bash
+scripts/harness/prepare-feature-task.sh --issue <번호>
+scripts/harness/run-task.sh --dry-run harness/tasks/issue-<번호>-feature-task.md
+```
+
+4. 구현 전 유사 코드/문서/테스트를 읽는다.
+5. `feature/<issue-number>-<short-topic>` branch에서 최소 변경을 구현한다.
+6. focused test → `scripts/harness/verify.sh` 순서로 검증한다.
+7. 작은 논리 단위로 stage/commit한다.
+8. PR body에는 최근 PR 양식에 맞춰 `개요`, `변경 유형`, `변경 내용`, `관련 이슈`, `스크린샷 (선택)`, `체크리스트`, `리뷰어에게`, `검증`을 채운다.
+9. `gh pr create` 결과 URL을 확인하고 보고한다.
+
+## Agent routing policy
+
+- Hermes: `/plan` 구체화, GitHub issue/PR lifecycle, 최종 검증, 사용자 보고.
+- Codex: repo-local implementation/review turn. `run-task.sh`가 만든 prompt와 task packet을 따른다.
+- Reviewer: Mermaid가 실제 변경과 맞는지, 검증 command가 실제 출력 기반인지 확인한다.
+
+## PR Mermaid 작성 기준
+
+- API 동작 추가/변경: `sequenceDiagram` 우선.
+- DB relation 추가/변경: `erDiagram` 추가.
+- 상태 전이/권한 흐름: `stateDiagram-v2` 또는 `flowchart` 사용.
+- diagram node에는 placeholder(`TODO`, `DomainService`, `NEW_ENTITY`)를 남기지 않는다.
+- diagram은 PR 설명용이며 코드와 다른 speculative component를 넣지 않는다.
+
+## Completion contract
+
+하네스 구현 모드의 완료 보고는 다음 증거를 포함해야 한다.
+
+- issue 번호와 URL
+- branch 이름
+- commit SHA 또는 commit이 blocked된 이유
+- PR URL 또는 PR 생성이 blocked된 이유
+- 실행한 검증 명령과 exit code
+- 남은 blocker/risk

--- a/harness/v1/2026-06-28/prompts/issue-branch-commit-pr.md
+++ b/harness/v1/2026-06-28/prompts/issue-branch-commit-pr.md
@@ -10,10 +10,13 @@ You are operating inside the GJLearn Backend repository. Treat the task file as 
 
 1. Read the task file completely.
 2. Read every file listed under `Read first`.
-3. Inspect current git state before editing.
-4. Modify only files allowed by the task packet.
-5. Run `scripts/harness/verify.sh` after changes unless the task explicitly narrows verification.
-6. Produce final JSON matching `harness/schemas/task-result.schema.json`.
+3. Inspect GitHub issue/PR/template context from `harness/runs/<run-id>/github-context.md` when present. Match the repository's observed issue/PR sections before inventing a new format.
+4. Inspect current git state before editing.
+5. Search for neighboring code and tests before changing code. Trace controller -> service -> repository -> DTO/test conventions rather than guessing imports or API shapes.
+6. Modify only files allowed by the task packet.
+7. Run focused tests for the touched domain, then `scripts/harness/verify.sh` after changes unless the task explicitly narrows verification.
+8. Update the PR handoff draft when the task creates a feature branch/PR: keep the repository's basic PR sections, include validation evidence, and add Mermaid only when it helps explain API/domain/data flow.
+9. Produce final JSON matching `harness/schemas/task-result.schema.json`.
 
 ## Completion rules
 
@@ -24,6 +27,9 @@ You are operating inside the GJLearn Backend repository. Treat the task file as 
 - Include the harness version in final `next_steps` or reviewer notes when relevant.
 - Treat the task packet `Guardrails` as mandatory. If a requested action violates them, stop and report a blocker.
 - Do not include raw secrets or private env values in final JSON.
+- Do not claim an issue or PR was created unless the `gh` command returned the number/URL.
+- Do not create broad commits. Stage small logical groups and use the repository conventional commit style when commit is explicitly permitted.
+- Mermaid diagrams, when used, must describe the actual implemented flow/entities. Replace placeholder node names before PR creation.
 
 ## Final JSON fields
 

--- a/scripts/harness/collect-github-context.sh
+++ b/scripts/harness/collect-github-context.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LIMIT="${HARNESS_CONTEXT_LIMIT:-5}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+printf '# GitHub Context Snapshot\n\n'
+printf 'Generated at: %s\n\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+printf '## Local templates\n\n'
+if [[ -d .github/ISSUE_TEMPLATE ]]; then
+  while IFS= read -r template; do
+    printf '### %s\n\n' "${template}"
+    sed -n '1,220p' "${template}"
+    printf '\n\n'
+  done < <(find .github/ISSUE_TEMPLATE -type f | sort)
+else
+  printf 'No .github/ISSUE_TEMPLATE directory found.\n\n'
+fi
+
+if [[ -f .github/pull_request_template.md ]]; then
+  printf '### .github/pull_request_template.md\n\n'
+  sed -n '1,260p' .github/pull_request_template.md
+  printf '\n\n'
+else
+  printf '### Pull request template\n\n'
+  printf 'No .github/pull_request_template.md file found. Use recent merged/open PR bodies as the style source.\n\n'
+fi
+
+if command -v gh >/dev/null 2>&1; then
+  printf '## Recent issues\n\n'
+  gh issue list --limit "${LIMIT}" --state all \
+    --json number,title,body,labels,state,url,createdAt \
+    --template '{{range .}}{{printf "### #%v %s (%s)\n%s\n\n%s\n\n" .number .title .state .url .body}}{{end}}' || \
+    printf 'Failed to read issues with gh.\n\n'
+
+  printf '## Recent pull requests\n\n'
+  gh pr list --limit "${LIMIT}" --state all \
+    --json number,title,body,headRefName,baseRefName,state,url,createdAt \
+    --template '{{range .}}{{printf "### #%v %s (%s)\n%s\nhead: %s -> base: %s\n\n%s\n\n" .number .title .state .url .headRefName .baseRefName .body}}{{end}}' || \
+    printf 'Failed to read pull requests with gh.\n\n'
+else
+  printf '## Recent issues / pull requests\n\n'
+  printf 'gh command not found; only local templates were collected.\n\n'
+fi

--- a/scripts/harness/draft-pr-body.sh
+++ b/scripts/harness/draft-pr-body.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ISSUE_NUMBER="${1:-}"
+if [[ -z "${ISSUE_NUMBER}" || ! "${ISSUE_NUMBER}" =~ ^[0-9]+$ ]]; then
+  echo "usage: $0 <issue-number>" >&2
+  exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh command not found" >&2
+  exit 127
+fi
+
+ISSUE_JSON="$(mktemp)"
+trap 'rm -f "${ISSUE_JSON}"' EXIT
+gh issue view "${ISSUE_NUMBER}" --json number,title,body,url > "${ISSUE_JSON}"
+
+python3 - "${ISSUE_JSON}" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+issue = json.loads(Path(sys.argv[1]).read_text(encoding='utf-8'))
+title = re.sub(r'^\[[^\]]+\]\s*', '', issue['title']).strip()
+
+print(f"""## 개요
+
+{title} 기능 요청을 기존 금정야학 백엔드 도메인 구조와 API 컨벤션에 맞춰 구현합니다.
+
+Harness version: `v1-2026-06-28`
+
+## 변경 유형
+
+- [x] 새 기능 (feat)
+- [ ] 버그 수정 (fix)
+- [ ] 리팩토링 (refactor)
+- [ ] 문서 수정 (docs)
+- [ ] 테스트 (test)
+- [ ] 기타 (chore)
+
+## 변경 내용
+
+- TODO: 구현한 도메인/API/DB/문서 변경을 bullet로 정리합니다.
+- TODO: 권한, validation, transaction, 예외 처리 정책을 명시합니다.
+- TODO: 기존 코드/PR convention을 따라 scope 밖 변경은 제외했다고 적습니다.
+
+## 관련 이슈
+
+Closes #{issue['number']}
+
+## 스크린샷 (선택)
+
+- 해당 없음 또는 관리자 화면/API 응답 증거를 첨부합니다.
+
+## 체크리스트
+
+- [ ] 코드 컨벤션을 준수했습니다
+- [ ] 테스트 코드를 작성/수정했습니다
+- [ ] 머지 전 `./gradlew test` 또는 필요한 focused test가 통과합니다
+- [ ] 문서를 업데이트했습니다 (필요한 경우)
+
+## 검증
+
+- [ ] `git diff --check`
+- [ ] `./gradlew test --tests '<focused-test>'`
+- [ ] `scripts/harness/verify.sh`
+
+## 리뷰어에게
+
+- TODO: DB migration/API contract/security/운영 위험을 적습니다.
+- TODO: API/DB/도메인 흐름이 복잡하면 최근 PR처럼 Mermaid를 추가합니다.
+- TODO: 미검증 항목이나 blocker가 있으면 명확히 남깁니다.
+""")
+PY

--- a/scripts/harness/prepare-feature-task.sh
+++ b/scripts/harness/prepare-feature-task.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DRY_RUN=false
+ISSUE_NUMBER=""
+RUN_ID="${HARNESS_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+
+usage() {
+  cat >&2 <<'EOF'
+usage: scripts/harness/prepare-feature-task.sh [--dry-run] --issue <number>
+
+Creates a feature implementation task packet from an existing GitHub issue,
+collects recent issue/PR style context, and prepares the conventional feature
+branch name. By default it switches to the branch; --dry-run only writes artifacts.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --issue)
+      ISSUE_NUMBER="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${ISSUE_NUMBER}" ]]; then
+  usage
+  exit 2
+fi
+
+if ! [[ "${ISSUE_NUMBER}" =~ ^[0-9]+$ ]]; then
+  echo "issue number must be numeric: ${ISSUE_NUMBER}" >&2
+  exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh command not found" >&2
+  exit 127
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+if [[ "${HARNESS_ALLOW_DIRTY:-false}" != "true" ]] && [[ -n "$(git status --porcelain)" ]]; then
+  echo "working tree is dirty; commit/stash first or set HARNESS_ALLOW_DIRTY=true" >&2
+  git status --short >&2
+  exit 3
+fi
+
+ARTIFACT_DIR="${REPO_ROOT}/harness/runs/${RUN_ID}"
+TASK_DIR="${REPO_ROOT}/harness/tasks"
+mkdir -p "${ARTIFACT_DIR}" "${TASK_DIR}"
+
+ISSUE_JSON="${ARTIFACT_DIR}/issue-${ISSUE_NUMBER}.json"
+ISSUE_BODY="${ARTIFACT_DIR}/issue-${ISSUE_NUMBER}.md"
+CONTEXT_FILE="${ARTIFACT_DIR}/github-context.md"
+BRANCH_FILE="${ARTIFACT_DIR}/branch-name.txt"
+TASK_FILE="${TASK_DIR}/issue-${ISSUE_NUMBER}-feature-task.md"
+PR_DRAFT="${ARTIFACT_DIR}/pr-draft.md"
+
+gh issue view "${ISSUE_NUMBER}" --json number,title,body,labels,state,url > "${ISSUE_JSON}"
+python3 - "${ISSUE_JSON}" "${ISSUE_BODY}" "${BRANCH_FILE}" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+issue_path, body_path, branch_path = map(Path, sys.argv[1:])
+issue = json.loads(issue_path.read_text(encoding='utf-8'))
+title = issue['title']
+body_path.write_text(issue.get('body') or '', encoding='utf-8')
+
+clean = re.sub(r'^\[[^\]]+\]\s*', '', title).lower()
+clean = re.sub(r'[^0-9a-z가-힣]+', '-', clean).strip('-')
+slug = clean[:40].strip('-') or 'feature'
+branch_path.write_text(f"feature/{issue['number']}-{slug}\n", encoding='utf-8')
+PY
+
+BRANCH_NAME="$(tr -d '\n' < "${BRANCH_FILE}")"
+scripts/harness/collect-github-context.sh > "${CONTEXT_FILE}"
+scripts/harness/draft-pr-body.sh "${ISSUE_NUMBER}" > "${PR_DRAFT}"
+
+python3 - \
+  "${TASK_FILE}" \
+  "${ISSUE_NUMBER}" \
+  "${RUN_ID}" \
+  "${BRANCH_NAME}" \
+  "${ISSUE_JSON#${REPO_ROOT}/}" \
+  "${ISSUE_BODY#${REPO_ROOT}/}" <<'PY'
+import sys
+from pathlib import Path
+
+task_file = Path(sys.argv[1])
+issue_number = sys.argv[2]
+run_id = sys.argv[3]
+branch_name = sys.argv[4]
+issue_json = sys.argv[5]
+issue_body = sys.argv[6]
+
+content = f"""# Task: GitHub issue #{issue_number} 기능 구현
+
+## Goal
+
+GitHub issue #{issue_number}의 기능 요청을 기존 코드/문서/테스트 컨벤션에 맞춰 구현하고, 작은 논리 commit과 PR handoff까지 준비한다.
+
+## Issue
+
+- GitHub issue: #{issue_number}
+- Issue snapshot: `{issue_json}`
+- Issue body: `{issue_body}`
+- Suggested branch: `{branch_name}`
+
+## Read first
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `HARNESS.md`
+- `harness/startup-words.md`
+- `harness/runs/{run_id}/github-context.md`
+- `harness/runs/{run_id}/issue-{issue_number}.md`
+- `docs/api/` 중 issue가 언급한 API 문서
+- 구현 대상 도메인의 `entity/`, `repository/`, `service/`, `v1/controller/`, `v1/dto/`, 관련 테스트
+
+## Discover before modify
+
+- `search_files`/ripgrep으로 issue 키워드, 유사 API, DTO, service, exception, test를 찾는다.
+- 기존 merged/open PR 본문에서 기본 섹션과 체크리스트 스타일을 확인한다.
+- 변경 전 `git status --short --branch`, `git diff --stat`를 기록한다.
+
+## Modify
+
+Allowed scope is the minimum set required by the issue:
+
+- `src/main/java/geumjeongyahak/domain/**`
+- `src/main/resources/**` only if schema/config change is required
+- `src/test/**`
+- `docs/api/**`, `docs/**` only when contract/docs change
+- `harness/runs/{run_id}/pr-draft.md` for PR handoff notes
+
+## Constraints
+
+- 기존 도메인 패키지 구조와 API 응답 형식을 따른다: `ApiResponse.success/error`, domain event boundary, BaseEntity, DTO request/response 분리.
+- 새 public API나 DB contract 변경은 docs와 테스트를 함께 갱신한다.
+- secrets, `.env`, credential 파일은 읽거나 수정하지 않는다.
+- destructive command, deploy, force push, auto merge는 실행하지 않는다.
+- 커밋은 사용자 또는 runner가 명시적으로 허용한 경우에만 수행한다.
+
+## Acceptance criteria
+
+- issue의 체크박스 요구사항이 구현/미구현/범위 밖으로 추적된다.
+- 기존 유사 코드의 naming, exception, validation, transaction, security convention을 따른다.
+- API/DB/도메인 흐름 변화가 PR 본문에 설명된다. 복잡한 흐름은 최근 PR처럼 Mermaid를 추가한다.
+- 테스트 또는 명시적 blocker가 있다. Codex/Hermes self-report만으로 완료 처리하지 않는다.
+
+## Verification
+
+Prefer focused tests first, then full gate:
+
+- `git diff --check`
+- 변경 도메인 관련 `./gradlew test --tests '<focused-test>'`
+- `scripts/harness/verify.sh`
+- `scripts/harness/summarize-diff.sh`
+
+## PR handoff
+
+Use `harness/runs/{run_id}/pr-draft.md` as the starting body. Fill in:
+
+- 개요
+- 변경 유형
+- 변경 내용
+- 관련 이슈: `Closes #{issue_number}`
+- 스크린샷 (선택)
+- 체크리스트
+- 검증: command + result
+- 리뷰어에게: risk/blocker/운영 영향
+
+## Output
+
+Return JSON matching `harness/schemas/task-result.schema.json`.
+"""
+task_file.write_text(content, encoding='utf-8')
+PY
+
+"${REPO_ROOT}/scripts/harness/monitor-hook.sh" "${RUN_ID}" "github.context" "${CONTEXT_FILE}" "ok"
+"${REPO_ROOT}/scripts/harness/monitor-hook.sh" "${RUN_ID}" "issue.snapshot" "${ISSUE_JSON}" "ok"
+"${REPO_ROOT}/scripts/harness/monitor-hook.sh" "${RUN_ID}" "task.prepared" "${TASK_FILE}" "ok"
+"${REPO_ROOT}/scripts/harness/monitor-hook.sh" "${RUN_ID}" "pr.drafted" "${PR_DRAFT}" "ok"
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+  echo "DRY RUN: prepared task packet ${TASK_FILE}"
+  echo "Suggested branch: ${BRANCH_NAME}"
+  echo "Artifacts: ${ARTIFACT_DIR}"
+  exit 0
+fi
+
+if git show-ref --verify --quiet "refs/heads/${BRANCH_NAME}"; then
+  git switch "${BRANCH_NAME}"
+else
+  git switch -c "${BRANCH_NAME}"
+fi
+
+echo "Prepared task packet: ${TASK_FILE}"
+echo "Branch: ${BRANCH_NAME}"
+echo "Artifacts: ${ARTIFACT_DIR}"

--- a/scripts/harness/run-task.sh
+++ b/scripts/harness/run-task.sh
@@ -25,9 +25,11 @@ RUN_ID="${HARNESS_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
 HARNESS_VERSION="${HARNESS_VERSION:-v1}"
 HARNESS_DATE="${HARNESS_DATE:-2026-06-28}"
 HARNESS_CAPTURE_INPUT="${HARNESS_CAPTURE_INPUT:-metadata}"
+HARNESS_GITHUB_CONTEXT="${HARNESS_GITHUB_CONTEXT:-auto}"
 ARTIFACT_DIR="${REPO_ROOT}/harness/runs/${RUN_ID}"
 PROMPT_FILE="${ARTIFACT_DIR}/prompt.txt"
 USER_INPUT_FILE="${ARTIFACT_DIR}/user-input.md"
+GITHUB_CONTEXT_FILE="${ARTIFACT_DIR}/github-context.md"
 EVENTS_FILE="${ARTIFACT_DIR}/events.jsonl"
 RESULT_FILE="${ARTIFACT_DIR}/result.json"
 VERIFY_LOG="${ARTIFACT_DIR}/verify.log"
@@ -60,12 +62,28 @@ case "${HARNESS_CAPTURE_INPUT}" in
     ;;
 esac
 
+case "${HARNESS_GITHUB_CONTEXT}" in
+  off)
+    ;;
+  auto|on)
+    if [[ ! -f "${GITHUB_CONTEXT_FILE}" ]]; then
+      scripts/harness/collect-github-context.sh > "${GITHUB_CONTEXT_FILE}"
+    fi
+    HARNESS_ARTIFACT_DIR="${ARTIFACT_DIR}" "${HOOK}" "${RUN_ID}" "github.context" "${GITHUB_CONTEXT_FILE}" "ok"
+    ;;
+  *)
+    echo "invalid HARNESS_GITHUB_CONTEXT=${HARNESS_GITHUB_CONTEXT}; expected off|auto|on" >&2
+    exit 2
+    ;;
+esac
+
 {
   echo "# Harness Run Prompt"
   echo
   echo "Run ID: ${RUN_ID}"
   echo "Harness version: ${HARNESS_VERSION} (${HARNESS_DATE})"
   echo "Input capture: ${HARNESS_CAPTURE_INPUT}"
+  echo "GitHub context: ${HARNESS_GITHUB_CONTEXT}"
   echo "Task file: ${TASK_FILE}"
   echo
   echo "## Base prompt"
@@ -73,6 +91,11 @@ esac
   echo
   echo "## Task packet"
   cat "${TASK_FILE}"
+  if [[ -f "${GITHUB_CONTEXT_FILE}" ]]; then
+    echo
+    echo "## GitHub issue/PR/template context"
+    cat "${GITHUB_CONTEXT_FILE}"
+  fi
 } > "${PROMPT_FILE}"
 
 HARNESS_ARTIFACT_DIR="${ARTIFACT_DIR}" "${HOOK}" "${RUN_ID}" "prompt.rendered" "${PROMPT_FILE}" "ok"

--- a/src/main/java/geumjeongyahak/common/security/config/WebSecurityConfig.java
+++ b/src/main/java/geumjeongyahak/common/security/config/WebSecurityConfig.java
@@ -137,6 +137,7 @@ public class WebSecurityConfig {
         CorsConfiguration config = new CorsConfiguration();
 
         config.setAllowCredentials(false);
+        config.setAllowPrivateNetwork(true);
 
         List<String> origins = Arrays.stream(corsAllowedOrigins.split(","))
             .map(String::trim)

--- a/src/main/java/geumjeongyahak/common/security/config/WebSecurityConfig.java
+++ b/src/main/java/geumjeongyahak/common/security/config/WebSecurityConfig.java
@@ -105,7 +105,7 @@ public class WebSecurityConfig {
                 // 관리자 로그인 페이지로 redirect 용
                 .requestMatchers(HttpMethod.GET, "/").permitAll()
                 // 정적 리소스 및 문서/헬스체크
-                .requestMatchers("/favicon.ico", "/sw.js", "/icons/**", "/site.webmanifest", "/actuator/health", "/actuator/prometheus", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/swagger-ui").permitAll()
+                .requestMatchers("/favicon.ico", "/sw.js", "/icons/**", "/mock/**", "/site.webmanifest", "/actuator/health", "/actuator/prometheus", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/swagger-ui").permitAll()
                 // 인증 API (로그인, 회원가입, 토큰 재발급, 로그아웃)
                 .requestMatchers("/api/v1/auth/login", "/api/v1/auth/admin/login", "/api/v1/auth/signup", "/api/v1/auth/refresh", "/api/v1/auth/logout", "/api/v1/auth/password-reset/request", "/api/v1/auth/password-reset/confirm", "/api/v1/auth/email-verification/confirm", "/api/v1/auth/email-verification/resend").permitAll()
                 .requestMatchers("/api/v1/auth/google/**").permitAll()

--- a/src/main/java/geumjeongyahak/common/security/service/CustomUserDetailsService.java
+++ b/src/main/java/geumjeongyahak/common/security/service/CustomUserDetailsService.java
@@ -37,6 +37,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Transactional(readOnly = true)
     public UserDetails loadUserByUserId(Long userId) throws UsernameNotFoundException {
         UserCredential credential = userCredentialRepository.findByUserIdAndProvider(userId, ProviderType.LOCAL)
+            .or(() -> userCredentialRepository.findAllByUserId(userId).stream().findFirst())
             .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + userId));
         return toUserDetails(credential);
     }

--- a/src/main/java/geumjeongyahak/domain/department/v1/controller/DepartmentViewController.java
+++ b/src/main/java/geumjeongyahak/domain/department/v1/controller/DepartmentViewController.java
@@ -105,9 +105,13 @@ public class DepartmentViewController {
         @RequestParam String scopeTarget,
         RedirectAttributes redirectAttributes
     ) {
-        String permissionCode = permissionRegistryViewService.buildPermissionCode(permissionKey, scopeTarget);
-        departmentAdminViewService.addPermission(departmentId, roleType, permissionCode);
-        redirectAttributes.addFlashAttribute("message", "부서 권한을 추가했습니다.");
+        try {
+            String permissionCode = permissionRegistryViewService.buildPermissionCode(permissionKey, scopeTarget);
+            departmentAdminViewService.addPermission(departmentId, roleType, permissionCode);
+            redirectAttributes.addFlashAttribute("message", "부서 권한을 추가했습니다.");
+        } catch (IllegalArgumentException exception) {
+            redirectAttributes.addFlashAttribute("error", exception.getMessage());
+        }
         return "redirect:/admin/department/departments/" + departmentId;
     }
 }

--- a/src/main/java/geumjeongyahak/domain/users/v1/controller/UserViewController.java
+++ b/src/main/java/geumjeongyahak/domain/users/v1/controller/UserViewController.java
@@ -181,9 +181,13 @@ public class UserViewController {
         @RequestParam String scopeTarget,
         RedirectAttributes redirectAttributes
     ) {
-        String permissionCode = permissionRegistryViewService.buildPermissionCode(permissionKey, scopeTarget);
-        userAdminViewService.addPermission(userId, permissionCode);
-        redirectAttributes.addFlashAttribute("message", "사용자 직접 권한을 추가했습니다.");
+        try {
+            String permissionCode = permissionRegistryViewService.buildPermissionCode(permissionKey, scopeTarget);
+            userAdminViewService.addPermission(userId, permissionCode);
+            redirectAttributes.addFlashAttribute("message", "사용자 직접 권한을 추가했습니다.");
+        } catch (IllegalArgumentException exception) {
+            redirectAttributes.addFlashAttribute("error", exception.getMessage());
+        }
         return "redirect:/admin/user/users/" + userId;
     }
 }

--- a/src/main/resources/templates/admin/fragments/layout.html
+++ b/src/main/resources/templates/admin/fragments/layout.html
@@ -267,6 +267,10 @@
             color: var(--green-dark);
             font-weight: 800;
         }
+        .flash.error {
+            background: #fff0ed;
+            color: var(--danger);
+        }
         .table-panel { padding: 0; overflow: hidden; }
         .table-scroll { overflow-x: auto; }
         .pager {
@@ -523,6 +527,7 @@
             <span th:text="${adminName}">admin@example.com</span>
         </div>
         <div class="flash" th:if="${message}" th:text="${message}">완료되었습니다.</div>
+        <div class="flash error" th:if="${error}" th:text="${error}">처리할 수 없습니다.</div>
         <th:block th:replace="${content}"></th:block>
     </div>
     <div class="push-modal-backdrop" data-push-prompt hidden>

--- a/src/test/java/geumjeongyahak/e2e/auth/AuthSignupTest.java
+++ b/src/test/java/geumjeongyahak/e2e/auth/AuthSignupTest.java
@@ -5,6 +5,7 @@ import io.restassured.http.ContentType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import geumjeongyahak.common.security.jwt.JwtTokenProvider;
 import geumjeongyahak.domain.auth.enums.ProviderType;
 import geumjeongyahak.domain.auth.repository.UserCredentialRepository;
 import geumjeongyahak.domain.auth.v1.dto.request.LocalSignupRequest;
@@ -24,6 +25,9 @@ class AuthSignupTest extends AuthBaseTest {
 
     @Autowired
     private UserCredentialRepository credentialRepository;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
 
     @Test
     @DisplayName("회원가입 후 이메일 인증을 완료해야 로그인할 수 있다")
@@ -122,6 +126,50 @@ class AuthSignupTest extends AuthBaseTest {
         .then()
             .statusCode(200)
             .body("name", equalTo("회원가입 테스트"));
+
+        RestAssured.basePath = originalBasePath;
+    }
+
+    @Test
+    @DisplayName("Google 회원가입 후 발급된 accessToken으로 내 정보를 조회할 수 있다")
+    void googleSignup_accessTokenCanReadMe() {
+        String uniqueEmail = "google-signup" + System.currentTimeMillis() + "@test.com";
+        String tempToken = jwtTokenProvider.createOAuth2TempToken(
+            "google-sub-" + System.currentTimeMillis(),
+            uniqueEmail,
+            "https://example.com/profile.png"
+        );
+
+        TokenResponse tokenResponse = given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "tempToken": "%s",
+                  "name": "구글 가입",
+                  "phoneNumber": "010-1234-5678",
+                  "birthDate": "1990-01-01"
+                }
+                """.formatted(tempToken))
+        .when()
+            .post("/google/signup")
+        .then()
+            .statusCode(201)
+            .body("accessToken", notNullValue())
+            .body("refreshToken", notNullValue())
+            .extract()
+            .as(TokenResponse.class);
+
+        String originalBasePath = RestAssured.basePath;
+        RestAssured.basePath = "";
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(tokenResponse.accessToken()))
+        .when()
+            .get("/api/v1/users/me")
+        .then()
+            .statusCode(200)
+            .body("email", equalTo(uniqueEmail))
+            .body("name", equalTo("구글 가입"));
 
         RestAssured.basePath = originalBasePath;
     }

--- a/src/test/java/geumjeongyahak/e2e/security/StaticResourceSecurityTest.java
+++ b/src/test/java/geumjeongyahak/e2e/security/StaticResourceSecurityTest.java
@@ -1,0 +1,23 @@
+package geumjeongyahak.e2e.security;
+
+import static io.restassured.RestAssured.given;
+
+import geumjeongyahak.e2e.BaseE2ETest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("security")
+@DisplayName("E2E: 정적 리소스 보안")
+class StaticResourceSecurityTest extends BaseE2ETest {
+
+    @Test
+    @DisplayName("mock 이미지는 인증 없이 조회된다")
+    void mockImage_permitAll() {
+        given()
+        .when()
+            .get("/mock/event-field-day.png")
+        .then()
+            .statusCode(200);
+    }
+}

--- a/src/test/java/geumjeongyahak/unit/security/CustomUserDetailsServiceTest.java
+++ b/src/test/java/geumjeongyahak/unit/security/CustomUserDetailsServiceTest.java
@@ -1,0 +1,64 @@
+package geumjeongyahak.unit.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import geumjeongyahak.common.security.service.CustomUserDetails;
+import geumjeongyahak.common.security.service.CustomUserDetailsService;
+import geumjeongyahak.domain.auth.entity.UserCredential;
+import geumjeongyahak.domain.auth.enums.ProviderType;
+import geumjeongyahak.domain.auth.enums.RoleType;
+import geumjeongyahak.domain.auth.repository.UserCredentialRepository;
+import geumjeongyahak.domain.department.service.DepartmentPermissionProxyService;
+import geumjeongyahak.domain.users.entity.User;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class CustomUserDetailsServiceTest {
+
+    @Mock
+    private UserCredentialRepository userCredentialRepository;
+
+    @Mock
+    private DepartmentPermissionProxyService departmentPermissionProxyService;
+
+    @InjectMocks
+    private CustomUserDetailsService customUserDetailsService;
+
+    @Test
+    void loadUserByUserId_allowsGoogleOnlyUser() {
+        Long userId = 1L;
+        Long credentialId = 10L;
+        User user = User.builder()
+            .name("Google 사용자")
+            .email("google@test.com")
+            .role(RoleType.GUEST)
+            .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+        UserCredential credential = UserCredential.google(
+            user,
+            "google-sub",
+            "google@test.com",
+            true
+        );
+        ReflectionTestUtils.setField(credential, "id", credentialId);
+
+        given(userCredentialRepository.findByUserIdAndProvider(userId, ProviderType.LOCAL))
+            .willReturn(Optional.empty());
+        given(userCredentialRepository.findAllByUserId(userId)).willReturn(List.of(credential));
+        given(departmentPermissionProxyService.getEffectivePermissions(user)).willReturn(List.of());
+
+        CustomUserDetails userDetails = (CustomUserDetails) customUserDetailsService.loadUserByUserId(userId);
+
+        assertThat(userDetails.getUserId()).isEqualTo(userId);
+        assertThat(userDetails.getCredentialId()).isEqualTo(credentialId);
+        assertThat(userDetails.getUsername()).isEqualTo("google@test.com");
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -62,6 +62,7 @@ app:
   jwt:
     secret: ${JWT_SECRET:1mvd5sX+y8zbGg1nOK08et6KoWnanipf0DKrygENcd0UVF6IvIYfVTJ7UliwCvhb}
     access-exp-seconds: ${JWT_ACCESS_EXP_SECONDS:1800}
+    oauth2-temp-exp-seconds: ${JWT_OAUTH2_TEMP_EXP_SECONDS:300}
     refresh-exp-seconds: ${JWT_REFRESH_EXP_SECONDS:1209600}
   file:
     image:


### PR DESCRIPTION
## 개요

현재 로컬 변경과 stash에 있던 변경을 dev 기준으로 정리했습니다.

## 변경 유형

- [ ] 새 기능 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 문서 수정 (docs)
- [x] 테스트 (test)
- [x] 기타 (chore)

## 변경 내용

- Google 전용 계정도 인증 로드가 가능하도록 보완했습니다.
- 정적 `/mock/**` 리소스와 private network CORS 설정을 보완했습니다.
- 관리자 사용자/부서 권한 추가 화면에서 잘못된 권한 입력 시 error flash로 되돌아오게 했습니다.
- harness issue/PR 자동화 문서를 추가하되 기존 issue 템플릿과 기본 PR 구조를 유지했습니다.
- 생성형 harness task packet은 `.gitignore`에 추가했습니다.

## 관련 이슈

- 없음

## 스크린샷 (선택)

- 해당 없음

## 체크리스트

- [x] 코드 컨벤션을 준수했습니다
- [x] 테스트 코드를 작성/수정했습니다
- [x] 머지 전 `./gradlew test --rerun-tasks`가 통과합니다
- [x] 문서를 업데이트했습니다 (필요한 경우)

## 리뷰어에게

- `harness/runs/`와 `harness/tasks/issue-*-feature-task.md`는 로컬 생성물로 ignore됩니다.
- stash 내용은 커밋에 반영했지만 stash entry 자체는 백업으로 남겨두었습니다.

## 검증

- `git diff --check`
- `bash -n scripts/harness/collect-github-context.sh scripts/harness/draft-pr-body.sh scripts/harness/prepare-feature-task.sh scripts/harness/run-task.sh`
- `./gradlew test --rerun-tasks` (`BUILD SUCCESSFUL in 2m 41s`)