### PR TITLE
fix(global): prod 배포 health 확인 수정

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -77,4 +77,4 @@ jobs:
             --zone "${GCP_ZONE}" \
             --tunnel-through-iap \
             --command \
-            "curl -fsS http://127.0.0.1:8080/actuator/health >/dev/null && sudo systemctl is-active --quiet gjlearn-app"
+            "cd ~/app-dev && set -a && . ./.env && set +a && curl -fsS http://127.0.0.1:\${MANAGEMENT_PORT:-9090}/actuator/health >/dev/null && sudo systemctl is-active --quiet gjlearn-app"

--- a/scripts/gcp/05_app/01_install-app-service.sh
+++ b/scripts/gcp/05_app/01_install-app-service.sh
@@ -63,8 +63,12 @@ configure_tailscale() {
         || sudo tailscale up --reset --advertise-routes="${advertise_routes}" --accept-dns="${accept_dns}"
     fi
     if [[ -n "${tags}" ]]; then
+      local tag_up_args=(--reset --advertise-tags="${tags}" --accept-dns="${accept_dns}")
+      if [[ -n "${advertise_routes}" ]]; then
+        tag_up_args+=(--advertise-routes="${advertise_routes}")
+      fi
       sudo tailscale set --advertise-tags="${tags}" 2>/dev/null \
-        || sudo tailscale up --reset --advertise-tags="${tags}" --accept-dns="${accept_dns}"
+        || sudo tailscale up "${tag_up_args[@]}"
     fi
     echo "tailscale already authenticated: $(sudo tailscale ip -4)"
     return 0


### PR DESCRIPTION
## 변경
- Tailscale tags fallback에서 기존 advertise routes를 같이 유지
- prod workflow health check를 `.env`의 `MANAGEMENT_PORT` 기준으로 변경

## 원인
직접 prod VM에서 install script를 실행해 보니 기존 Tailscale route가 있는 상태에서 tags만 reset하려 해 실패했습니다. 또한 prod actuator는 9090인데 workflow는 8080을 확인하고 있었습니다.

## 검증
- bash -n scripts/gcp/05_app/01_install-app-service.sh
- YAML 파싱 확인
- git diff --check 통과
- gcloud IAP SSH로 prod 수동 설치 및 http://127.0.0.1:9090/actuator/health UP 확인