### PR TITLE
fix(global): Tailscale 재설정 옵션 추가

### DIFF
--- a/scripts/gcp/04_db/01_install-db-service.sh
+++ b/scripts/gcp/04_db/01_install-db-service.sh
@@ -18,7 +18,7 @@ configure_tailscale() {
     sudo tailscale set --accept-dns="${accept_dns}"
     if [[ -n "${tags}" ]]; then
       sudo tailscale set --advertise-tags="${tags}" 2>/dev/null \
-        || sudo tailscale up --advertise-tags="${tags}" --accept-dns="${accept_dns}"
+        || sudo tailscale up --reset --advertise-tags="${tags}" --accept-dns="${accept_dns}"
     fi
     echo "tailscale already authenticated: $(sudo tailscale ip -4)"
     return 0

--- a/scripts/gcp/05_app/01_install-app-service.sh
+++ b/scripts/gcp/05_app/01_install-app-service.sh
@@ -51,7 +51,7 @@ configure_tailscale() {
     sudo tailscale set --accept-dns="${accept_dns}"
     if [[ -n "${tags}" ]]; then
       sudo tailscale set --advertise-tags="${tags}" 2>/dev/null \
-        || sudo tailscale up --advertise-tags="${tags}" --accept-dns="${accept_dns}"
+        || sudo tailscale up --reset --advertise-tags="${tags}" --accept-dns="${accept_dns}"
     fi
     echo "tailscale already authenticated: $(sudo tailscale ip -4)"
     return 0


### PR DESCRIPTION
## 변경 사항
- 이미 인증된 Tailscale 노드에서 ACL tag 설정 fallback으로 `tailscale up`을 호출할 때 `--reset`을 함께 전달합니다.
- app/db 설치 스크립트에 동일하게 반영했습니다.

## 원인
- 기존 노드에 `--advertise-routes` 같은 non-default 설정이 남아 있으면 Tailscale이 `tailscale up` 실행 시 모든 non-default 플래그를 명시하라고 요구합니다.
- 이 배포 스크립트는 simple-node 모드로 subnet route를 광고하지 않는 정책이라, fallback 재설정 시 stale 설정을 초기화해야 합니다.

## 검증
- `bash -n scripts/gcp/04_db/01_install-db-service.sh scripts/gcp/05_app/01_install-app-service.sh`

Closes #178