### PR TITLE
fix(auth): 이메일 인증 및 재가입 흐름 수정

### DIFF
--- a/src/main/java/geumjeongyahak/common/security/config/WebSecurityConfig.java
+++ b/src/main/java/geumjeongyahak/common/security/config/WebSecurityConfig.java
@@ -104,6 +104,7 @@ public class WebSecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 // 관리자 로그인 페이지로 redirect 용
                 .requestMatchers(HttpMethod.GET, "/").permitAll()
+                .requestMatchers(HttpMethod.GET, "/auth/email-verification").permitAll()
                 // 정적 리소스 및 문서/헬스체크
                 .requestMatchers("/favicon.ico", "/sw.js", "/icons/**", "/mock/**", "/site.webmanifest", "/actuator/health", "/actuator/prometheus", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/swagger-ui").permitAll()
                 // 인증 API (로그인, 회원가입, 토큰 재발급, 로그아웃)

--- a/src/main/java/geumjeongyahak/domain/auth/service/LocalAuthService.java
+++ b/src/main/java/geumjeongyahak/domain/auth/service/LocalAuthService.java
@@ -13,6 +13,7 @@ import geumjeongyahak.domain.auth.entity.UserCredential;
 import geumjeongyahak.domain.auth.enums.ProviderType;
 import geumjeongyahak.domain.auth.enums.RoleType;
 import geumjeongyahak.domain.auth.exception.AuthErrorCode;
+import geumjeongyahak.domain.auth.exception.DuplicateCredentialException;
 import geumjeongyahak.domain.auth.exception.InvalidRefreshTokenException;
 import geumjeongyahak.domain.auth.v1.dto.request.LocalLoginRequest;
 import geumjeongyahak.domain.auth.v1.dto.request.LocalSignupRequest;
@@ -85,11 +86,38 @@ public class LocalAuthService {
     public AuthMessageResponse signup(LocalSignupRequest request) {
         log.debug("회원가입 시도: {}", request.email());
 
+        if (request.email() != null
+            && userCredentialService.existsByCredentialEmailAndProvider(request.email(), ProviderType.GOOGLE)) {
+            throw new DuplicateCredentialException("이미 Google 계정으로 가입된 이메일입니다. Google로 로그인해 주세요.");
+        }
+
+        var localCredential = userCredentialService.findOptionalByCredentialEmailAndProvider(
+            request.email(),
+            ProviderType.LOCAL
+        );
+        if (localCredential.isPresent()) {
+            UserCredential credential = localCredential.get();
+            if (!credential.getUser().isDeleted()) {
+                throw new DuplicateEmailException(request.email());
+            }
+            credential.getUser().reactivateForSignup(
+                request.name(),
+                request.phoneNumber(),
+                UserBirthDateConverter.toResidentRegistrationNumberPrefix(request.birthDate())
+            );
+            credential.changePassword(passwordEncoder.encode(request.password()));
+            credential.setEmailVerified(false);
+            credential.clearEmailVerificationToken();
+            emailVerificationService.issueVerification(credential);
+            log.info("비활성 사용자 재가입 성공: userId={}, email={}", credential.getUser().getId(), request.email());
+            return AuthMessageResponse.of("회원가입이 완료되었습니다. 이메일 인증 후 로그인해 주세요.");
+        }
+
         if (request.email() != null && userProxyService.existsByEmailIncludingDeleted(request.email())) {
             throw new DuplicateEmailException(request.email());
         }
 
-        User user = User.builder()
+        User savedUser = userProxyService.save(User.builder()
             .name(request.name())
             .email(request.email())
             .phoneNumber(request.phoneNumber())
@@ -97,9 +125,7 @@ public class LocalAuthService {
                 UserBirthDateConverter.toResidentRegistrationNumberPrefix(request.birthDate())
             )
             .role(RoleType.GUEST)
-            .build();
-
-        User savedUser = userProxyService.save(user);
+            .build());
         UserCredential credential = userCredentialService.createLocalCredential(
             savedUser,
             request.email(),

--- a/src/main/java/geumjeongyahak/domain/auth/v1/controller/EmailVerificationLinkController.java
+++ b/src/main/java/geumjeongyahak/domain/auth/v1/controller/EmailVerificationLinkController.java
@@ -1,0 +1,25 @@
+package geumjeongyahak.domain.auth.v1.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Controller
+public class EmailVerificationLinkController {
+
+    @GetMapping("/auth/email-verification")
+    public void redirectToEmailVerificationApi(
+            @RequestParam String email,
+            @RequestParam("code") String verificationCode,
+            HttpServletResponse response
+    ) throws IOException {
+        response.sendRedirect(UriComponentsBuilder
+            .fromPath("/api/v1/auth/email-verification/confirm")
+            .queryParam("email", email)
+            .queryParam("code", verificationCode)
+            .toUriString());
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/auth/v1/controller/LocalAuthController.java
+++ b/src/main/java/geumjeongyahak/domain/auth/v1/controller/LocalAuthController.java
@@ -2,14 +2,20 @@ package geumjeongyahak.domain.auth.v1.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+import geumjeongyahak.common.exception.BusinessException;
+import geumjeongyahak.common.mail.MailProperties;
 import geumjeongyahak.common.security.service.CustomUserDetails;
+import geumjeongyahak.domain.auth.exception.AuthErrorCode;
 import geumjeongyahak.domain.auth.service.EmailVerificationService;
 import geumjeongyahak.domain.auth.service.LocalAuthService;
 import geumjeongyahak.domain.auth.service.PasswordResetService;
@@ -33,6 +39,7 @@ public class LocalAuthController {
     private final LocalAuthService localLoginService;
     private final PasswordResetService passwordResetService;
     private final EmailVerificationService emailVerificationService;
+    private final MailProperties mailProperties;
 
     @Operation(
         summary = "로그인",
@@ -81,6 +88,34 @@ public class LocalAuthController {
         log.debug("POST /api/v1/auth/email-verification/confirm - 이메일 인증 요청");
         emailVerificationService.confirm(request.email(), request.verificationCode());
         return ResponseEntity.ok(AuthMessageResponse.of("이메일 인증이 완료되었습니다. 로그인해 주세요."));
+    }
+
+    @Operation(
+        summary = "이메일 인증 링크 처리",
+        description = "메일의 인증 버튼에서 호출되며, 인증 결과를 프론트엔드 인증 결과 페이지로 리다이렉트합니다."
+    )
+    @GetMapping("/email-verification/confirm")
+    public void confirmEmailVerificationLink(
+            @RequestParam String email,
+            @RequestParam("code") String verificationCode,
+            HttpServletResponse response
+    ) throws IOException {
+        String status = "success";
+        try {
+            emailVerificationService.confirm(email, verificationCode);
+        } catch (BusinessException exception) {
+            status = AuthErrorCode.EMAIL_VERIFICATION_TOKEN_EXPIRED.getCode().equals(exception.getCode())
+                ? "expired"
+                : "invalid";
+            log.info("이메일 인증 링크 처리 실패 - email={}, status={}", email, status);
+        }
+
+        response.sendRedirect(UriComponentsBuilder
+            .fromUriString(mailProperties.frontendBaseUrl())
+            .replacePath("/auth/email-verification")
+            .queryParam("status", status)
+            .queryParam("email", email)
+            .toUriString());
     }
 
     @Operation(

--- a/src/main/java/geumjeongyahak/domain/users/entity/User.java
+++ b/src/main/java/geumjeongyahak/domain/users/entity/User.java
@@ -156,6 +156,20 @@ public class User extends BaseEntity {
         this.deletedAt = LocalDateTime.now();
     }
 
+    public void reactivateForSignup(String name, String phoneNumber, String residentRegistrationNumberPrefix) {
+        this.isDeleted = false;
+        this.deletedAt = null;
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+        this.residentRegistrationNumberPrefix = residentRegistrationNumberPrefix;
+        this.department = null;
+        this.classroom = null;
+        this.teacherStartAt = null;
+        this.teacherEndAt = null;
+        this.role = RoleType.GUEST;
+        clearPermissions();
+    }
+
     private Optional<UserCredential> findLocalCredential() {
         return credentials.stream()
             .filter(credential -> credential.getProvider() == ProviderType.LOCAL)

--- a/src/test/java/geumjeongyahak/e2e/auth/AuthSignupTest.java
+++ b/src/test/java/geumjeongyahak/e2e/auth/AuthSignupTest.java
@@ -7,9 +7,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import geumjeongyahak.common.security.jwt.JwtTokenProvider;
 import geumjeongyahak.domain.auth.enums.ProviderType;
+import geumjeongyahak.domain.auth.enums.RoleType;
 import geumjeongyahak.domain.auth.repository.UserCredentialRepository;
 import geumjeongyahak.domain.auth.v1.dto.request.LocalSignupRequest;
 import geumjeongyahak.domain.auth.v1.dto.response.TokenResponse;
+import geumjeongyahak.domain.users.repository.UserRepository;
 import geumjeongyahak.e2e.TestStorageConfig.ControlledMailSenderService;
 import java.time.LocalDate;
 
@@ -25,6 +27,9 @@ class AuthSignupTest extends AuthBaseTest {
 
     @Autowired
     private UserCredentialRepository credentialRepository;
+
+    @Autowired
+    private UserRepository userRepository;
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
@@ -175,6 +180,161 @@ class AuthSignupTest extends AuthBaseTest {
     }
 
     @Test
+    @DisplayName("메일 인증 링크는 인증 후 프론트 결과 페이지로 리다이렉트한다")
+    void emailVerification_LinkRedirectsToFrontendResultPage() {
+        String uniqueEmail = "verify-link" + System.currentTimeMillis() + "@test.com";
+        LocalSignupRequest req = new LocalSignupRequest(
+            "password123!",
+            "메일 링크 인증",
+            uniqueEmail,
+            "010-1234-5678",
+            LocalDate.of(1990, 1, 1)
+        );
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(req)
+        .when()
+            .post("/signup")
+        .then()
+            .statusCode(201);
+
+        String verificationCode = mailSenderService.getLastEmailVerificationCode();
+
+        given()
+            .redirects().follow(false)
+            .queryParam("email", uniqueEmail)
+            .queryParam("code", verificationCode)
+        .when()
+            .get("/email-verification/confirm")
+        .then()
+            .statusCode(302)
+            .header("Location", startsWith("https://geumjeongschool.com/auth/email-verification?status=success"));
+
+        var verifiedCredential = credentialRepository.findByCredentialEmailAndProvider(uniqueEmail, ProviderType.LOCAL)
+            .orElseThrow();
+        assertThat(verifiedCredential.isEmailVerified()).isTrue();
+    }
+
+    @Test
+    @DisplayName("프론트 인증 경로가 백엔드로 들어와도 인증 API로 리다이렉트한다")
+    void emailVerification_FrontendPathOnApiRedirectsToVerificationEndpoint() {
+        String uniqueEmail = "verify-api-host" + System.currentTimeMillis() + "@test.com";
+        LocalSignupRequest req = new LocalSignupRequest(
+            "password123!",
+            "API 호스트 메일 링크",
+            uniqueEmail,
+            "010-1234-5678",
+            LocalDate.of(1990, 1, 1)
+        );
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(req)
+        .when()
+            .post("/signup")
+        .then()
+            .statusCode(201);
+
+        String verificationCode = mailSenderService.getLastEmailVerificationCode();
+        String originalBasePath = RestAssured.basePath;
+        RestAssured.basePath = "";
+
+        given()
+            .redirects().follow(false)
+            .queryParam("email", uniqueEmail)
+            .queryParam("code", verificationCode)
+        .when()
+            .get("/auth/email-verification")
+        .then()
+            .statusCode(302)
+            .header("Location", containsString("/api/v1/auth/email-verification/confirm?"));
+
+        RestAssured.basePath = originalBasePath;
+    }
+
+    @Test
+    @DisplayName("메일 인증 링크 실패도 프론트 결과 페이지로 리다이렉트한다")
+    void emailVerification_InvalidLinkRedirectsToFrontendResultPage() {
+        String uniqueEmail = "verify-fail" + System.currentTimeMillis() + "@test.com";
+        LocalSignupRequest req = new LocalSignupRequest(
+            "password123!",
+            "메일 링크 실패",
+            uniqueEmail,
+            "010-1234-5678",
+            LocalDate.of(1990, 1, 1)
+        );
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(req)
+        .when()
+            .post("/signup")
+        .then()
+            .statusCode(201);
+
+        given()
+            .redirects().follow(false)
+            .queryParam("email", uniqueEmail)
+            .queryParam("code", "000000")
+        .when()
+            .get("/email-verification/confirm")
+        .then()
+            .statusCode(302)
+            .header("Location", startsWith("https://geumjeongschool.com/auth/email-verification?status=invalid"));
+    }
+
+    @Test
+    @DisplayName("Google 계정 이메일로 Local 회원가입하면 거절한다")
+    void signup_WithExistingGoogleEmailIsRejected() {
+        String uniqueEmail = "google-to-local" + System.currentTimeMillis() + "@test.com";
+        String tempToken = jwtTokenProvider.createOAuth2TempToken(
+            "google-sub-local-" + System.currentTimeMillis(),
+            uniqueEmail,
+            "https://example.com/profile.png"
+        );
+
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                  "tempToken": "%s",
+                  "name": "구글 기존 사용자",
+                  "phoneNumber": "010-1234-5678",
+                  "birthDate": "1990-01-01"
+                }
+                """.formatted(tempToken))
+        .when()
+            .post("/google/signup")
+        .then()
+            .statusCode(201);
+
+        Long googleUserId = userTestHelper.getUser(uniqueEmail).getId();
+
+        LocalSignupRequest localReq = new LocalSignupRequest(
+            "password123!",
+            "로컬 가입 요청 이름",
+            uniqueEmail,
+            "010-9999-8888",
+            LocalDate.of(2000, 1, 1)
+        );
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(localReq)
+        .when()
+            .post("/signup")
+        .then()
+            .statusCode(409)
+            .body("code", equalTo("AUTH007"))
+            .body("detail", equalTo("이미 Google 계정으로 가입된 이메일입니다. Google로 로그인해 주세요."));
+
+        assertThat(credentialRepository.findByCredentialEmailAndProvider(uniqueEmail, ProviderType.LOCAL))
+            .isEmpty();
+        assertThat(userTestHelper.getUser(uniqueEmail).getId()).isEqualTo(googleUserId);
+    }
+
+    @Test
     @DisplayName("중복된 이메일로 회원가입 실패(409 Conflict)")
     void signup_DuplicateEmail() {
         LocalSignupRequest req = new LocalSignupRequest(
@@ -193,6 +353,60 @@ class AuthSignupTest extends AuthBaseTest {
         .then()
             .statusCode(409)
             .log().all();
+    }
+
+    @Test
+    @DisplayName("비활성화된 Local 사용자 이메일은 재가입할 수 있다")
+    void signup_DeactivatedLocalUserEmailCanSignupAgain() {
+        String uniqueEmail = "resignup" + System.currentTimeMillis() + "@test.com";
+        LocalSignupRequest firstReq = new LocalSignupRequest(
+            "password123!",
+            "첫 가입",
+            uniqueEmail,
+            "010-1234-5678",
+            LocalDate.of(1990, 1, 1)
+        );
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(firstReq)
+        .when()
+            .post("/signup")
+        .then()
+            .statusCode(201);
+
+        var deactivatedUser = userRepository.findByEmail(uniqueEmail).orElseThrow();
+        deactivatedUser.softDelete();
+        userRepository.save(deactivatedUser);
+
+        LocalSignupRequest secondReq = new LocalSignupRequest(
+            "newpassword123!",
+            "재가입",
+            uniqueEmail,
+            "010-9999-8888",
+            LocalDate.of(2000, 1, 1)
+        );
+
+        given()
+            .contentType(ContentType.JSON)
+            .body(secondReq)
+        .when()
+            .post("/signup")
+        .then()
+            .statusCode(201)
+            .body("message", equalTo("회원가입이 완료되었습니다. 이메일 인증 후 로그인해 주세요."));
+
+        var reactivatedUser = userRepository.findByEmail(uniqueEmail).orElseThrow();
+        assertThat(reactivatedUser.getId()).isEqualTo(deactivatedUser.getId());
+        assertThat(reactivatedUser.isDeleted()).isFalse();
+        assertThat(reactivatedUser.getName()).isEqualTo("재가입");
+        assertThat(reactivatedUser.getPhoneNumber()).isEqualTo("010-9999-8888");
+        assertThat(reactivatedUser.getRole()).isEqualTo(RoleType.GUEST);
+
+        var credential = credentialRepository.findByCredentialEmailAndProvider(uniqueEmail, ProviderType.LOCAL)
+            .orElseThrow();
+        assertThat(credential.isEmailVerified()).isFalse();
+        assertThat(credential.getEmailVerificationTokenHash()).isNotBlank();
     }
 
     @Test


### PR DESCRIPTION
## Summary

- 이메일 인증 링크 클릭 시 JSON 401 대신 프론트 결과 페이지로 리디렉션되도록 확인 엔드포인트와 공개 alias를 추가했습니다.
- Google 계정 이메일로 로컬 회원가입을 시도하면 명확히 거부하도록 처리했습니다.
- soft delete된 로컬 계정은 재가입 시 같은 사용자 row를 재활성화하고 인증 메일을 다시 발송하도록 수정했습니다.

## Root Cause

- 이메일의 `/auth/email-verification` 링크가 백엔드 호스트에서 열릴 경우 Spring Security 보호 대상이어서 `AUTH001` JSON이 그대로 반환됐습니다.
- 회원가입 중복 검사가 soft delete된 로컬 사용자와 활성 사용자를 구분하지 않았습니다.

## Test Plan

- [x] `./gradlew test --tests geumjeongyahak.e2e.auth.AuthSignupTest --tests geumjeongyahak.unit.auth.EmailVerificationServiceTest --tests geumjeongyahak.unit.users.UserCrudServiceDeactivationTest --tests geumjeongyahak.e2e.auth.AuthLoginTest --tests geumjeongyahak.e2e.users.UserDeleteTest`

## Related

- Frontend PR: https://github.com/Geumjeongyahak/Frontend/pull/182

Closes #180