### PR TITLE
fix(auth): 이메일 인증 링크 보안 강화

### DIFF
--- a/src/main/java/geumjeongyahak/common/mail/MailProperties.java
+++ b/src/main/java/geumjeongyahak/common/mail/MailProperties.java
@@ -31,7 +31,7 @@ public record MailProperties(
             passwordResetExpirationMinutes = 15;
         }
         if (emailVerificationPath == null || emailVerificationPath.isBlank()) {
-            emailVerificationPath = "/auth/email-verification";
+            emailVerificationPath = "/api/v1/auth/email-verification/confirm";
         }
         if (emailVerificationExpirationMinutes <= 0) {
             emailVerificationExpirationMinutes = 15;

--- a/src/main/java/geumjeongyahak/common/mail/TemplateMailSenderService.java
+++ b/src/main/java/geumjeongyahak/common/mail/TemplateMailSenderService.java
@@ -60,9 +60,9 @@ public class TemplateMailSenderService implements MailSenderService {
     public MailDeliveryResult sendEmailVerificationMail(
         String recipientEmail,
         String recipientName,
-        String verificationCode
+        String verificationToken
     ) {
-        String verificationUrl = buildEmailVerificationUrl(recipientEmail, verificationCode);
+        String verificationUrl = buildEmailVerificationUrl(verificationToken);
         return sendHtmlMail(
             "email-verification",
             EMAIL_VERIFICATION_TEMPLATE,
@@ -70,7 +70,6 @@ public class TemplateMailSenderService implements MailSenderService {
             "금정야학 이메일 인증 안내",
             Map.of(
                 "name", defaultName(recipientName),
-                "verificationCode", verificationCode,
                 "verificationUrl", verificationUrl,
                 "expiresMinutes", mailProperties.emailVerificationExpirationMinutes()
             )
@@ -143,10 +142,9 @@ public class TemplateMailSenderService implements MailSenderService {
             .toUriString();
     }
 
-    private String buildEmailVerificationUrl(String recipientEmail, String verificationCode) {
+    private String buildEmailVerificationUrl(String verificationToken) {
         return UriComponentsBuilder.fromUriString(buildFrontendUrl(mailProperties.emailVerificationPath()))
-            .queryParam("email", recipientEmail)
-            .queryParam("code", verificationCode)
+            .queryParam("token", verificationToken)
             .toUriString();
     }
 

--- a/src/main/java/geumjeongyahak/domain/auth/repository/UserCredentialRepository.java
+++ b/src/main/java/geumjeongyahak/domain/auth/repository/UserCredentialRepository.java
@@ -14,6 +14,8 @@ public interface UserCredentialRepository extends JpaRepository<UserCredential, 
     Optional<UserCredential> findByUserIdAndProvider(Long userId, ProviderType provider);
     
     Optional<UserCredential> findByCredentialEmailAndProvider(String credentialEmail, ProviderType provider);
+
+    Optional<UserCredential> findByEmailVerificationTokenHash(String emailVerificationTokenHash);
     
     boolean existsByCredentialEmail(String credentialEmail);
 

--- a/src/main/java/geumjeongyahak/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/geumjeongyahak/domain/auth/service/EmailVerificationService.java
@@ -8,12 +8,15 @@ import geumjeongyahak.domain.auth.entity.UserCredential;
 import geumjeongyahak.domain.auth.enums.ProviderType;
 import geumjeongyahak.domain.auth.exception.AuthErrorCode;
 import geumjeongyahak.domain.auth.repository.UserCredentialRepository;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.HexFormat;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,7 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class EmailVerificationService {
 
     private final UserCredentialRepository credentialRepository;
-    private final PasswordEncoder passwordEncoder;
     private final MailSenderService mailSenderService;
     private final Clock clock;
     private final Supplier<String> verificationCodeSupplier;
@@ -33,31 +35,27 @@ public class EmailVerificationService {
     @Autowired
     public EmailVerificationService(
         UserCredentialRepository credentialRepository,
-        PasswordEncoder passwordEncoder,
         MailSenderService mailSenderService,
         Clock clock,
         MailProperties mailProperties
     ) {
         this(
             credentialRepository,
-            passwordEncoder,
             mailSenderService,
             clock,
-            new NumericCodeGenerator(),
+            new UrlTokenGenerator(),
             mailProperties.emailVerificationExpirationMinutes()
         );
     }
 
     public EmailVerificationService(
         UserCredentialRepository credentialRepository,
-        PasswordEncoder passwordEncoder,
         MailSenderService mailSenderService,
         Clock clock,
         Supplier<String> verificationCodeSupplier
     ) {
         this(
             credentialRepository,
-            passwordEncoder,
             mailSenderService,
             clock,
             verificationCodeSupplier,
@@ -67,14 +65,12 @@ public class EmailVerificationService {
 
     private EmailVerificationService(
         UserCredentialRepository credentialRepository,
-        PasswordEncoder passwordEncoder,
         MailSenderService mailSenderService,
         Clock clock,
         Supplier<String> verificationCodeSupplier,
         long expirationMinutes
     ) {
         this.credentialRepository = credentialRepository;
-        this.passwordEncoder = passwordEncoder;
         this.mailSenderService = mailSenderService;
         this.clock = clock;
         this.verificationCodeSupplier = verificationCodeSupplier;
@@ -98,8 +94,21 @@ public class EmailVerificationService {
             .filter(candidate -> !candidate.getUser().isDeleted())
             .orElseThrow(() -> new BusinessException(AuthErrorCode.EMAIL_VERIFICATION_TOKEN_INVALID));
 
+        confirmCredential(credential, verificationCode);
+    }
+
+    @Transactional
+    public void confirmByToken(String token) {
+        UserCredential credential = credentialRepository.findByEmailVerificationTokenHash(hashToken(token))
+            .filter(candidate -> !candidate.getUser().isDeleted())
+            .orElseThrow(() -> new BusinessException(AuthErrorCode.EMAIL_VERIFICATION_TOKEN_INVALID));
+
+        confirmCredential(credential, token);
+    }
+
+    private void confirmCredential(UserCredential credential, String token) {
         if (credential.getEmailVerificationTokenHash() == null
-            || !passwordEncoder.matches(verificationCode, credential.getEmailVerificationTokenHash())) {
+            || !hashToken(token).equals(credential.getEmailVerificationTokenHash())) {
             credential.recordEmailVerificationFailure(MAX_FAILED_ATTEMPTS);
             credentialRepository.save(credential);
             throw new BusinessException(AuthErrorCode.EMAIL_VERIFICATION_TOKEN_INVALID);
@@ -130,16 +139,16 @@ public class EmailVerificationService {
 
     private void issueVerificationCode(UserCredential credential) {
         validateCooldown(credential.getEmailVerificationRequestedAt());
-        String verificationCode = verificationCodeSupplier.get();
+        String verificationToken = verificationCodeSupplier.get();
         LocalDateTime requestedAt = LocalDateTime.now(clock);
         LocalDateTime expiresAt = requestedAt.plusMinutes(expirationMinutes);
-        credential.issueEmailVerificationToken(passwordEncoder.encode(verificationCode), expiresAt, requestedAt);
+        credential.issueEmailVerificationToken(hashToken(verificationToken), expiresAt, requestedAt);
         credentialRepository.save(credential);
         try {
             mailSenderService.sendEmailVerificationMail(
                 credential.getCredentialEmail(),
                 credential.getUser().getName(),
-                verificationCode
+                verificationToken
             );
         } catch (Exception exception) {
             log.warn(
@@ -155,6 +164,15 @@ public class EmailVerificationService {
     private void validateCooldown(LocalDateTime requestedAt) {
         if (requestedAt != null && requestedAt.plusSeconds(RESEND_COOLDOWN_SECONDS).isAfter(LocalDateTime.now(clock))) {
             throw new BusinessException(CommonErrorCode.INVALID_INPUT, "인증번호는 60초 후 다시 요청할 수 있습니다.");
+        }
+    }
+
+    private static String hashToken(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(token.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 algorithm is unavailable", exception);
         }
     }
 }

--- a/src/main/java/geumjeongyahak/domain/auth/service/UrlTokenGenerator.java
+++ b/src/main/java/geumjeongyahak/domain/auth/service/UrlTokenGenerator.java
@@ -1,0 +1,17 @@
+package geumjeongyahak.domain.auth.service;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.function.Supplier;
+
+class UrlTokenGenerator implements Supplier<String> {
+    private static final int TOKEN_BYTES = 32;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    @Override
+    public String get() {
+        byte[] token = new byte[TOKEN_BYTES];
+        secureRandom.nextBytes(token);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(token);
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/auth/v1/controller/EmailVerificationLinkController.java
+++ b/src/main/java/geumjeongyahak/domain/auth/v1/controller/EmailVerificationLinkController.java
@@ -1,25 +1,56 @@
 package geumjeongyahak.domain.auth.v1.controller;
 
+import geumjeongyahak.common.exception.BusinessException;
+import geumjeongyahak.common.exception.CommonErrorCode;
+import geumjeongyahak.common.mail.MailProperties;
+import geumjeongyahak.domain.auth.exception.AuthErrorCode;
+import geumjeongyahak.domain.auth.service.EmailVerificationService;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Controller
+@RequiredArgsConstructor
 public class EmailVerificationLinkController {
+    private final MailProperties mailProperties;
+    private final EmailVerificationService emailVerificationService;
 
     @GetMapping("/auth/email-verification")
     public void redirectToEmailVerificationApi(
-            @RequestParam String email,
-            @RequestParam("code") String verificationCode,
+            @RequestParam(required = false) String token,
+            @RequestParam(required = false) String email,
+            @RequestParam(value = "code", required = false) String verificationCode,
             HttpServletResponse response
     ) throws IOException {
-        response.sendRedirect(UriComponentsBuilder
-            .fromPath("/api/v1/auth/email-verification/confirm")
-            .queryParam("email", email)
-            .queryParam("code", verificationCode)
-            .toUriString());
+        String status = "success";
+        String errorCode = null;
+        try {
+            if (token != null && !token.isBlank()) {
+                emailVerificationService.confirmByToken(token);
+            } else if (email != null && !email.isBlank() && verificationCode != null && !verificationCode.isBlank()) {
+                emailVerificationService.confirm(email, verificationCode);
+            } else {
+                status = "invalid";
+                errorCode = CommonErrorCode.MISSING_REQUIRED_FIELD.getCode();
+            }
+        } catch (BusinessException exception) {
+            status = AuthErrorCode.EMAIL_VERIFICATION_TOKEN_EXPIRED.getCode().equals(exception.getCode())
+                ? "expired"
+                : "invalid";
+            errorCode = exception.getCode();
+        }
+
+        UriComponentsBuilder builder = UriComponentsBuilder
+            .fromUriString(mailProperties.frontendBaseUrl())
+            .replacePath("/auth/email-verification")
+            .queryParam("status", status);
+        if (errorCode != null) {
+            builder.queryParam("errorCode", errorCode);
+        }
+        response.sendRedirect(builder.toUriString());
     }
 }

--- a/src/main/java/geumjeongyahak/domain/auth/v1/controller/LocalAuthController.java
+++ b/src/main/java/geumjeongyahak/domain/auth/v1/controller/LocalAuthController.java
@@ -13,6 +13,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 import geumjeongyahak.common.exception.BusinessException;
+import geumjeongyahak.common.exception.CommonErrorCode;
 import geumjeongyahak.common.mail.MailProperties;
 import geumjeongyahak.common.security.service.CustomUserDetails;
 import geumjeongyahak.domain.auth.exception.AuthErrorCode;
@@ -96,26 +97,38 @@ public class LocalAuthController {
     )
     @GetMapping("/email-verification/confirm")
     public void confirmEmailVerificationLink(
-            @RequestParam String email,
-            @RequestParam("code") String verificationCode,
+            @RequestParam(required = false) String token,
+            @RequestParam(required = false) String email,
+            @RequestParam(value = "code", required = false) String verificationCode,
             HttpServletResponse response
     ) throws IOException {
         String status = "success";
+        String errorCode = null;
         try {
-            emailVerificationService.confirm(email, verificationCode);
+            if (token != null && !token.isBlank()) {
+                emailVerificationService.confirmByToken(token);
+            } else if (email != null && !email.isBlank() && verificationCode != null && !verificationCode.isBlank()) {
+                emailVerificationService.confirm(email, verificationCode);
+            } else {
+                status = "invalid";
+                errorCode = CommonErrorCode.MISSING_REQUIRED_FIELD.getCode();
+            }
         } catch (BusinessException exception) {
             status = AuthErrorCode.EMAIL_VERIFICATION_TOKEN_EXPIRED.getCode().equals(exception.getCode())
                 ? "expired"
                 : "invalid";
-            log.info("이메일 인증 링크 처리 실패 - email={}, status={}", email, status);
+            errorCode = exception.getCode();
+            log.info("이메일 인증 링크 처리 실패 - status={}, code={}", status, errorCode);
         }
 
-        response.sendRedirect(UriComponentsBuilder
+        UriComponentsBuilder builder = UriComponentsBuilder
             .fromUriString(mailProperties.frontendBaseUrl())
             .replacePath("/auth/email-verification")
-            .queryParam("status", status)
-            .queryParam("email", email)
-            .toUriString());
+            .queryParam("status", status);
+        if (errorCode != null) {
+            builder.queryParam("errorCode", errorCode);
+        }
+        response.sendRedirect(builder.toUriString());
     }
 
     @Operation(

--- a/src/main/java/geumjeongyahak/domain/auth/v1/dto/request/EmailVerificationConfirmRequest.java
+++ b/src/main/java/geumjeongyahak/domain/auth/v1/dto/request/EmailVerificationConfirmRequest.java
@@ -3,7 +3,6 @@ package geumjeongyahak.domain.auth.v1.dto.request;
 import geumjeongyahak.common.validation.annotation.ValidEmail;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 
 public record EmailVerificationConfirmRequest(
     @Schema(description = "인증할 Local 로그인 이메일", example = "user@example.com")
@@ -11,9 +10,8 @@ public record EmailVerificationConfirmRequest(
     @ValidEmail
     String email,
 
-    @Schema(description = "메일로 받은 6자리 이메일 인증번호", example = "123456")
+    @Schema(description = "메일 인증 token", example = "0iWz3Xc7rC7m6R8uW4ME7jnhEtvXjqUy5S9Gc1hxmKw")
     @NotBlank(message = "인증번호는 필수입니다.")
-    @Pattern(regexp = "^\\d{6}$", message = "인증번호는 6자리 숫자여야 합니다.")
     String verificationCode
 ) {
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,7 +51,7 @@ app:
     frontend-base-url: ${FRONTEND_BASE_URL:https://geumjeongschool.com}
     password-reset-path: ${MAIL_PASSWORD_RESET_PATH:/auth/reset-password}
     password-reset-expiration-minutes: ${PASSWORD_RESET_EXPIRATION_MINUTES:15}
-    email-verification-path: ${MAIL_EMAIL_VERIFICATION_PATH:/auth/email-verification}
+    email-verification-path: ${MAIL_EMAIL_VERIFICATION_PATH:/api/v1/auth/email-verification/confirm}
     email-verification-expiration-minutes: ${EMAIL_VERIFICATION_EXPIRATION_MINUTES:15}
   oauth2:
     google:

--- a/src/main/resources/templates/mail/email-verification.html
+++ b/src/main/resources/templates/mail/email-verification.html
@@ -28,7 +28,7 @@
               <table role="presentation" cellspacing="0" cellpadding="0" align="center" style="margin:0 auto 24px;">
                 <tr>
                   <td align="center" style="background:#4f9d34;border-radius:8px;">
-                    <a th:href="${verificationUrl}" href="https://geumjeongschool.com/auth/email-verification" style="display:inline-block;padding:14px 22px;color:#ffffff;text-decoration:none;font-size:15px;font-weight:800;">이메일 인증하기</a>
+                    <a th:href="${verificationUrl}" href="https://geumjeongschool.com/api/v1/auth/email-verification/confirm" style="display:inline-block;padding:14px 22px;color:#ffffff;text-decoration:none;font-size:15px;font-weight:800;">이메일 인증하기</a>
                   </td>
                 </tr>
               </table>
@@ -39,7 +39,7 @@
                 <tr>
                   <td style="padding-top:18px;">
                     <p style="margin:0 0 8px;font-size:13px;line-height:1.7;color:#6a746f;">새 인증 메일을 발급받으면 이전 링크는 사용할 수 없습니다.</p>
-                    <p style="margin:0;font-size:13px;line-height:1.7;color:#6a746f;">버튼이 열리지 않으면 아래 주소로 접속해 주세요.<br><span style="word-break:break-all;color:#4f9d34;" th:text="${verificationUrl}">https://geumjeongschool.com/auth/email-verification</span></p>
+                    <p style="margin:0;font-size:13px;line-height:1.7;color:#6a746f;">버튼이 열리지 않으면 아래 주소로 접속해 주세요.<br><span style="word-break:break-all;color:#4f9d34;" th:text="${verificationUrl}">https://geumjeongschool.com/api/v1/auth/email-verification/confirm</span></p>
                   </td>
                 </tr>
               </table>

--- a/src/test/java/geumjeongyahak/e2e/TestStorageConfig.java
+++ b/src/test/java/geumjeongyahak/e2e/TestStorageConfig.java
@@ -54,6 +54,7 @@ public class TestStorageConfig {
         private String lastPasswordResetCode;
         private String lastEmailVerificationRecipient;
         private String lastEmailVerificationCode;
+        private String lastEmailVerificationUrl;
 
         @Override
         public MailDeliveryResult sendSignupWelcomeMail(String recipientEmail, String recipientName) {
@@ -76,6 +77,7 @@ public class TestStorageConfig {
         ) {
             this.lastEmailVerificationRecipient = recipientEmail;
             this.lastEmailVerificationCode = verificationCode;
+            this.lastEmailVerificationUrl = "/api/v1/auth/email-verification/confirm?token=" + verificationCode;
             return MailDeliveryResult.sent("email-verification", recipientEmail);
         }
 
@@ -97,6 +99,10 @@ public class TestStorageConfig {
 
         public String getLastEmailVerificationCode() {
             return lastEmailVerificationCode;
+        }
+
+        public String getLastEmailVerificationUrl() {
+            return lastEmailVerificationUrl;
         }
     }
 

--- a/src/test/java/geumjeongyahak/e2e/auth/AuthSignupTest.java
+++ b/src/test/java/geumjeongyahak/e2e/auth/AuthSignupTest.java
@@ -68,6 +68,7 @@ class AuthSignupTest extends AuthBaseTest {
         assertThat(mailSenderService.getLastEmailVerificationRecipient()).isEqualTo(uniqueEmail);
         String verificationCode = mailSenderService.getLastEmailVerificationCode();
         assertThat(verificationCode).isNotBlank();
+        assertThat(mailSenderService.getLastEmailVerificationUrl()).doesNotContain("email=");
 
         given()
             .contentType(ContentType.JSON)
@@ -180,7 +181,7 @@ class AuthSignupTest extends AuthBaseTest {
     }
 
     @Test
-    @DisplayName("메일 인증 링크는 인증 후 프론트 결과 페이지로 리다이렉트한다")
+    @DisplayName("메일 인증 링크는 token만으로 인증 후 이메일 없는 프론트 결과 페이지로 리다이렉트한다")
     void emailVerification_LinkRedirectsToFrontendResultPage() {
         String uniqueEmail = "verify-link" + System.currentTimeMillis() + "@test.com";
         LocalSignupRequest req = new LocalSignupRequest(
@@ -199,17 +200,16 @@ class AuthSignupTest extends AuthBaseTest {
         .then()
             .statusCode(201);
 
-        String verificationCode = mailSenderService.getLastEmailVerificationCode();
+        String verificationToken = mailSenderService.getLastEmailVerificationCode();
 
         given()
             .redirects().follow(false)
-            .queryParam("email", uniqueEmail)
-            .queryParam("code", verificationCode)
+            .queryParam("token", verificationToken)
         .when()
             .get("/email-verification/confirm")
         .then()
             .statusCode(302)
-            .header("Location", startsWith("https://geumjeongschool.com/auth/email-verification?status=success"));
+            .header("Location", equalTo("https://geumjeongschool.com/auth/email-verification?status=success"));
 
         var verifiedCredential = credentialRepository.findByCredentialEmailAndProvider(uniqueEmail, ProviderType.LOCAL)
             .orElseThrow();
@@ -217,7 +217,7 @@ class AuthSignupTest extends AuthBaseTest {
     }
 
     @Test
-    @DisplayName("프론트 인증 경로가 백엔드로 들어와도 인증 API로 리다이렉트한다")
+    @DisplayName("프론트 인증 경로가 백엔드로 들어와도 token만으로 인증 후 프론트 결과 페이지로 리다이렉트한다")
     void emailVerification_FrontendPathOnApiRedirectsToVerificationEndpoint() {
         String uniqueEmail = "verify-api-host" + System.currentTimeMillis() + "@test.com";
         LocalSignupRequest req = new LocalSignupRequest(
@@ -236,19 +236,39 @@ class AuthSignupTest extends AuthBaseTest {
         .then()
             .statusCode(201);
 
-        String verificationCode = mailSenderService.getLastEmailVerificationCode();
+        String verificationToken = mailSenderService.getLastEmailVerificationCode();
         String originalBasePath = RestAssured.basePath;
         RestAssured.basePath = "";
 
         given()
             .redirects().follow(false)
-            .queryParam("email", uniqueEmail)
-            .queryParam("code", verificationCode)
+            .queryParam("token", verificationToken)
         .when()
             .get("/auth/email-verification")
         .then()
             .statusCode(302)
-            .header("Location", containsString("/api/v1/auth/email-verification/confirm?"));
+            .header("Location", equalTo("https://geumjeongschool.com/auth/email-verification?status=success"));
+
+        var verifiedCredential = credentialRepository.findByCredentialEmailAndProvider(uniqueEmail, ProviderType.LOCAL)
+            .orElseThrow();
+        assertThat(verifiedCredential.isEmailVerified()).isTrue();
+
+        RestAssured.basePath = originalBasePath;
+    }
+
+    @Test
+    @DisplayName("인증 링크 필수값 누락도 JSON 대신 프론트 실패 페이지로 리다이렉트한다")
+    void emailVerification_MissingTokenRedirectsToFrontendErrorPage() {
+        String originalBasePath = RestAssured.basePath;
+        RestAssured.basePath = "";
+
+        given()
+            .redirects().follow(false)
+        .when()
+            .get("/auth/email-verification")
+        .then()
+            .statusCode(302)
+            .header("Location", equalTo("https://geumjeongschool.com/auth/email-verification?status=invalid&errorCode=VAL003"));
 
         RestAssured.basePath = originalBasePath;
     }
@@ -275,13 +295,12 @@ class AuthSignupTest extends AuthBaseTest {
 
         given()
             .redirects().follow(false)
-            .queryParam("email", uniqueEmail)
-            .queryParam("code", "000000")
+            .queryParam("token", "invalid-token")
         .when()
             .get("/email-verification/confirm")
         .then()
             .statusCode(302)
-            .header("Location", startsWith("https://geumjeongschool.com/auth/email-verification?status=invalid"));
+            .header("Location", equalTo("https://geumjeongschool.com/auth/email-verification?status=invalid&errorCode=AUTH014"));
     }
 
     @Test

--- a/src/test/java/geumjeongyahak/unit/auth/EmailVerificationServiceTest.java
+++ b/src/test/java/geumjeongyahak/unit/auth/EmailVerificationServiceTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @ExtendWith(MockitoExtension.class)
 class EmailVerificationServiceTest {
@@ -34,13 +33,10 @@ class EmailVerificationServiceTest {
     private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-06-25T10:15:30Z"), ZoneId.of("Asia/Seoul"));
     private static final String EMAIL = "verify@test.com";
     private static final String RAW_CODE = "123456";
-    private static final String TOKEN_HASH = "hashed-verification-token";
+    private static final String TOKEN_HASH = "8d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c92";
 
     @Mock
     private UserCredentialRepository credentialRepository;
-
-    @Mock
-    private PasswordEncoder passwordEncoder;
 
     @Mock
     private MailSenderService mailSenderService;
@@ -51,7 +47,6 @@ class EmailVerificationServiceTest {
     void setUp() {
         emailVerificationService = new EmailVerificationService(
             credentialRepository,
-            passwordEncoder,
             mailSenderService,
             CLOCK,
             () -> RAW_CODE
@@ -59,9 +54,8 @@ class EmailVerificationServiceTest {
     }
 
     @Test
-    void issueVerification_storesHashedTokenAndSendsEmailVerificationMail() {
+    void issueVerification_storesSha256TokenHashAndSendsRawTokenOnlyInMail() {
         UserCredential credential = unverifiedCredential();
-        given(passwordEncoder.encode(RAW_CODE)).willReturn(TOKEN_HASH);
         given(mailSenderService.sendEmailVerificationMail(eq(EMAIL), eq("이메일 인증 사용자"), eq(RAW_CODE)))
             .willReturn(MailDeliveryResult.sent("email-verification", EMAIL));
 
@@ -79,7 +73,6 @@ class EmailVerificationServiceTest {
     @Test
     void issueVerification_keepsTokenWhenMailDeliveryFails() {
         UserCredential credential = unverifiedCredential();
-        given(passwordEncoder.encode(RAW_CODE)).willReturn(TOKEN_HASH);
         given(mailSenderService.sendEmailVerificationMail(eq(EMAIL), eq("이메일 인증 사용자"), eq(RAW_CODE)))
             .willThrow(new RuntimeException("smtp down"));
 
@@ -95,7 +88,6 @@ class EmailVerificationServiceTest {
         credential.issueEmailVerificationToken(TOKEN_HASH, LocalDateTime.now(CLOCK).plusMinutes(15), LocalDateTime.now(CLOCK));
         given(credentialRepository.findByCredentialEmailAndProvider(EMAIL, ProviderType.LOCAL))
             .willReturn(Optional.of(credential));
-        given(passwordEncoder.matches(RAW_CODE, TOKEN_HASH)).willReturn(true);
 
         emailVerificationService.confirm(EMAIL, RAW_CODE);
 
@@ -112,7 +104,6 @@ class EmailVerificationServiceTest {
         credential.issueEmailVerificationToken(TOKEN_HASH, LocalDateTime.now(CLOCK).minusMinutes(1), LocalDateTime.now(CLOCK).minusMinutes(16));
         given(credentialRepository.findByCredentialEmailAndProvider(EMAIL, ProviderType.LOCAL))
             .willReturn(Optional.of(credential));
-        given(passwordEncoder.matches(RAW_CODE, TOKEN_HASH)).willReturn(true);
 
         assertThatThrownBy(() -> emailVerificationService.confirm(EMAIL, RAW_CODE))
             .isInstanceOf(BusinessException.class)
@@ -129,7 +120,6 @@ class EmailVerificationServiceTest {
         credential.issueEmailVerificationToken(TOKEN_HASH, LocalDateTime.now(CLOCK).plusMinutes(15), LocalDateTime.now(CLOCK));
         given(credentialRepository.findByCredentialEmailAndProvider(EMAIL, ProviderType.LOCAL))
             .willReturn(Optional.of(credential));
-        given(passwordEncoder.matches("654321", TOKEN_HASH)).willReturn(false);
 
         assertThatThrownBy(() -> emailVerificationService.confirm(EMAIL, "654321"))
             .isInstanceOf(BusinessException.class)
@@ -147,7 +137,6 @@ class EmailVerificationServiceTest {
         credential.issueEmailVerificationToken(TOKEN_HASH, LocalDateTime.now(CLOCK).plusMinutes(15), LocalDateTime.now(CLOCK));
         given(credentialRepository.findByCredentialEmailAndProvider(EMAIL, ProviderType.LOCAL))
             .willReturn(Optional.of(credential));
-        given(passwordEncoder.matches("654321", TOKEN_HASH)).willReturn(false);
 
         for (int i = 0; i < 5; i++) {
             assertThatThrownBy(() -> emailVerificationService.confirm(EMAIL, "654321"))
@@ -164,7 +153,6 @@ class EmailVerificationServiceTest {
     void resend_replacesExistingVerificationCode() {
         emailVerificationService = new EmailVerificationService(
             credentialRepository,
-            passwordEncoder,
             mailSenderService,
             CLOCK,
             () -> "222222"
@@ -177,14 +165,38 @@ class EmailVerificationServiceTest {
         );
         given(credentialRepository.findByCredentialEmailAndProvider(EMAIL, ProviderType.LOCAL))
             .willReturn(Optional.of(credential));
-        given(passwordEncoder.encode("222222")).willReturn("new-hash");
         given(mailSenderService.sendEmailVerificationMail(eq(EMAIL), eq("이메일 인증 사용자"), eq("222222")))
             .willReturn(MailDeliveryResult.sent("email-verification", EMAIL));
 
         emailVerificationService.resend(EMAIL);
 
-        assertThat(credential.getEmailVerificationTokenHash()).isEqualTo("new-hash");
+        assertThat(credential.getEmailVerificationTokenHash())
+            .isEqualTo("4cc8f4d609b717356701c57a03e737e5ac8fe885da8c7163d3de47e01849c635");
         verify(mailSenderService).sendEmailVerificationMail(EMAIL, "이메일 인증 사용자", "222222");
+    }
+
+    @Test
+    void confirmByToken_marksEmailVerifiedWithoutEmailLookup() {
+        UserCredential credential = unverifiedCredential();
+        credential.issueEmailVerificationToken(TOKEN_HASH, LocalDateTime.now(CLOCK).plusMinutes(15), LocalDateTime.now(CLOCK));
+        given(credentialRepository.findByEmailVerificationTokenHash(TOKEN_HASH))
+            .willReturn(Optional.of(credential));
+
+        emailVerificationService.confirmByToken(RAW_CODE);
+
+        assertThat(credential.isEmailVerified()).isTrue();
+        assertThat(credential.getEmailVerificationTokenHash()).isNull();
+        verify(credentialRepository).save(credential);
+    }
+
+    @Test
+    void confirmByToken_rejectsInvalidToken() {
+        given(credentialRepository.findByEmailVerificationTokenHash(TOKEN_HASH))
+            .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> emailVerificationService.confirmByToken(RAW_CODE))
+            .isInstanceOf(BusinessException.class)
+            .hasMessage("유효하지 않은 이메일 인증번호입니다.");
     }
 
     @Test
@@ -223,7 +235,6 @@ class EmailVerificationServiceTest {
         credential.issueEmailVerificationToken(TOKEN_HASH, LocalDateTime.now(CLOCK).plusMinutes(15), LocalDateTime.now(CLOCK));
         given(credentialRepository.findByCredentialEmailAndProvider(EMAIL, ProviderType.LOCAL))
             .willReturn(Optional.of(credential));
-        given(passwordEncoder.matches(RAW_CODE, TOKEN_HASH)).willReturn(true);
 
         emailVerificationService.confirm(EMAIL, RAW_CODE);
 


### PR DESCRIPTION
## Summary

- 이메일 인증 메일 링크를 `email+code` query에서 opaque `token` query로 변경했습니다.
- 인증 성공/실패 리디렉션에서 이메일을 제거하고 `status`, `errorCode`만 전달합니다.
- `/auth/email-verification`이 백엔드로 들어와도 JSON을 노출하지 않고 인증 처리 후 프론트 결과 페이지로 리디렉션합니다.
- 인증 token은 SHA-256 hash만 저장하고 raw token은 메일 링크에만 사용합니다.

## Root Cause

- 기존 메일 링크와 결과 리디렉션 URL에 이메일이 그대로 노출됐습니다.
- `code` 누락 시 컨트롤러 진입 전에 validation 에러 JSON이 그대로 반환됐습니다.

## Test Plan

- [x] `./gradlew test --tests geumjeongyahak.e2e.auth.AuthSignupTest --tests geumjeongyahak.unit.auth.EmailVerificationServiceTest --tests geumjeongyahak.unit.users.UserCrudServiceDeactivationTest --tests geumjeongyahak.e2e.auth.AuthLoginTest --tests geumjeongyahak.e2e.users.UserDeleteTest`

## Related

- Frontend PR: https://github.com/Geumjeongyahak/Frontend/pull/184
- Follow-up to #181
- Refs #180