### PR TITLE
[FEAT] 링크 기반 인증 메일 플로우 적용

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
-name: Bug report
-about: Create a report to help us improve
-title: "[BUG] "
+name: Fix Request
+about: 수정이 필요한 문제를 제보합니다
+title: "[FIX] "
 labels: bug
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/workflows/validate-issue-title.yml
+++ b/.github/workflows/validate-issue-title.yml
@@ -1,0 +1,24 @@
+name: Validate Issue Title
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  issues: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check issue title prefix
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${ISSUE_TITLE}" =~ ^\[(FEAT|FIX)\]\ .+ ]]; then
+            echo "::error title=Invalid issue title::Issue title must start with '[FEAT] ' or '[FIX] '."
+            echo "Current title: ${ISSUE_TITLE}"
+            exit 1
+          fi

--- a/docs/convention/convention.md
+++ b/docs/convention/convention.md
@@ -186,4 +186,13 @@ domain/{도메인명}/
 
 - [PR 템플릿](./pr_template.md)
 - [Issue 템플릿 - Feature](./issue_feature_template.md)
-- [Issue 템플릿 - Bug](./issue_bug_template.md)
+- [Issue 템플릿 - Fix](./issue_bug_template.md)
+
+### 4.1 Issue 제목 규칙
+
+이슈 제목은 다음 형식을 사용합니다.
+
+```
+[FEAT] 새 기능 요약
+[FIX] 수정 사항 요약
+```

--- a/docs/convention/issue_bug_template.md
+++ b/docs/convention/issue_bug_template.md
@@ -1,6 +1,6 @@
-# Issue 템플릿 - Bug Report
+# Issue 템플릿 - Fix Request
 
-버그 리포트 시 사용하는 템플릿입니다.
+수정 요청 시 사용하는 템플릿입니다.
 
 ---
 
@@ -8,9 +8,9 @@
 
 ```markdown
 ---
-name: Bug Report
-about: 버그를 제보합니다
-title: '[BUG] '
+name: Fix Request
+about: 수정이 필요한 문제를 제보합니다
+title: '[FIX] '
 labels: bug
 assignees: ''
 ---

--- a/github/ISSUE_TEMPLATE/bug_report.md
+++ b/github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
-name: Bug Report
-about: 버그를 제보합니다
-title: '[BUG] '
+name: Fix Request
+about: 수정이 필요한 문제를 제보합니다
+title: '[FIX] '
 labels: bug
 assignees: ''
 ---

--- a/github/ISSUE_TEMPLATE/config.yml
+++ b/github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/src/main/java/geumjeongyahak/common/mail/TemplateMailSenderService.java
+++ b/src/main/java/geumjeongyahak/common/mail/TemplateMailSenderService.java
@@ -41,12 +41,12 @@ public class TemplateMailSenderService implements MailSenderService {
 
     @Override
     public MailDeliveryResult sendPasswordResetMail(String recipientEmail, String recipientName, String resetCode) {
-        String resetUrl = buildPasswordResetUrl(resetCode);
+        String resetUrl = buildPasswordResetUrl(recipientEmail, resetCode);
         return sendHtmlMail(
             "password-reset",
             PASSWORD_RESET_TEMPLATE,
             recipientEmail,
-            "금정야학 비밀번호 재설정 인증번호",
+            "금정야학 비밀번호 변경 안내",
             Map.of(
                 "name", defaultName(recipientName),
                 "resetCode", resetCode,
@@ -67,7 +67,7 @@ public class TemplateMailSenderService implements MailSenderService {
             "email-verification",
             EMAIL_VERIFICATION_TEMPLATE,
             recipientEmail,
-            "금정야학 이메일 인증번호",
+            "금정야학 이메일 인증 안내",
             Map.of(
                 "name", defaultName(recipientName),
                 "verificationCode", verificationCode,
@@ -136,8 +136,9 @@ public class TemplateMailSenderService implements MailSenderService {
             : MailDeliveryResult.skipped(templateKey, recipientEmail, message);
     }
 
-    private String buildPasswordResetUrl(String resetCode) {
+    private String buildPasswordResetUrl(String recipientEmail, String resetCode) {
         return UriComponentsBuilder.fromUriString(buildFrontendUrl(mailProperties.passwordResetPath()))
+            .queryParam("email", recipientEmail)
             .queryParam("code", resetCode)
             .toUriString();
     }

--- a/src/main/java/geumjeongyahak/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/geumjeongyahak/domain/auth/service/EmailVerificationService.java
@@ -135,11 +135,20 @@ public class EmailVerificationService {
         LocalDateTime expiresAt = requestedAt.plusMinutes(expirationMinutes);
         credential.issueEmailVerificationToken(passwordEncoder.encode(verificationCode), expiresAt, requestedAt);
         credentialRepository.save(credential);
-        mailSenderService.sendEmailVerificationMail(
-            credential.getCredentialEmail(),
-            credential.getUser().getName(),
-            verificationCode
-        );
+        try {
+            mailSenderService.sendEmailVerificationMail(
+                credential.getCredentialEmail(),
+                credential.getUser().getName(),
+                verificationCode
+            );
+        } catch (Exception exception) {
+            log.warn(
+                "이메일 인증 메일 발송 실패 - credentialId={}, email={}",
+                credential.getId(),
+                credential.getCredentialEmail(),
+                exception
+            );
+        }
         log.info("이메일 인증 메일 처리 완료: credentialId={}, expiresAt={}", credential.getId(), expiresAt);
     }
 

--- a/src/main/resources/templates/mail/email-verification.html
+++ b/src/main/resources/templates/mail/email-verification.html
@@ -5,33 +5,49 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>금정야학 이메일 인증</title>
 </head>
-<body style="margin:0;padding:0;background:#f6f8fb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI','Apple SD Gothic Neo','Noto Sans KR',Arial,sans-serif;color:#111827;">
-  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#f6f8fb;padding:32px 16px;">
+<body style="margin:0;padding:0;background:#f4f6f4;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI','Apple SD Gothic Neo','Noto Sans KR',Arial,sans-serif;color:#151a18;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#f4f6f4;padding:28px 14px;">
     <tr>
       <td align="center">
-        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:560px;background:#ffffff;border-radius:24px;overflow:hidden;border:1px solid #e5e7eb;box-shadow:0 18px 45px rgba(15,23,42,0.08);">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:560px;background:#ffffff;border:1px solid #dde6dc;border-radius:12px;overflow:hidden;">
           <tr>
-            <td style="background:#1d4ed8;padding:28px 32px;color:white;">
-              <div style="display:inline-block;background:#fef3c7;color:#92400e;border-radius:999px;padding:6px 12px;font-size:12px;font-weight:800;letter-spacing:.04em;">EMAIL VERIFY</div>
-              <h1 style="margin:16px 0 0;font-size:25px;line-height:1.4;font-weight:800;">금정야학 이메일 인증번호입니다.</h1>
+            <td style="padding:26px 28px 22px;border-top:6px solid #89ca6b;background:#ffffff;">
+              <div style="font-size:13px;font-weight:800;color:#4f9d34;letter-spacing:0;">금정열린배움터</div>
+              <h1 style="margin:10px 0 0;font-size:24px;line-height:1.42;font-weight:800;color:#151a18;letter-spacing:0;">회원가입 이메일 인증</h1>
+              <p style="margin:10px 0 0;font-size:14px;line-height:1.7;color:#52605a;">아래 버튼으로 금정야학 계정 인증을 완료해 주세요.</p>
             </td>
           </tr>
           <tr>
-            <td style="padding:32px;">
-              <p style="margin:0 0 16px;font-size:16px;line-height:1.8;"><strong th:text="${name}">금정야학 회원</strong>님, 회원가입을 완료하려면 이메일 인증이 필요합니다.</p>
-              <p style="margin:0 0 22px;font-size:14px;line-height:1.8;color:#4b5563;">아래 인증번호를 입력해 이메일 주소를 인증해 주세요. 인증이 완료된 뒤 로그인할 수 있습니다.</p>
-              <div style="text-align:center;background:#f8fafc;border:1px solid #e2e8f0;border-radius:20px;padding:26px 16px;margin:0 0 22px;">
-                <div style="font-size:13px;font-weight:800;color:#64748b;margin-bottom:10px;">인증번호</div>
-                <div style="font-size:38px;letter-spacing:.24em;font-weight:900;color:#1d4ed8;font-family:'SFMono-Regular',Consolas,monospace;" th:text="${verificationCode}">123456</div>
-                <div style="font-size:13px;color:#ef4444;margin-top:12px;"><span th:text="${expiresMinutes}">15</span>분 동안 유효합니다.</div>
-              </div>
-              <div style="text-align:center;margin:0 0 24px;">
-                <a th:href="${verificationUrl}" href="https://geumjeongschool.com/auth/email-verification" style="display:inline-block;background:#2563eb;color:#ffffff;text-decoration:none;font-size:15px;font-weight:800;border-radius:14px;padding:14px 22px;">이메일 인증 화면 열기</a>
-              </div>
-              <div style="border-top:1px solid #e5e7eb;padding-top:18px;">
-                <p style="margin:0 0 8px;font-size:13px;line-height:1.7;color:#6b7280;">보안을 위해 인증번호는 새로 발급받으면 이전 번호가 즉시 무효화됩니다.</p>
-                <p style="margin:0;font-size:13px;line-height:1.7;color:#6b7280;">버튼이 열리지 않으면 브라우저에서 아래 주소로 접속해 주세요:<br><span style="word-break:break-all;color:#2563eb;" th:text="${verificationUrl}">https://geumjeongschool.com/auth/email-verification</span></p>
-              </div>
+            <td style="padding:28px;">
+              <p style="margin:0 0 14px;font-size:16px;line-height:1.75;color:#151a18;">
+                <strong th:text="${name}">금정야학 회원</strong>님, 안녕하세요.
+              </p>
+              <p style="margin:0 0 22px;font-size:14px;line-height:1.8;color:#52605a;">
+                회원가입을 완료하려면 인증 화면으로 이동해 주세요. 버튼에는 인증에 필요한 정보가 포함되어 있습니다.
+              </p>
+              <table role="presentation" cellspacing="0" cellpadding="0" align="center" style="margin:0 auto 24px;">
+                <tr>
+                  <td align="center" style="background:#4f9d34;border-radius:8px;">
+                    <a th:href="${verificationUrl}" href="https://geumjeongschool.com/auth/email-verification" style="display:inline-block;padding:14px 22px;color:#ffffff;text-decoration:none;font-size:15px;font-weight:800;">이메일 인증하기</a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin:0 0 22px;font-size:13px;line-height:1.7;color:#da3a30;text-align:center;">
+                인증 링크는 <span th:text="${expiresMinutes}">15</span>분 동안 유효합니다.
+              </p>
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="border-top:1px solid #e6ece5;">
+                <tr>
+                  <td style="padding-top:18px;">
+                    <p style="margin:0 0 8px;font-size:13px;line-height:1.7;color:#6a746f;">새 인증 메일을 발급받으면 이전 링크는 사용할 수 없습니다.</p>
+                    <p style="margin:0;font-size:13px;line-height:1.7;color:#6a746f;">버튼이 열리지 않으면 아래 주소로 접속해 주세요.<br><span style="word-break:break-all;color:#4f9d34;" th:text="${verificationUrl}">https://geumjeongschool.com/auth/email-verification</span></p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:18px 28px;background:#f8f8f8;border-top:1px solid #e6ece5;font-size:12px;line-height:1.6;color:#7a837e;">
+              이 메일은 금정야학 회원가입 인증을 위해 발송되었습니다.
             </td>
           </tr>
         </table>

--- a/src/main/resources/templates/mail/password-reset.html
+++ b/src/main/resources/templates/mail/password-reset.html
@@ -3,35 +3,51 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>금정야학 비밀번호 재설정</title>
+  <title>금정야학 비밀번호 변경</title>
 </head>
-<body style="margin:0;padding:0;background:#f6f8fb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI','Apple SD Gothic Neo','Noto Sans KR',Arial,sans-serif;color:#111827;">
-  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#f6f8fb;padding:32px 16px;">
+<body style="margin:0;padding:0;background:#f4f6f4;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI','Apple SD Gothic Neo','Noto Sans KR',Arial,sans-serif;color:#151a18;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#f4f6f4;padding:28px 14px;">
     <tr>
       <td align="center">
-        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:560px;background:#ffffff;border-radius:24px;overflow:hidden;border:1px solid #e5e7eb;box-shadow:0 18px 45px rgba(15,23,42,0.08);">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:560px;background:#ffffff;border:1px solid #dde6dc;border-radius:12px;overflow:hidden;">
           <tr>
-            <td style="background:#0f172a;padding:28px 32px;color:white;">
-              <div style="display:inline-block;background:#f59e0b;color:#111827;border-radius:999px;padding:6px 12px;font-size:12px;font-weight:800;letter-spacing:.04em;">PASSWORD RESET</div>
-              <h1 style="margin:16px 0 0;font-size:25px;line-height:1.4;font-weight:800;">금정야학 비밀번호 재설정 인증번호입니다.</h1>
+            <td style="padding:26px 28px 22px;border-top:6px solid #89ca6b;background:#ffffff;">
+              <div style="font-size:13px;font-weight:800;color:#4f9d34;letter-spacing:0;">금정열린배움터</div>
+              <h1 style="margin:10px 0 0;font-size:24px;line-height:1.42;font-weight:800;color:#151a18;letter-spacing:0;">비밀번호 변경 안내</h1>
+              <p style="margin:10px 0 0;font-size:14px;line-height:1.7;color:#52605a;">아래 버튼으로 새 비밀번호를 설정해 주세요.</p>
             </td>
           </tr>
           <tr>
-            <td style="padding:32px;">
-              <p style="margin:0 0 16px;font-size:16px;line-height:1.8;"><strong th:text="${name}">금정야학 회원</strong>님, 비밀번호 재설정을 요청하셨습니다.</p>
-              <p style="margin:0 0 22px;font-size:14px;line-height:1.8;color:#4b5563;">아래 인증번호를 입력해 새 비밀번호를 설정해 주세요. 본인이 요청하지 않았다면 이 메일을 무시하셔도 됩니다.</p>
-              <div style="text-align:center;background:#f8fafc;border:1px solid #e2e8f0;border-radius:20px;padding:26px 16px;margin:0 0 22px;">
-                <div style="font-size:13px;font-weight:800;color:#64748b;margin-bottom:10px;">인증번호</div>
-                <div style="font-size:38px;letter-spacing:.24em;font-weight:900;color:#1d4ed8;font-family:'SFMono-Regular',Consolas,monospace;" th:text="${resetCode}">123456</div>
-                <div style="font-size:13px;color:#ef4444;margin-top:12px;"><span th:text="${expiresMinutes}">15</span>분 동안 유효합니다.</div>
-              </div>
-              <div style="text-align:center;margin:0 0 24px;">
-                <a th:href="${resetUrl}" href="https://geumjeongschool.com/auth/reset-password" style="display:inline-block;background:#2563eb;color:#ffffff;text-decoration:none;font-size:15px;font-weight:800;border-radius:14px;padding:14px 22px;">비밀번호 재설정 화면 열기</a>
-              </div>
-              <div style="border-top:1px solid #e5e7eb;padding-top:18px;">
-                <p style="margin:0 0 8px;font-size:13px;line-height:1.7;color:#6b7280;">보안을 위해 인증번호는 한 번 사용하면 즉시 만료됩니다.</p>
-                <p style="margin:0;font-size:13px;line-height:1.7;color:#6b7280;">버튼이 열리지 않으면 브라우저에서 아래 주소로 접속해 주세요:<br><span style="word-break:break-all;color:#2563eb;" th:text="${resetUrl}">https://geumjeongschool.com/auth/reset-password</span></p>
-              </div>
+            <td style="padding:28px;">
+              <p style="margin:0 0 14px;font-size:16px;line-height:1.75;color:#151a18;">
+                <strong th:text="${name}">금정야학 회원</strong>님, 비밀번호 변경 요청이 접수되었습니다.
+              </p>
+              <p style="margin:0 0 22px;font-size:14px;line-height:1.8;color:#52605a;">
+                비밀번호 변경 화면으로 이동하면 이메일과 인증번호가 함께 전달됩니다. 직접 요청하지 않았다면 이 메일을 무시해 주세요.
+              </p>
+              <table role="presentation" cellspacing="0" cellpadding="0" align="center" style="margin:0 auto 24px;">
+                <tr>
+                  <td align="center" style="background:#4f9d34;border-radius:8px;">
+                    <a th:href="${resetUrl}" href="https://geumjeongschool.com/auth/reset-password" style="display:inline-block;padding:14px 22px;color:#ffffff;text-decoration:none;font-size:15px;font-weight:800;">비밀번호 변경하기</a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin:0 0 22px;font-size:13px;line-height:1.7;color:#da3a30;text-align:center;">
+                비밀번호 변경 링크는 <span th:text="${expiresMinutes}">15</span>분 동안 유효합니다.
+              </p>
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="border-top:1px solid #e6ece5;">
+                <tr>
+                  <td style="padding-top:18px;">
+                    <p style="margin:0 0 8px;font-size:13px;line-height:1.7;color:#6a746f;">비밀번호 변경 링크는 한 번 사용하면 즉시 만료됩니다.</p>
+                    <p style="margin:0;font-size:13px;line-height:1.7;color:#6a746f;">버튼이 열리지 않으면 아래 주소로 접속해 주세요.<br><span style="word-break:break-all;color:#4f9d34;" th:text="${resetUrl}">https://geumjeongschool.com/auth/reset-password</span></p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:18px 28px;background:#f8f8f8;border-top:1px solid #e6ece5;font-size:12px;line-height:1.6;color:#7a837e;">
+              이 메일은 금정야학 계정의 비밀번호 변경 안내를 위해 발송되었습니다.
             </td>
           </tr>
         </table>

--- a/src/main/resources/templates/mail/signup-welcome.html
+++ b/src/main/resources/templates/mail/signup-welcome.html
@@ -3,32 +3,44 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>금정야학 가입 환영</title>
+  <title>금정야학 가입 안내</title>
 </head>
-<body style="margin:0;padding:0;background:#f6f8fb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI','Apple SD Gothic Neo','Noto Sans KR',Arial,sans-serif;color:#1f2937;">
-  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#f6f8fb;padding:32px 16px;">
+<body style="margin:0;padding:0;background:#f4f6f4;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI','Apple SD Gothic Neo','Noto Sans KR',Arial,sans-serif;color:#151a18;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#f4f6f4;padding:28px 14px;">
     <tr>
       <td align="center">
-        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:560px;background:#ffffff;border-radius:24px;overflow:hidden;border:1px solid #e5e7eb;box-shadow:0 18px 45px rgba(15,23,42,0.08);">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:560px;background:#ffffff;border:1px solid #dde6dc;border-radius:12px;overflow:hidden;">
           <tr>
-            <td style="background:linear-gradient(135deg,#1d4ed8 0%,#2563eb 50%,#f59e0b 100%);padding:28px 32px;color:white;">
-              <div style="font-size:14px;font-weight:700;letter-spacing:.08em;opacity:.9;">GEUMJEONG YAHㄱAK</div>
-              <h1 style="margin:14px 0 0;font-size:26px;line-height:1.35;font-weight:800;">배움을 잇는 공간,<br>금정야학에 오신 것을 환영합니다.</h1>
+            <td style="padding:26px 28px 22px;border-top:6px solid #89ca6b;background:#ffffff;">
+              <div style="font-size:13px;font-weight:800;color:#4f9d34;letter-spacing:0;">금정열린배움터</div>
+              <h1 style="margin:10px 0 0;font-size:24px;line-height:1.42;font-weight:800;color:#151a18;letter-spacing:0;">금정야학 가입을 환영합니다</h1>
+              <p style="margin:10px 0 0;font-size:14px;line-height:1.7;color:#52605a;">배움과 봉사를 이어가는 공간에서 함께하겠습니다.</p>
             </td>
           </tr>
           <tr>
-            <td style="padding:32px;">
-              <p style="margin:0 0 16px;font-size:17px;line-height:1.7;"><strong th:text="${name}">금정야학 회원</strong>님, 가입이 완료되었습니다.</p>
-              <p style="margin:0 0 24px;font-size:15px;line-height:1.8;color:#4b5563;">금정야학 플랫폼에서 수업 일정, 출석, 요청 사항을 더 편하게 확인할 수 있습니다. 따뜻하고 안정적인 학습 경험을 위해 필요한 알림을 이 메일로 안내드릴게요.</p>
-              <div style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:18px;padding:18px 20px;margin:0 0 24px;">
-                <div style="font-size:14px;font-weight:800;color:#1d4ed8;margin-bottom:8px;">다음 단계</div>
-                <ul style="margin:0;padding-left:18px;color:#374151;font-size:14px;line-height:1.8;">
-                  <li>프로필 정보를 확인해 주세요.</li>
-                  <li>담당 수업과 요청 내역은 로그인 후 확인할 수 있습니다.</li>
-                  <li>문의가 있으면 금정야학 운영진에게 알려주세요.</li>
-                </ul>
-              </div>
-              <p style="margin:0;font-size:13px;line-height:1.7;color:#6b7280;">이 메일은 금정야학 계정 가입 안내를 위해 발송되었습니다.</p>
+            <td style="padding:28px;">
+              <p style="margin:0 0 14px;font-size:16px;line-height:1.75;color:#151a18;">
+                <strong th:text="${name}">금정야학 회원</strong>님, 가입이 완료되었습니다.
+              </p>
+              <p style="margin:0 0 22px;font-size:14px;line-height:1.8;color:#52605a;">
+                금정야학 플랫폼에서 수업 일정, 출석, 요청 사항을 확인할 수 있습니다. 필요한 안내는 이 메일 주소로 전달됩니다.
+              </p>
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#eef9e6;border:1px solid #cfecc0;border-radius:10px;margin:0 0 22px;">
+                <tr>
+                  <td style="padding:18px 20px;">
+                    <div style="font-size:14px;font-weight:800;color:#4f9d34;margin-bottom:10px;">가입 후 확인할 내용</div>
+                    <p style="margin:0 0 6px;font-size:14px;line-height:1.7;color:#2f3834;">1. 프로필 정보가 정확한지 확인해 주세요.</p>
+                    <p style="margin:0 0 6px;font-size:14px;line-height:1.7;color:#2f3834;">2. 담당 수업과 요청 내역은 로그인 후 확인할 수 있습니다.</p>
+                    <p style="margin:0;font-size:14px;line-height:1.7;color:#2f3834;">3. 문의가 있으면 금정야학 운영진에게 알려주세요.</p>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin:0;font-size:13px;line-height:1.7;color:#6a746f;">이 메일은 금정야학 계정 가입 안내를 위해 발송되었습니다.</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:18px 28px;background:#f8f8f8;border-top:1px solid #e6ece5;font-size:12px;line-height:1.6;color:#7a837e;">
+              금정열린배움터와 함께해 주셔서 감사합니다.
             </td>
           </tr>
         </table>

--- a/src/test/java/geumjeongyahak/unit/auth/EmailVerificationServiceTest.java
+++ b/src/test/java/geumjeongyahak/unit/auth/EmailVerificationServiceTest.java
@@ -77,6 +77,19 @@ class EmailVerificationServiceTest {
     }
 
     @Test
+    void issueVerification_keepsTokenWhenMailDeliveryFails() {
+        UserCredential credential = unverifiedCredential();
+        given(passwordEncoder.encode(RAW_CODE)).willReturn(TOKEN_HASH);
+        given(mailSenderService.sendEmailVerificationMail(eq(EMAIL), eq("이메일 인증 사용자"), eq(RAW_CODE)))
+            .willThrow(new RuntimeException("smtp down"));
+
+        emailVerificationService.issueVerification(credential);
+
+        assertThat(credential.getEmailVerificationTokenHash()).isEqualTo(TOKEN_HASH);
+        verify(credentialRepository).save(credential);
+    }
+
+    @Test
     void confirm_marksEmailVerifiedAndClearsVerificationToken() {
         UserCredential credential = unverifiedCredential();
         credential.issueEmailVerificationToken(TOKEN_HASH, LocalDateTime.now(CLOCK).plusMinutes(15), LocalDateTime.now(CLOCK));


### PR DESCRIPTION
## Summary
- 회원가입 인증 메일 발송 실패가 가입 API 500으로 이어지지 않도록 토큰 발급 흐름을 유지했습니다.
- 이메일 인증/비밀번호 변경 메일을 링크 기반 플로우로 정리하고, 비밀번호 변경 링크에 email/code 파라미터를 포함했습니다.
- 이슈 제목을 `[FEAT] ...`, `[FIX] ...` 형식으로 맞추도록 템플릿과 검증 워크플로우를 추가했습니다.

## Test Plan
- `./gradlew test --tests geumjeongyahak.unit.auth.EmailVerificationServiceTest --tests geumjeongyahak.unit.auth.PasswordResetServiceTest --stacktrace`
- issue title regex smoke test
- `bash -n .github/workflows/validate-issue-title.yml`
