### PR TITLE
fix(global): prod health check 재시도 추가

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -77,4 +77,4 @@ jobs:
             --zone "${GCP_ZONE}" \
             --tunnel-through-iap \
             --command \
-            "cd ~/app-dev && set -a && . ./.env && set +a && curl -fsS http://127.0.0.1:\${MANAGEMENT_PORT:-9090}/actuator/health >/dev/null && sudo systemctl is-active --quiet gjlearn-app"
+            "cd ~/app-dev && set -a && . ./.env && set +a && for i in \$(seq 1 60); do curl -fsS http://127.0.0.1:\${MANAGEMENT_PORT:-9090}/actuator/health >/dev/null && sudo systemctl is-active --quiet gjlearn-app && exit 0; sleep 5; done; sudo journalctl -u gjlearn-app -n 120 --no-pager; exit 1"


### PR DESCRIPTION
## 변경
- prod deploy workflow의 actuator health check에 최대 5분 retry 추가

## 원인
prod 앱은 restart 직후 OTel javaagent 포함 Spring Boot 초기화에 시간이 걸리는데 workflow가 9090 actuator를 한 번만 확인해 curl exit 7로 실패했습니다.

## 검증
- YAML 파싱 확인
- git diff --check 통과
- prod VM에서 9090 actuator health UP 확인