### PR TITLE
fix(global): prod 배포를 IAP SSH로 전환

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,4 +1,4 @@
-name: Deploy to Prod (SSH)
+name: Deploy to Prod (IAP)
 
 on:
   push:
@@ -11,10 +11,26 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
+
+    env:
+      GCP_PROJECT_ID: project-4d44e135-cd9f-4802-8be
+      GCP_ZONE: asia-northeast1-a
+      GCE_INSTANCE: gjlearn-prod-app
+      GCE_USER: min
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER_PROD }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_PROD }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -26,20 +42,9 @@ jobs:
       - name: Build Spring Boot jar
         run: ./gradlew bootJar -x test
 
-      - name: Deploy jar over SSH
-        env:
-          SSH_HOST: ${{ secrets.PROD_GCE_HOST }}
-          SSH_USER: ${{ secrets.PROD_GCE_USER }}
-          SSH_KEY: ${{ secrets.PROD_GCE_SSH_KEY }}
+      - name: Deploy jar over IAP
         run: |
           set -euo pipefail
-          test -n "${SSH_HOST}"
-          test -n "${SSH_USER}"
-          test -n "${SSH_KEY}"
-
-          install -m 700 -d ~/.ssh
-          printf '%s\n' "${SSH_KEY}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
 
           APP_JAR="$(find build/libs -maxdepth 1 -type f -name '*.jar' ! -name '*-plain.jar' | sort | tail -n 1)"
           if [[ -z "${APP_JAR}" ]]; then
@@ -47,21 +52,29 @@ jobs:
             exit 1
           fi
 
-          ssh-keyscan -H "${SSH_HOST}" >> ~/.ssh/known_hosts
-          ssh -i ~/.ssh/deploy_key "${SSH_USER}@${SSH_HOST}" "mkdir -p ~/app-dev"
-          scp -i ~/.ssh/deploy_key "${APP_JAR}" scripts/gcp/05_app/01_install-app-service.sh \
-            "${SSH_USER}@${SSH_HOST}:~/app-dev/"
-          ssh -i ~/.ssh/deploy_key "${SSH_USER}@${SSH_HOST}" \
+          gcloud compute ssh "${GCE_USER}@${GCE_INSTANCE}" \
+            --project "${GCP_PROJECT_ID}" \
+            --zone "${GCP_ZONE}" \
+            --tunnel-through-iap \
+            --command "mkdir -p ~/app-dev"
+          gcloud compute scp "${APP_JAR}" scripts/gcp/05_app/01_install-app-service.sh \
+            "${GCE_USER}@${GCE_INSTANCE}:~/app-dev/" \
+            --project "${GCP_PROJECT_ID}" \
+            --zone "${GCP_ZONE}" \
+            --tunnel-through-iap
+          gcloud compute ssh "${GCE_USER}@${GCE_INSTANCE}" \
+            --project "${GCP_PROJECT_ID}" \
+            --zone "${GCP_ZONE}" \
+            --tunnel-through-iap \
+            --command \
             "cd ~/app-dev && test -f .env && mv \"$(basename "${APP_JAR}")\" app.jar && chmod +x 01_install-app-service.sh && ./01_install-app-service.sh"
 
       - name: Verify prod health
-        env:
-          SSH_HOST: ${{ secrets.PROD_GCE_HOST }}
-          SSH_USER: ${{ secrets.PROD_GCE_USER }}
-          SSH_KEY: ${{ secrets.PROD_GCE_SSH_KEY }}
         run: |
           set -euo pipefail
-          printf '%s\n' "${SSH_KEY}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh -i ~/.ssh/deploy_key "${SSH_USER}@${SSH_HOST}" \
+          gcloud compute ssh "${GCE_USER}@${GCE_INSTANCE}" \
+            --project "${GCP_PROJECT_ID}" \
+            --zone "${GCP_ZONE}" \
+            --tunnel-through-iap \
+            --command \
             "curl -fsS http://127.0.0.1:8080/actuator/health >/dev/null && sudo systemctl is-active --quiet gjlearn-app"


### PR DESCRIPTION
## 변경
- prod 배포 workflow를 직접 SSH에서 gcloud IAP SSH/SCP로 전환
- Workload Identity 인증과 gcloud setup 추가
- PROD_GCE_* SSH secrets 의존 제거

## 원인
prod 방화벽은 IAP SSH 대역(35.235.240.0/20) 기준인데 GitHub Actions는 public TCP/22 직접 SSH를 사용해서 timeout이 발생했습니다.

## 검증
- YAML 파싱 확인
- git diff --check 통과
- 필요한 GCP prod WIF secrets 존재 확인