### PR TITLE
[FEAT] 학생 출석부 전용 조회 API 추가

### DIFF
--- a/src/main/java/geumjeongyahak/domain/daily_schedule/repository/DailyStudentAttendanceRepository.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/repository/DailyStudentAttendanceRepository.java
@@ -12,6 +12,7 @@ public interface DailyStudentAttendanceRepository extends JpaRepository<DailyStu
     @EntityGraph(attributePaths = {"student"})
     List<DailyStudentAttendance> findAllByDailyScheduleIdAndIsDeletedFalse(Long dailyScheduleId);
 
+    @EntityGraph(attributePaths = {"dailySchedule", "student"})
     List<DailyStudentAttendance> findAllByDailySchedule_IdInAndIsDeletedFalse(List<Long> dailyScheduleIds);
 
     Optional<DailyStudentAttendance> findByDailyScheduleIdAndStudentId(Long dailyScheduleId, Long studentId);

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleService.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleService.java
@@ -2,6 +2,7 @@ package geumjeongyahak.domain.daily_schedule.service;
 
 import geumjeongyahak.domain.classroom.entity.Classroom;
 import geumjeongyahak.domain.base.dto.response.PaginationResponse;
+import geumjeongyahak.domain.classroom.service.ClassroomProxyService;
 import geumjeongyahak.domain.daily_schedule.entity.DailySchedule;
 import geumjeongyahak.domain.daily_schedule.entity.DailyStudentAttendance;
 import geumjeongyahak.domain.daily_schedule.entity.DailyTeacherAttendance;
@@ -29,6 +30,7 @@ import geumjeongyahak.domain.daily_schedule.v1.dto.request.CreateDailyScheduleJo
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailyScheduleListRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailySchedulePaginationRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.DailyScheduleVolunteerHoursRequest;
+import geumjeongyahak.domain.daily_schedule.v1.dto.request.StudentAttendanceSheetRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyScheduleJournalRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyStudentAttendanceItemRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyStudentAttendancesRequest;
@@ -37,6 +39,10 @@ import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleDetailR
 import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleLessonResponse;
 import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleSummaryResponse;
 import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleVolunteerHoursResponse;
+import geumjeongyahak.domain.daily_schedule.v1.dto.response.StudentAttendanceSheetAttendanceResponse;
+import geumjeongyahak.domain.daily_schedule.v1.dto.response.StudentAttendanceSheetResponse;
+import geumjeongyahak.domain.daily_schedule.v1.dto.response.StudentAttendanceSheetScheduleResponse;
+import geumjeongyahak.domain.daily_schedule.v1.dto.response.StudentAttendanceSheetStudentResponse;
 import geumjeongyahak.domain.lesson.entity.Lesson;
 import geumjeongyahak.domain.lesson.enums.LessonStatus;
 import geumjeongyahak.domain.lesson.service.LessonProxyService;
@@ -45,10 +51,12 @@ import geumjeongyahak.domain.student.service.StudentProxyService;
 import geumjeongyahak.domain.users.entity.User;
 import geumjeongyahak.domain.users.service.UserProxyService;
 import java.time.Clock;
+import java.time.DayOfWeek;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.YearMonth;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -76,6 +84,7 @@ public class DailyScheduleService {
     private final DailyStudentAttendanceRepository dailyStudentAttendanceRepository;
     private final LessonProxyService lessonProxyService;
     private final StudentProxyService studentProxyService;
+    private final ClassroomProxyService classroomProxyService;
     private final UserProxyService userProxyService;
     private final Clock clock;
 
@@ -157,6 +166,68 @@ public class DailyScheduleService {
             .toList();
         log.debug("DailySchedule 목록 조회 완료 - 총 {}건", responses.size());
         return responses;
+    }
+
+    public StudentAttendanceSheetResponse getStudentAttendanceSheet(StudentAttendanceSheetRequest request) {
+        YearMonth yearMonth = YearMonth.of(request.year(), request.month());
+        LocalDate from = yearMonth.atDay(1);
+        LocalDate to = yearMonth.atEndOfMonth();
+
+        log.debug(
+            "학생 출석부 조회 요청 (year={}, month={}, classroomId={})",
+            request.year(),
+            request.month(),
+            request.classroomId()
+        );
+
+        Classroom classroom = classroomProxyService.getActiveById(request.classroomId());
+        List<StudentAttendanceSheetStudentResponse> students = studentProxyService
+            .getActiveStudentsByClassroomId(request.classroomId())
+            .stream()
+            .sorted(Comparator.comparing(Student::getName).thenComparing(Student::getId))
+            .map(StudentAttendanceSheetStudentResponse::from)
+            .toList();
+        List<DailySchedule> dailySchedules = dailyScheduleRepository
+            .findAllByIsDeletedFalseAndLessonDateBetweenOrderByLessonDateAscIdAsc(from, to)
+            .stream()
+            .filter(dailySchedule -> dailySchedule.getClassroom().getId().equals(request.classroomId()))
+            .toList();
+        List<Long> dailyScheduleIds = dailySchedules.stream()
+            .map(DailySchedule::getId)
+            .toList();
+        Map<Long, List<StudentAttendanceSheetAttendanceResponse>> attendancesByScheduleId = dailyScheduleIds.isEmpty()
+            ? Map.of()
+            : dailyStudentAttendanceRepository.findAllByDailySchedule_IdInAndIsDeletedFalse(dailyScheduleIds)
+                .stream()
+                .sorted(Comparator
+                    .comparing((DailyStudentAttendance attendance) -> attendance.getStudent().getName())
+                    .thenComparing(attendance -> attendance.getStudent().getId()))
+                .collect(Collectors.groupingBy(
+                    attendance -> attendance.getDailySchedule().getId(),
+                    Collectors.mapping(StudentAttendanceSheetAttendanceResponse::from, Collectors.toList())
+                ));
+        List<StudentAttendanceSheetScheduleResponse> schedules = dailySchedules.stream()
+            .map(dailySchedule -> StudentAttendanceSheetScheduleResponse.of(
+                dailySchedule,
+                getDayOfWeekLabel(dailySchedule.getLessonDate().getDayOfWeek()),
+                attendancesByScheduleId.getOrDefault(dailySchedule.getId(), List.of())
+            ))
+            .toList();
+
+        log.debug(
+            "학생 출석부 조회 완료 (classroomId={}, studentCount={}, scheduleCount={})",
+            request.classroomId(),
+            students.size(),
+            schedules.size()
+        );
+        return StudentAttendanceSheetResponse.of(
+            request.year(),
+            request.month(),
+            classroom.getId(),
+            classroom.getName(),
+            students,
+            schedules
+        );
     }
 
     public PaginationResponse<DailyScheduleSummaryResponse> getJournalDailySchedules(
@@ -937,6 +1008,18 @@ public class DailyScheduleService {
 
     private boolean hasText(String value) {
         return value != null && !value.isBlank();
+    }
+
+    private String getDayOfWeekLabel(DayOfWeek dayOfWeek) {
+        return switch (dayOfWeek) {
+            case MONDAY -> "월";
+            case TUESDAY -> "화";
+            case WEDNESDAY -> "수";
+            case THURSDAY -> "목";
+            case FRIDAY -> "금";
+            case SATURDAY -> "토";
+            case SUNDAY -> "일";
+        };
     }
 
     private Map<DailyScheduleLessonKey, List<Lesson>> getLessonsByScheduleKey(List<DailySchedule> dailySchedules) {

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/StudentAttendanceSheetController.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/StudentAttendanceSheetController.java
@@ -1,0 +1,54 @@
+package geumjeongyahak.domain.daily_schedule.v1.controller;
+
+import geumjeongyahak.domain.daily_schedule.service.DailyScheduleService;
+import geumjeongyahak.domain.daily_schedule.v1.dto.request.StudentAttendanceSheetRequest;
+import geumjeongyahak.domain.daily_schedule.v1.dto.response.StudentAttendanceSheetResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/attendance-sheets")
+@RequiredArgsConstructor
+@Tag(name = "AttendanceSheet", description = "학생 출석부 API")
+public class StudentAttendanceSheetController {
+
+    private static final String DAILY_SCHEDULE_READ_ACCESS =
+        "hasRole('VOLUNTEER') or hasRole('MANAGER') or hasRole('ADMIN')";
+
+    private final DailyScheduleService dailyScheduleService;
+
+    @PreAuthorize(DAILY_SCHEDULE_READ_ACCESS)
+    @Operation(
+        summary = "월간 학생 출석부 조회",
+        description = """
+            특정 연월과 분반을 기준으로 학생 출석부 데이터를 조회합니다.
+
+            응답은 시트 생성을 위해 학생 목록과 날짜별 수업 일정 목록을 분리해 반환합니다.
+            학생 목록은 행 방향, 일정 목록은 열 방향으로 사용할 수 있으며,
+            각 일정의 studentAttendances에는 학생별 출석 상태와 출석 식별자가 포함됩니다.
+            """
+    )
+    @GetMapping
+    public ResponseEntity<StudentAttendanceSheetResponse> getStudentAttendanceSheet(
+        @ParameterObject @Valid @ModelAttribute StudentAttendanceSheetRequest request
+    ) {
+        log.debug(
+            "GET /api/v1/attendance-sheets - 월간 학생 출석부 조회 요청 (year={}, month={}, classroomId={})",
+            request.year(),
+            request.month(),
+            request.classroomId()
+        );
+        return ResponseEntity.ok(dailyScheduleService.getStudentAttendanceSheet(request));
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/StudentAttendanceSheetController.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/StudentAttendanceSheetController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class StudentAttendanceSheetController {
 
     private static final String DAILY_SCHEDULE_READ_ACCESS =
-        "hasRole('VOLUNTEER') or hasRole('MANAGER') or hasRole('ADMIN')";
+        "hasRole('ADMIN') or hasAuthority('daily-schedule:read:*')";
 
     private final DailyScheduleService dailyScheduleService;
 

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/v1/dto/request/StudentAttendanceSheetRequest.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/v1/dto/request/StudentAttendanceSheetRequest.java
@@ -1,0 +1,27 @@
+package geumjeongyahak.domain.daily_schedule.v1.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record StudentAttendanceSheetRequest(
+    @NotNull
+    @Min(2000)
+    @Max(2100)
+    @Schema(description = "조회 연도", example = "2026")
+    Integer year,
+
+    @NotNull
+    @Min(1)
+    @Max(12)
+    @Schema(description = "조회 월", example = "2")
+    Integer month,
+
+    @NotNull
+    @Positive
+    @Schema(description = "분반 ID", example = "1")
+    Long classroomId
+) {
+}

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/v1/dto/response/StudentAttendanceSheetAttendanceResponse.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/v1/dto/response/StudentAttendanceSheetAttendanceResponse.java
@@ -1,0 +1,29 @@
+package geumjeongyahak.domain.daily_schedule.v1.dto.response;
+
+import geumjeongyahak.domain.daily_schedule.entity.DailyStudentAttendance;
+import geumjeongyahak.domain.daily_schedule.enums.DailyStudentAttendanceStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record StudentAttendanceSheetAttendanceResponse(
+    @Schema(description = "학생 출석 식별자", example = "1")
+    Long attendanceId,
+
+    @Schema(description = "학생 ID", example = "10")
+    Long studentId,
+
+    @Schema(
+        description = "학생 출석 상태",
+        example = "PRESENT",
+        allowableValues = {"PRESENT", "ABSENT", "LATE"}
+    )
+    DailyStudentAttendanceStatus status
+) {
+
+    public static StudentAttendanceSheetAttendanceResponse from(DailyStudentAttendance attendance) {
+        return new StudentAttendanceSheetAttendanceResponse(
+            attendance.getId(),
+            attendance.getStudent().getId(),
+            attendance.getStatus()
+        );
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/v1/dto/response/StudentAttendanceSheetResponse.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/v1/dto/response/StudentAttendanceSheetResponse.java
@@ -1,0 +1,36 @@
+package geumjeongyahak.domain.daily_schedule.v1.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record StudentAttendanceSheetResponse(
+    @Schema(description = "조회 연도", example = "2026")
+    Integer year,
+
+    @Schema(description = "조회 월", example = "2")
+    Integer month,
+
+    @Schema(description = "분반 ID", example = "1")
+    Long classroomId,
+
+    @Schema(description = "분반명", example = "벚꽃반")
+    String classroomName,
+
+    @Schema(description = "출석부 학생 목록")
+    List<StudentAttendanceSheetStudentResponse> students,
+
+    @Schema(description = "월간 수업 일정별 출석 목록")
+    List<StudentAttendanceSheetScheduleResponse> schedules
+) {
+
+    public static StudentAttendanceSheetResponse of(
+        Integer year,
+        Integer month,
+        Long classroomId,
+        String classroomName,
+        List<StudentAttendanceSheetStudentResponse> students,
+        List<StudentAttendanceSheetScheduleResponse> schedules
+    ) {
+        return new StudentAttendanceSheetResponse(year, month, classroomId, classroomName, students, schedules);
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/v1/dto/response/StudentAttendanceSheetScheduleResponse.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/v1/dto/response/StudentAttendanceSheetScheduleResponse.java
@@ -1,0 +1,47 @@
+package geumjeongyahak.domain.daily_schedule.v1.dto.response;
+
+import geumjeongyahak.domain.daily_schedule.entity.DailySchedule;
+import geumjeongyahak.domain.daily_schedule.enums.DailyScheduleStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.List;
+
+public record StudentAttendanceSheetScheduleResponse(
+    @Schema(description = "하루 일정 식별자", example = "1")
+    Long dailyScheduleId,
+
+    @Schema(description = "수업 날짜", example = "2026-02-07")
+    LocalDate lessonDate,
+
+    @Schema(description = "월 중 날짜", example = "7")
+    Integer day,
+
+    @Schema(description = "요일", example = "토")
+    String dayOfWeek,
+
+    @Schema(
+        description = "하루 일정 상태",
+        example = "SCHEDULED",
+        allowableValues = {"SCHEDULED", "COMPLETED", "CANCELLED"}
+    )
+    DailyScheduleStatus status,
+
+    @Schema(description = "일정별 학생 출석 목록")
+    List<StudentAttendanceSheetAttendanceResponse> studentAttendances
+) {
+
+    public static StudentAttendanceSheetScheduleResponse of(
+        DailySchedule dailySchedule,
+        String dayOfWeek,
+        List<StudentAttendanceSheetAttendanceResponse> studentAttendances
+    ) {
+        return new StudentAttendanceSheetScheduleResponse(
+            dailySchedule.getId(),
+            dailySchedule.getLessonDate(),
+            dailySchedule.getLessonDate().getDayOfMonth(),
+            dayOfWeek,
+            dailySchedule.getStatus(),
+            studentAttendances
+        );
+    }
+}

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/v1/dto/response/StudentAttendanceSheetStudentResponse.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/v1/dto/response/StudentAttendanceSheetStudentResponse.java
@@ -1,0 +1,20 @@
+package geumjeongyahak.domain.daily_schedule.v1.dto.response;
+
+import geumjeongyahak.domain.student.entity.Student;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record StudentAttendanceSheetStudentResponse(
+    @Schema(description = "학생 ID", example = "10")
+    Long studentId,
+
+    @Schema(description = "학생 이름", example = "김민수")
+    String studentName
+) {
+
+    public static StudentAttendanceSheetStudentResponse from(Student student) {
+        return new StudentAttendanceSheetStudentResponse(
+            student.getId(),
+            student.getName()
+        );
+    }
+}

--- a/src/main/resources/sql/init_data.sql
+++ b/src/main/resources/sql/init_data.sql
@@ -98,6 +98,7 @@ INSERT INTO user_permissions (user_id, permission_code) VALUES
     (2, 'lesson:write:*'),
     (6, 'channel:write:6'),
     (10, 'daily-schedule:manage:*'),
+    (10, 'daily-schedule:read:*'),
     (10, 'user:read:*'),
     (10, 'purchase-request:read:*'),
     (10, 'purchase-request:manage:*'),

--- a/src/test/java/geumjeongyahak/unit/daily_schedule/DailyScheduleAdminServiceTest.java
+++ b/src/test/java/geumjeongyahak/unit/daily_schedule/DailyScheduleAdminServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import geumjeongyahak.domain.auth.enums.RoleType;
 import geumjeongyahak.domain.classroom.entity.Classroom;
 import geumjeongyahak.domain.classroom.enums.ClassroomType;
+import geumjeongyahak.domain.classroom.service.ClassroomProxyService;
 import geumjeongyahak.domain.daily_schedule.entity.DailySchedule;
 import geumjeongyahak.domain.daily_schedule.entity.DailyTeacherAttendance;
 import geumjeongyahak.domain.daily_schedule.enums.DailyScheduleStatus;
@@ -61,6 +62,9 @@ class DailyScheduleAdminServiceTest {
     private StudentProxyService studentProxyService;
 
     @Mock
+    private ClassroomProxyService classroomProxyService;
+
+    @Mock
     private UserProxyService userProxyService;
 
     private DailyScheduleAdminService dailyScheduleAdminService;
@@ -73,6 +77,7 @@ class DailyScheduleAdminServiceTest {
             dailyStudentAttendanceRepository,
             lessonProxyService,
             studentProxyService,
+            classroomProxyService,
             userProxyService,
             Clock.systemDefaultZone()
         );

--- a/src/test/java/geumjeongyahak/unit/daily_schedule/DailyScheduleServiceTest.java
+++ b/src/test/java/geumjeongyahak/unit/daily_schedule/DailyScheduleServiceTest.java
@@ -3,6 +3,7 @@ package geumjeongyahak.unit.daily_schedule;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import geumjeongyahak.domain.auth.enums.RoleType;
@@ -12,12 +13,15 @@ import geumjeongyahak.domain.classroom.service.ClassroomProxyService;
 import geumjeongyahak.domain.daily_schedule.entity.DailySchedule;
 import geumjeongyahak.domain.daily_schedule.entity.DailyStudentAttendance;
 import geumjeongyahak.domain.daily_schedule.entity.DailyTeacherAttendance;
+import geumjeongyahak.domain.daily_schedule.enums.DailyStudentAttendanceStatus;
 import geumjeongyahak.domain.daily_schedule.enums.DailyTeacherAttendanceStatus;
 import geumjeongyahak.domain.daily_schedule.repository.DailyScheduleRepository;
 import geumjeongyahak.domain.daily_schedule.repository.DailyStudentAttendanceRepository;
 import geumjeongyahak.domain.daily_schedule.repository.DailyTeacherAttendanceRepository;
 import geumjeongyahak.domain.daily_schedule.service.DailyScheduleService;
+import geumjeongyahak.domain.daily_schedule.v1.dto.request.StudentAttendanceSheetRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyTeacherAttendanceRequest;
+import geumjeongyahak.domain.daily_schedule.v1.dto.response.StudentAttendanceSheetResponse;
 import geumjeongyahak.domain.lesson.entity.Lesson;
 import geumjeongyahak.domain.lesson.service.LessonProxyService;
 import geumjeongyahak.domain.student.entity.Student;
@@ -64,6 +68,85 @@ class DailyScheduleServiceTest {
 
     @InjectMocks
     private DailyScheduleService dailyScheduleService;
+
+    @Test
+    void getStudentAttendanceSheet_aggregatesMonthlySchedulesAndStudentAttendances() {
+        Classroom classroom = classroom(1L, "해바라기반");
+        User teacher = teacher(2L, "홍길동");
+        Student firstStudent = student(10L, "김민수", classroom);
+        Student secondStudent = student(11L, "박영희", classroom);
+        DailySchedule firstSchedule = dailySchedule(100L, classroom, teacher, LocalDate.of(2026, 2, 7));
+        DailySchedule secondSchedule = dailySchedule(101L, classroom, teacher, LocalDate.of(2026, 2, 14));
+        DailyStudentAttendance firstAttendance = studentAttendance(
+            1000L,
+            firstSchedule,
+            firstStudent,
+            DailyStudentAttendanceStatus.PRESENT
+        );
+        DailyStudentAttendance secondAttendance = studentAttendance(
+            1001L,
+            firstSchedule,
+            secondStudent,
+            DailyStudentAttendanceStatus.ABSENT
+        );
+
+        given(classroomProxyService.getActiveById(classroom.getId())).willReturn(classroom);
+        given(studentProxyService.getActiveStudentsByClassroomId(classroom.getId()))
+            .willReturn(List.of(secondStudent, firstStudent));
+        given(dailyScheduleRepository.findAllByIsDeletedFalseAndLessonDateBetweenOrderByLessonDateAscIdAsc(
+            LocalDate.of(2026, 2, 1),
+            LocalDate.of(2026, 2, 28)
+        )).willReturn(List.of(firstSchedule, secondSchedule));
+        given(dailyStudentAttendanceRepository.findAllByDailySchedule_IdInAndIsDeletedFalse(List.of(100L, 101L)))
+            .willReturn(List.of(secondAttendance, firstAttendance));
+
+        StudentAttendanceSheetResponse response = dailyScheduleService.getStudentAttendanceSheet(
+            new StudentAttendanceSheetRequest(2026, 2, classroom.getId())
+        );
+
+        assertThat(response.year()).isEqualTo(2026);
+        assertThat(response.month()).isEqualTo(2);
+        assertThat(response.classroomId()).isEqualTo(classroom.getId());
+        assertThat(response.classroomName()).isEqualTo("해바라기반");
+        assertThat(response.students())
+            .extracting("studentId", "studentName")
+            .containsExactly(
+                org.assertj.core.groups.Tuple.tuple(10L, "김민수"),
+                org.assertj.core.groups.Tuple.tuple(11L, "박영희")
+            );
+        assertThat(response.schedules()).hasSize(2);
+        assertThat(response.schedules().get(0).dailyScheduleId()).isEqualTo(100L);
+        assertThat(response.schedules().get(0).day()).isEqualTo(7);
+        assertThat(response.schedules().get(0).dayOfWeek()).isEqualTo("토");
+        assertThat(response.schedules().get(0).studentAttendances())
+            .extracting("attendanceId", "studentId", "status")
+            .containsExactly(
+                org.assertj.core.groups.Tuple.tuple(1000L, 10L, DailyStudentAttendanceStatus.PRESENT),
+                org.assertj.core.groups.Tuple.tuple(1001L, 11L, DailyStudentAttendanceStatus.ABSENT)
+            );
+        assertThat(response.schedules().get(1).dailyScheduleId()).isEqualTo(101L);
+        assertThat(response.schedules().get(1).studentAttendances()).isEmpty();
+    }
+
+    @Test
+    void getStudentAttendanceSheet_skipsAttendanceQueryWhenMonthlyScheduleIsEmpty() {
+        Classroom classroom = classroom(1L, "해바라기반");
+
+        given(classroomProxyService.getActiveById(classroom.getId())).willReturn(classroom);
+        given(studentProxyService.getActiveStudentsByClassroomId(classroom.getId())).willReturn(List.of());
+        given(dailyScheduleRepository.findAllByIsDeletedFalseAndLessonDateBetweenOrderByLessonDateAscIdAsc(
+            LocalDate.of(2026, 2, 1),
+            LocalDate.of(2026, 2, 28)
+        )).willReturn(List.of());
+
+        StudentAttendanceSheetResponse response = dailyScheduleService.getStudentAttendanceSheet(
+            new StudentAttendanceSheetRequest(2026, 2, classroom.getId())
+        );
+
+        assertThat(response.students()).isEmpty();
+        assertThat(response.schedules()).isEmpty();
+        verify(dailyStudentAttendanceRepository, never()).findAllByDailySchedule_IdInAndIsDeletedFalse(any());
+    }
 
     @Test
     void synchronizeByClassroomAndDate_createsScheduleAndInitialAttendances() {
@@ -170,8 +253,12 @@ class DailyScheduleServiceTest {
     }
 
     private Classroom classroom(Long id) {
+        return classroom(id, "장미반");
+    }
+
+    private Classroom classroom(Long id, String name) {
         Classroom classroom = Classroom.builder()
-            .name("장미반")
+            .name(name)
             .type(ClassroomType.WEEKDAY)
             .build();
         ReflectionTestUtils.setField(classroom, "id", id);
@@ -231,8 +318,24 @@ class DailyScheduleServiceTest {
     }
 
     private Student student(Long id, Classroom classroom) {
-        Student student = new Student("최양지", null, null, classroom);
+        return student(id, "최양지", classroom);
+    }
+
+    private Student student(Long id, String name, Classroom classroom) {
+        Student student = new Student(name, null, null, classroom);
         ReflectionTestUtils.setField(student, "id", id);
         return student;
+    }
+
+    private DailyStudentAttendance studentAttendance(
+        Long id,
+        DailySchedule dailySchedule,
+        Student student,
+        DailyStudentAttendanceStatus status
+    ) {
+        DailyStudentAttendance attendance = new DailyStudentAttendance(dailySchedule, student);
+        ReflectionTestUtils.setField(attendance, "id", id);
+        attendance.updateStatus(status);
+        return attendance;
     }
 }

--- a/src/test/java/geumjeongyahak/unit/daily_schedule/DailyScheduleServiceTest.java
+++ b/src/test/java/geumjeongyahak/unit/daily_schedule/DailyScheduleServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import geumjeongyahak.domain.auth.enums.RoleType;
 import geumjeongyahak.domain.classroom.entity.Classroom;
 import geumjeongyahak.domain.classroom.enums.ClassroomType;
+import geumjeongyahak.domain.classroom.service.ClassroomProxyService;
 import geumjeongyahak.domain.daily_schedule.entity.DailySchedule;
 import geumjeongyahak.domain.daily_schedule.entity.DailyStudentAttendance;
 import geumjeongyahak.domain.daily_schedule.entity.DailyTeacherAttendance;
@@ -57,6 +58,9 @@ class DailyScheduleServiceTest {
 
     @Mock
     private StudentProxyService studentProxyService;
+
+    @Mock
+    private ClassroomProxyService classroomProxyService;
 
     @InjectMocks
     private DailyScheduleService dailyScheduleService;
@@ -122,6 +126,7 @@ class DailyScheduleServiceTest {
             dailyStudentAttendanceRepository,
             lessonProxyService,
             studentProxyService,
+            null,
             null,
             seoulClock
         );

--- a/src/test/java/geumjeongyahak/unit/daily_schedule/StudentAttendanceSheetControllerTest.java
+++ b/src/test/java/geumjeongyahak/unit/daily_schedule/StudentAttendanceSheetControllerTest.java
@@ -1,0 +1,43 @@
+package geumjeongyahak.unit.daily_schedule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import geumjeongyahak.domain.daily_schedule.service.DailyScheduleService;
+import geumjeongyahak.domain.daily_schedule.v1.controller.StudentAttendanceSheetController;
+import geumjeongyahak.domain.daily_schedule.v1.dto.request.StudentAttendanceSheetRequest;
+import geumjeongyahak.domain.daily_schedule.v1.dto.response.StudentAttendanceSheetResponse;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class StudentAttendanceSheetControllerTest {
+
+    @Mock
+    private DailyScheduleService dailyScheduleService;
+
+    @Test
+    void getStudentAttendanceSheet_returnsServiceResponse() {
+        StudentAttendanceSheetController controller = new StudentAttendanceSheetController(dailyScheduleService);
+        StudentAttendanceSheetRequest request = new StudentAttendanceSheetRequest(2026, 2, 1L);
+        StudentAttendanceSheetResponse serviceResponse = StudentAttendanceSheetResponse.of(
+            2026,
+            2,
+            1L,
+            "해바라기반",
+            List.of(),
+            List.of()
+        );
+        given(dailyScheduleService.getStudentAttendanceSheet(request)).willReturn(serviceResponse);
+
+        ResponseEntity<StudentAttendanceSheetResponse> response = controller.getStudentAttendanceSheet(request);
+
+        assertThat(response.getBody()).isEqualTo(serviceResponse);
+        verify(dailyScheduleService).getStudentAttendanceSheet(request);
+    }
+}

--- a/src/test/resources/sql/init_data.sql
+++ b/src/test/resources/sql/init_data.sql
@@ -43,6 +43,7 @@ ALTER TABLE user_credentials ALTER COLUMN id RESTART WITH 6;
 INSERT INTO user_permissions (user_id, permission_code) VALUES
     (2, 'channel:write:1'),
     (5, 'daily-schedule:manage:*'),
+    (5, 'daily-schedule:read:*'),
     (5, 'user:read:*'),
     (5, 'purchase-request:read:*'),
     (5, 'purchase-request:manage:*'),


### PR DESCRIPTION
## 개요

학생 기준 반별 출석부를 시트에서 구성할 수 있도록, 월/분반 기준 학생 출석부 전용 조회 API를 추가했습니다.

## 변경 유형

- [x] 새 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [x] 테스트 (test)
- [ ] 기타 (chore)

## 변경 내용

- 학생 출석부 조회 요청/응답 DTO 추가
- 월/분반 기준으로 학생 목록, 수업 일정, 학생 출석 정보를 조합하는 서비스 로직 추가
- `GET /api/v1/attendance-sheets` 조회 API 추가
- 출석부 조회 API 권한을 `ADMIN` 또는 `daily-schedule:read:*` 기준으로 설정
- Apps Script Bot 시드 계정에 `daily-schedule:read:*` 권한 추가
- 학생 출석부 서비스 집계 로직 테스트 추가
- 학생 출석부 컨트롤러 위임 테스트 추가

## 관련 이슈

Closes #197

## 스크린샷 (선택)



## 체크리스트

- [x] 코드 컨벤션을 준수했습니다
- [x] 테스트 코드를 작성/수정했습니다
- [x] 모든 테스트가 통과합니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)

## 리뷰어에게

출석부 응답 구조는 시트 생성을 고려해 학생 목록과 일정 목록을 분리했습니다.

- `students`: 출석부의 행 구성용 학생 목록
- `schedules`: 출석부의 날짜/요일 열 구성용 일정 목록
- `schedules[].studentAttendances`: 일정별 학생 출석 상태 매핑

출석부 조회 API는 Apps Script Bot 사용을 고려해 `daily-schedule:read:*` 권한으로 접근할 수 있도록 했습니다.