### PR TITLE
fix(global): prod WIF workflow 조건 유지

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,4 +1,4 @@
-name: Deploy to Prod (IAP)
+name: Deploy to Prod (SSH)
 
 on:
   push:


### PR DESCRIPTION
## 변경
- prod workflow 표시 이름을 기존 `Deploy to Prod (SSH)`로 복구
- 실제 배포 방식은 PR #186의 IAP SSH/SCP 유지

## 원인
prod Workload Identity Federation이 GitHub OIDC attribute condition을 사용하고 있고, workflow 이름 변경 후 `unauthorized_client: The given credential is rejected by the attribute condition`로 인증이 실패했습니다.

## 검증
- YAML 파싱 확인
- git diff --check 통과