### PR TITLE
[FEAT] 결제 신청 생성 시 담당 부서 선택 기능 추가

### DIFF
--- a/src/main/java/geumjeongyahak/domain/purchase_request/entity/PurchaseRequest.java
+++ b/src/main/java/geumjeongyahak/domain/purchase_request/entity/PurchaseRequest.java
@@ -146,10 +146,14 @@ public class PurchaseRequest extends BaseEntity {
     }
 
     public void update(
+        Classroom classroom,
+        Department department,
         String title,
         String content,
         List<PurchaseRequestItem> items
     ) {
+        this.classroom = classroom;
+        this.department = department;
         this.title = title;
         this.content = content;
         this.items.clear();

--- a/src/main/java/geumjeongyahak/domain/purchase_request/service/PurchaseRequestAdminViewService.java
+++ b/src/main/java/geumjeongyahak/domain/purchase_request/service/PurchaseRequestAdminViewService.java
@@ -2,6 +2,7 @@ package geumjeongyahak.domain.purchase_request.service;
 
 import geumjeongyahak.domain.base.dto.response.AdminPage;
 import geumjeongyahak.domain.classroom.service.ClassroomAdminViewService;
+import geumjeongyahak.domain.department.service.DepartmentAdminViewService;
 import geumjeongyahak.domain.file.service.ImageUploadService;
 import geumjeongyahak.domain.file.v1.dto.response.FileUploadResponse;
 import geumjeongyahak.domain.purchase_request.enums.PurchaseRequestStatus;
@@ -27,6 +28,7 @@ public class PurchaseRequestAdminViewService {
 
     private final PurchaseRequestService purchaseRequestService;
     private final ClassroomAdminViewService classroomAdminViewService;
+    private final DepartmentAdminViewService departmentAdminViewService;
     private final ImageUploadService imageUploadService;
     private final VendorService vendorService;
 
@@ -60,6 +62,7 @@ public class PurchaseRequestAdminViewService {
     public Long createPurchaseRequest(
         Long requesterId,
         Long classroomId,
+        Long departmentId,
         String title,
         String content,
         PurchasePaymentType paymentType,
@@ -67,7 +70,7 @@ public class PurchaseRequestAdminViewService {
     ) {
         return purchaseRequestService.createPurchaseRequest(
             requesterId,
-            new CreatePurchaseRequestRequest(title, content, classroomId, paymentType, items)
+            new CreatePurchaseRequestRequest(title, content, classroomId, departmentId, paymentType, items)
         ).id();
     }
 
@@ -75,6 +78,8 @@ public class PurchaseRequestAdminViewService {
     public void updatePurchaseRequest(
         Long requesterId,
         Long requestId,
+        Long classroomId,
+        Long departmentId,
         String title,
         String content,
         List<CreatePurchaseRequestRequest.Item> items
@@ -82,7 +87,7 @@ public class PurchaseRequestAdminViewService {
         purchaseRequestService.updatePurchaseRequest(
             requesterId,
             requestId,
-            new UpdatePurchaseRequestRequest(title, content, items),
+            new UpdatePurchaseRequestRequest(classroomId, departmentId, title, content, items),
             true
         );
     }
@@ -94,6 +99,12 @@ public class PurchaseRequestAdminViewService {
 
     public List<ClassroomAdminViewService.AdminClassroomRow> getAllClassrooms() {
         return classroomAdminViewService.getClassrooms(new ClassroomAdminViewService.ClassroomFilter(null, null, "name,ASC"));
+    }
+
+    public List<DepartmentAdminViewService.AdminDepartmentRow> getAllDepartments() {
+        return departmentAdminViewService.getDepartments(
+            new DepartmentAdminViewService.DepartmentFilter(null, null, null, "name,ASC")
+        );
     }
 
     public List<VendorResponse> getAllVendors() {

--- a/src/main/java/geumjeongyahak/domain/purchase_request/service/PurchaseRequestService.java
+++ b/src/main/java/geumjeongyahak/domain/purchase_request/service/PurchaseRequestService.java
@@ -20,6 +20,8 @@ import geumjeongyahak.common.exception.ResourceNotFoundException;
 import geumjeongyahak.domain.base.dto.response.PaginationResponse;
 import geumjeongyahak.domain.classroom.entity.Classroom;
 import geumjeongyahak.domain.classroom.service.ClassroomProxyService;
+import geumjeongyahak.domain.department.entity.Department;
+import geumjeongyahak.domain.department.service.DepartmentProxyService;
 import geumjeongyahak.domain.file.entity.File;
 import geumjeongyahak.domain.file.service.FileProxyService;
 import geumjeongyahak.domain.notification.enums.PushRequestType;
@@ -54,6 +56,7 @@ public class PurchaseRequestService {
     private final PurchaseRequestRepository purchaseRequestRepository;
     private final FileProxyService fileProxyService;
     private final ClassroomProxyService classroomProxyService;
+    private final DepartmentProxyService departmentProxyService;
     private final UserProxyService userProxyService;
     private final VendorService vendorService;
     private final EventPublisher eventPublisher;
@@ -63,9 +66,15 @@ public class PurchaseRequestService {
     public PurchaseRequestDetailResponse createPurchaseRequest(
         Long requesterId, CreatePurchaseRequestRequest request
     ) {
-        log.debug("구입 요청 생성 (requesterId={}, classroomId={})", requesterId, request.classroomId());
+        log.debug(
+            "구입 요청 생성 (requesterId={}, classroomId={}, departmentId={})",
+            requesterId,
+            request.classroomId(),
+            request.departmentId()
+        );
 
         Classroom classroom = classroomProxyService.getActiveById(request.classroomId());
+        Department department = departmentProxyService.getById(request.departmentId());
         User requester = userProxyService.getById(requesterId);
         List<PurchaseRequestItem> items = request.items().stream()
             .map(item -> new PurchaseRequestItem(
@@ -78,6 +87,7 @@ public class PurchaseRequestService {
         return createPurchaseRequest(
             requester,
             classroom,
+            department,
             request.paymentType(),
             request.title(),
             request.content(),
@@ -90,13 +100,15 @@ public class PurchaseRequestService {
         Long actorId, CreatePurchaseRequestByAdminRequest request
     ) {
         log.debug(
-            "관리자 구입 요청 대리 생성 (actorId={}, requestedById={}, classroomId={})",
+            "관리자 구입 요청 대리 생성 (actorId={}, requestedById={}, classroomId={}, departmentId={})",
             actorId,
             request.requestedById(),
-            request.classroomId()
+            request.classroomId(),
+            request.departmentId()
         );
 
         Classroom classroom = classroomProxyService.getActiveById(request.classroomId());
+        Department department = departmentProxyService.getById(request.departmentId());
         User requester = userProxyService.getById(request.requestedById());
         List<PurchaseRequestItem> items = request.items().stream()
             .map(item -> new PurchaseRequestItem(
@@ -109,6 +121,7 @@ public class PurchaseRequestService {
         return createPurchaseRequest(
             requester,
             classroom,
+            department,
             request.paymentType(),
             request.title(),
             request.content(),
@@ -185,6 +198,8 @@ public class PurchaseRequestService {
             throw new BusinessException(PurchaseRequestErrorCode.INVALID_STATUS);
         }
 
+        Classroom classroom = classroomProxyService.getActiveById(request.classroomId());
+        Department department = departmentProxyService.getById(request.departmentId());
         List<PurchaseRequestItem> items = request.items().stream()
             .map(item -> new PurchaseRequestItem(
                 item.name(),
@@ -193,7 +208,7 @@ public class PurchaseRequestService {
             ))
             .toList();
 
-        purchaseRequest.update(request.title(), request.content(), items);
+        purchaseRequest.update(classroom, department, request.title(), request.content(), items);
 
         log.debug("구입 요청 수정 완료 (id={})", purchaseRequest.getId());
         return toDetailResponse(purchaseRequest);
@@ -471,6 +486,7 @@ public class PurchaseRequestService {
     private PurchaseRequestDetailResponse createPurchaseRequest(
         User requester,
         Classroom classroom,
+        Department department,
         PurchasePaymentType paymentType,
         String title,
         String content,
@@ -479,7 +495,7 @@ public class PurchaseRequestService {
         PurchaseRequest saved = purchaseRequestRepository.save(
             new PurchaseRequest(
                 classroom,
-                requester.getDepartment(),
+                department,
                 requester,
                 paymentType,
                 title,

--- a/src/main/java/geumjeongyahak/domain/purchase_request/v1/controller/PurchaseRequestAdminController.java
+++ b/src/main/java/geumjeongyahak/domain/purchase_request/v1/controller/PurchaseRequestAdminController.java
@@ -54,7 +54,8 @@ public class PurchaseRequestAdminController {
 
     @Operation(
         summary = "구입 요청 대리 생성",
-        description = "관리자 또는 purchase-request:manage:* 권한자가 requestedById 사용자를 실제 요청자로 지정해 구입 요청을 생성합니다."
+        description = "관리자 또는 purchase-request:manage:* 권한자가 requestedById 사용자를 실제 요청자로 지정해 구입 요청을 생성합니다. "
+            + "필수값인 classroomId와 departmentId로 담당 분반과 부서를 직접 지정합니다."
     )
     @PreAuthorize("hasRole('ADMIN') or hasAuthority('purchase-request:manage:*')")
     @PostMapping
@@ -175,16 +176,16 @@ public class PurchaseRequestAdminController {
 
     @Operation(
         summary = "구입 요청 수정",
-        description = "관리자 또는 purchase-request:manage:* 권한자가 PENDING 상태의 구입 요청 제목, 내용, 품목을 수정합니다."
+        description = "관리자 또는 purchase-request:manage:* 권한자가 PENDING 상태의 구입 요청 분반, 담당 부서, 제목, 내용, 품목을 전체 교체합니다."
     )
     @PreAuthorize("hasRole('ADMIN') or hasAuthority('purchase-request:manage:*')")
-    @PatchMapping("/{requestId}")
+    @PutMapping("/{requestId}")
     public ResponseEntity<PurchaseRequestDetailResponse> updatePurchaseRequest(
         @PathVariable Long requestId,
         @Valid @RequestBody UpdatePurchaseRequestRequest request,
         @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        log.debug("PATCH /api/v1/admin/purchase-requests/{}", requestId);
+        log.debug("PUT /api/v1/admin/purchase-requests/{}", requestId);
         return ResponseEntity.ok(
             purchaseRequestService.updatePurchaseRequest(
                 userDetails.getUserId(),

--- a/src/main/java/geumjeongyahak/domain/purchase_request/v1/controller/PurchaseRequestController.java
+++ b/src/main/java/geumjeongyahak/domain/purchase_request/v1/controller/PurchaseRequestController.java
@@ -35,6 +35,7 @@ import geumjeongyahak.domain.purchase_request.v1.dto.request.CreatePurchaseReque
 import geumjeongyahak.domain.purchase_request.v1.dto.request.PurchaseRequestListRequest;
 import geumjeongyahak.domain.purchase_request.v1.dto.request.ReportPurchaseRequest;
 import geumjeongyahak.domain.purchase_request.v1.dto.request.SavePurchaseRequestProposalRequest;
+import geumjeongyahak.domain.purchase_request.v1.dto.request.UpdatePurchaseRequestRequest;
 import geumjeongyahak.domain.purchase_request.v1.dto.response.PurchaseRequestDetailResponse;
 import geumjeongyahak.domain.purchase_request.v1.dto.response.PurchaseRequestProposalResponse;
 import geumjeongyahak.domain.purchase_request.v1.dto.response.PurchaseRequestSummaryResponse;
@@ -57,7 +58,7 @@ public class PurchaseRequestController {
     @PreAuthorize(TEACHER_OR_HIGHER_ACCESS)
     @Operation(
         summary = "구입 요청 생성",
-        description = "classroomId 로 지정한 분반에 대한 기자재 구입 요청을 생성합니다. "
+        description = "필수값인 classroomId와 departmentId로 담당 분반과 부서를 직접 지정하여 기자재 구입 요청을 생성합니다. "
             + "품목은 품명, 사유, 확정 결제금액, 선택 영수증을 입력합니다. "
             + "상태는 PENDING 으로 시작합니다."
     )
@@ -116,6 +117,28 @@ public class PurchaseRequestController {
         log.debug("GET /api/v1/purchase-requests/{}", requestId);
         return ResponseEntity.ok(
             purchaseRequestService.getPurchaseRequest(requestId)
+        );
+    }
+
+    @PreAuthorize(TEACHER_OR_HIGHER_ACCESS)
+    @Operation(
+        summary = "구입 요청 수정",
+        description = "작성자가 본인의 PENDING 상태 구입 요청 분반, 담당 부서, 제목, 내용, 품목을 전체 교체합니다."
+    )
+    @PutMapping("/{requestId}")
+    public ResponseEntity<PurchaseRequestDetailResponse> updatePurchaseRequest(
+        @PathVariable Long requestId,
+        @Valid @RequestBody UpdatePurchaseRequestRequest request,
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        log.debug("PUT /api/v1/purchase-requests/{}", requestId);
+        return ResponseEntity.ok(
+            purchaseRequestService.updatePurchaseRequest(
+                userDetails.getUserId(),
+                requestId,
+                request,
+                false
+            )
         );
     }
 

--- a/src/main/java/geumjeongyahak/domain/purchase_request/v1/controller/PurchaseRequestViewController.java
+++ b/src/main/java/geumjeongyahak/domain/purchase_request/v1/controller/PurchaseRequestViewController.java
@@ -91,6 +91,7 @@ public class PurchaseRequestViewController {
         model.addAttribute("active", "purchaseRequests");
         model.addAttribute("adminName", authentication.getName());
         model.addAttribute("classrooms", purchaseRequestAdminViewService.getAllClassrooms());
+        model.addAttribute("departments", purchaseRequestAdminViewService.getAllDepartments());
         model.addAttribute("vendors", purchaseRequestAdminViewService.getAllVendors());
 
         PurchaseRequestForm form = new PurchaseRequestForm();
@@ -113,6 +114,7 @@ public class PurchaseRequestViewController {
             model.addAttribute("active", "purchaseRequests");
             model.addAttribute("adminName", authentication.getName());
             model.addAttribute("classrooms", purchaseRequestAdminViewService.getAllClassrooms());
+            model.addAttribute("departments", purchaseRequestAdminViewService.getAllDepartments());
             model.addAttribute("vendors", purchaseRequestAdminViewService.getAllVendors());
             return "admin/request/purchase/purchase-requests-form";
         }
@@ -124,6 +126,7 @@ public class PurchaseRequestViewController {
         Long requestId = purchaseRequestAdminViewService.createPurchaseRequest(
             userDetails.getUserId(),
             form.getClassroomId(),
+            form.getDepartmentId(),
             form.getTitle(),
             form.getContent(),
             form.getPaymentType(),
@@ -144,6 +147,7 @@ public class PurchaseRequestViewController {
 
         PurchaseRequestForm form = new PurchaseRequestForm();
         form.setClassroomId(response.classroomId());
+        form.setDepartmentId(response.departmentId());
         form.setTitle(response.title());
         form.setContent(response.content());
         form.setPaymentType(response.paymentType());
@@ -188,6 +192,7 @@ public class PurchaseRequestViewController {
         model.addAttribute("request", response);
         model.addAttribute("form", form);
         model.addAttribute("classrooms", purchaseRequestAdminViewService.getAllClassrooms());
+        model.addAttribute("departments", purchaseRequestAdminViewService.getAllDepartments());
         model.addAttribute("vendors", purchaseRequestAdminViewService.getAllVendors());
         model.addAttribute("purchasePaymentMethods", PurchasePaymentMethod.values());
         return "admin/request/purchase/purchase-requests-edit";
@@ -207,6 +212,7 @@ public class PurchaseRequestViewController {
             model.addAttribute("active", "purchaseRequests");
             model.addAttribute("adminName", authentication.getName());
             model.addAttribute("classrooms", purchaseRequestAdminViewService.getAllClassrooms());
+            model.addAttribute("departments", purchaseRequestAdminViewService.getAllDepartments());
             model.addAttribute("vendors", purchaseRequestAdminViewService.getAllVendors());
             model.addAttribute("request", purchaseRequestAdminViewService.getPurchaseRequest(userDetails.getUserId(), requestId));
             return "admin/request/purchase/purchase-requests-edit";
@@ -219,6 +225,8 @@ public class PurchaseRequestViewController {
         purchaseRequestAdminViewService.updatePurchaseRequest(
             userDetails.getUserId(),
             requestId,
+            form.getClassroomId(),
+            form.getDepartmentId(),
             form.getTitle(),
             form.getContent(),
             items);

--- a/src/main/java/geumjeongyahak/domain/purchase_request/v1/dto/request/CreatePurchaseRequestByAdminRequest.java
+++ b/src/main/java/geumjeongyahak/domain/purchase_request/v1/dto/request/CreatePurchaseRequestByAdminRequest.java
@@ -28,6 +28,10 @@ public record CreatePurchaseRequestByAdminRequest(
     Long classroomId,
 
     @NotNull
+    @Schema(description = "구입 요청 담당 부서 ID", example = "4")
+    Long departmentId,
+
+    @NotNull
     @Schema(description = "결제 유형", example = "PREPAID")
     PurchasePaymentType paymentType,
 

--- a/src/main/java/geumjeongyahak/domain/purchase_request/v1/dto/request/CreatePurchaseRequestRequest.java
+++ b/src/main/java/geumjeongyahak/domain/purchase_request/v1/dto/request/CreatePurchaseRequestRequest.java
@@ -24,6 +24,10 @@ public record CreatePurchaseRequestRequest(
     Long classroomId,
 
     @NotNull
+    @Schema(description = "구입 요청 담당 부서 ID", example = "4")
+    Long departmentId,
+
+    @NotNull
     @Schema(description = "결제 유형", example = "PREPAID")
     PurchasePaymentType paymentType,
 

--- a/src/main/java/geumjeongyahak/domain/purchase_request/v1/dto/request/PurchaseRequestForm.java
+++ b/src/main/java/geumjeongyahak/domain/purchase_request/v1/dto/request/PurchaseRequestForm.java
@@ -20,7 +20,11 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public class PurchaseRequestForm {
 
+    @NotNull(message = "분반은 필수입니다.")
     private Long classroomId;
+
+    @NotNull(message = "담당 부서는 필수입니다.")
+    private Long departmentId;
 
     @NotBlank(message = "제목은 필수입니다.")
     private String title;

--- a/src/main/java/geumjeongyahak/domain/purchase_request/v1/dto/request/UpdatePurchaseRequestRequest.java
+++ b/src/main/java/geumjeongyahak/domain/purchase_request/v1/dto/request/UpdatePurchaseRequestRequest.java
@@ -4,9 +4,18 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record UpdatePurchaseRequestRequest(
+
+    @NotNull
+    @Schema(description = "구입 요청 대상 분반 ID", example = "1")
+    Long classroomId,
+
+    @NotNull
+    @Schema(description = "구입 요청 담당 부서 ID", example = "4")
+    Long departmentId,
 
     @NotBlank
     @Schema(description = "구입 요청 제목", example = "교재 구입")

--- a/src/main/java/geumjeongyahak/domain/purchase_request/v1/dto/response/PurchaseRequestDetailResponse.java
+++ b/src/main/java/geumjeongyahak/domain/purchase_request/v1/dto/response/PurchaseRequestDetailResponse.java
@@ -22,10 +22,10 @@ public record PurchaseRequestDetailResponse(
     @Schema(description = "분반 이름", example = "한글반")
     String classroomName,
 
-    @Schema(description = "신청 당시 요청자의 소속 부서 ID. 소속 부서가 없으면 null입니다.", example = "2", nullable = true)
+    @Schema(description = "구입 요청 담당 부서 ID. 기존 데이터에 담당 부서가 없으면 null입니다.", example = "2", nullable = true)
     Long departmentId,
 
-    @Schema(description = "신청 당시 요청자의 소속 부서 이름. 소속 부서가 없으면 null입니다.", example = "교육연구부", nullable = true)
+    @Schema(description = "구입 요청 담당 부서 이름. 기존 데이터에 담당 부서가 없으면 null입니다.", example = "교육연구부", nullable = true)
     String departmentName,
 
     @Schema(description = "요청자 ID", example = "3")

--- a/src/main/resources/templates/admin/request/purchase/purchase-requests-edit.html
+++ b/src/main/resources/templates/admin/request/purchase/purchase-requests-edit.html
@@ -25,8 +25,23 @@
     </div>
 
     <form id="purchase-form" class="panel form-grid" th:action="${request.status.name() == 'APPROVED'} ? @{/admin/request/purchase/purchase-requests/{requestId}/report(requestId=${request.id})} : @{/admin/request/purchase/purchase-requests/{requestId}(requestId=${request.id})}" th:object="${form}" method="post">
-        <label>분반
+        <label th:if="${request.status.name() == 'PENDING'}">분반
+            <select th:field="*{classroomId}" required>
+                <option th:each="classroom : ${classrooms}" th:value="${classroom.id}" th:text="${classroom.name}">분반명</option>
+            </select>
+        </label>
+        <label th:unless="${request.status.name() == 'PENDING'}">분반
             <input type="text" th:value="${request.classroomName}" readonly disabled>
+            <input type="hidden" th:field="*{classroomId}">
+        </label>
+        <label th:if="${request.status.name() == 'PENDING'}">담당 부서
+            <select th:field="*{departmentId}" required>
+                <option th:each="department : ${departments}" th:value="${department.id}" th:text="${department.name}">부서명</option>
+            </select>
+        </label>
+        <label th:unless="${request.status.name() == 'PENDING'}">담당 부서
+            <input type="text" th:value="${request.departmentName}" readonly disabled>
+            <input type="hidden" th:field="*{departmentId}">
         </label>
         <label>제목 <input th:field="*{title}" th:readonly="${request.status.name() != 'PENDING'}" required></label>
         <label>내용 <textarea th:field="*{content}" th:readonly="${request.status.name() != 'PENDING'}"></textarea></label>

--- a/src/main/resources/templates/admin/request/purchase/purchase-requests-form.html
+++ b/src/main/resources/templates/admin/request/purchase/purchase-requests-form.html
@@ -21,6 +21,12 @@
                 <option th:each="classroom : ${classrooms}" th:value="${classroom.id}" th:text="${classroom.name}">분반명</option>
             </select>
         </label>
+        <label>담당 부서
+            <select th:field="*{departmentId}" required>
+                <option value="">선택</option>
+                <option th:each="department : ${departments}" th:value="${department.id}" th:text="${department.name}">부서명</option>
+            </select>
+        </label>
         <label>제목 <input th:field="*{title}" required placeholder="예: 교재 구입"></label>
         <label>내용 <textarea th:field="*{content}" placeholder="구매 요청 사유 및 상세 내용을 입력하세요."></textarea></label>
         <label>결제 유형

--- a/src/test/java/geumjeongyahak/e2e/request/RequestBaseTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/RequestBaseTest.java
@@ -43,6 +43,7 @@ public abstract class RequestBaseTest extends BaseE2ETest {
     protected static final String VOLUNTEER_USERNAME = "teacher01";   // id=2
     protected static final String VOLUNTEER2_USERNAME = "teacher02";  // id=3
     protected static final long CLASSROOM_ID = 1L;
+    protected static final long DEPARTMENT_ID = 4L;  // 총무부
     protected static final long TEACHER_ID = 2L;   // teacher01
     protected static final long TEACHER2_ID = 3L;  // teacher02
     protected static final long SUBJECT_ID = 1L;   // init_data subject (teacher01 담당)
@@ -167,6 +168,7 @@ public abstract class RequestBaseTest extends BaseE2ETest {
                 entry("title", title),
                 entry("content", content),
                 entry("classroomId", classroomId),
+                entry("departmentId", DEPARTMENT_ID),
                 entry("paymentType", paymentType),
                 entry("items", java.util.List.of(Map.ofEntries(
                     entry("name", title + " 품목"),

--- a/src/test/java/geumjeongyahak/e2e/request/purchase/PurchaseRequestCreateTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/purchase/PurchaseRequestCreateTest.java
@@ -62,6 +62,7 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
                 entry("title", "교재 구입 요청"),
                 entry("content", "한글 기초 교재가 필요합니다."),
                 entry("classroomId", CLASSROOM_ID),
+                entry("departmentId", DEPARTMENT_ID),
                 entry("paymentType", "PREPAID"),
                 entry("items", List.of(Map.ofEntries(
                     entry("name", "한글 기초 교재"),
@@ -74,8 +75,8 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
             .statusCode(201)
             .body("id", notNullValue())
             .body("classroomId", equalTo((int) CLASSROOM_ID))
-            .body("departmentId", equalTo(2))
-            .body("departmentName", equalTo("교육연구부"))
+            .body("departmentId", equalTo((int) DEPARTMENT_ID))
+            .body("departmentName", equalTo("총무부"))
             .body("title", equalTo("교재 구입 요청"))
             .body("totalPrice", equalTo(0))
             .body("status", equalTo("PENDING"))
@@ -100,6 +101,7 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
                 entry("title", "칠판 구입"),
                 entry("content", "교실용 칠판"),
                 entry("classroomId", CLASSROOM_ID),
+                entry("departmentId", DEPARTMENT_ID),
                 entry("paymentType", "ACTUAL"),
                 entry("items", List.of(Map.ofEntries(
                     entry("name", "칠판"),
@@ -125,6 +127,7 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
             .body(Map.ofEntries(
                 entry("title", "내용 없는 구입 요청"),
                 entry("classroomId", CLASSROOM_ID),
+                entry("departmentId", DEPARTMENT_ID),
                 entry("paymentType", "ACTUAL"),
                 entry("items", List.of(Map.ofEntries(
                     entry("name", "복사용지"),
@@ -153,6 +156,7 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
                 entry("title", "시트 구입 요청"),
                 entry("content", "Apps Script에서 등록한 구입 요청입니다."),
                 entry("classroomId", CLASSROOM_ID),
+                entry("departmentId", DEPARTMENT_ID),
                 entry("paymentType", "ACTUAL"),
                 entry("items", List.of(Map.ofEntries(
                     entry("name", "프린터 토너"),
@@ -174,8 +178,8 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
     }
 
     @Test
-    @DisplayName("관리자가 소속 부서 없는 요청자의 구입 요청 대리 생성 → 부서 정보 null")
-    void createRequestByAdmin_withoutRequesterDepartment_returnsNullDepartment() {
+    @DisplayName("관리자가 소속 부서 없는 요청자의 구입 요청 대리 생성 → 선택한 부서 저장")
+    void createRequestByAdmin_withoutRequesterDepartment_savesSelectedDepartment() {
         createdRequestIds.add(given()
             .basePath("/api/v1/admin/purchase-requests")
             .header(AUTH_HEADER, getAuthHeader(adminToken))
@@ -184,6 +188,7 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
                 entry("requestedById", 5L),
                 entry("title", "미소속 요청자 구입 요청"),
                 entry("classroomId", CLASSROOM_ID),
+                entry("departmentId", DEPARTMENT_ID),
                 entry("paymentType", "ACTUAL"),
                 entry("items", List.of(Map.ofEntries(
                     entry("name", "복사용지"),
@@ -194,8 +199,8 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
             .post()
             .then()
             .statusCode(201)
-            .body("departmentId", nullValue())
-            .body("departmentName", nullValue())
+            .body("departmentId", equalTo((int) DEPARTMENT_ID))
+            .body("departmentName", equalTo("총무부"))
             .extract()
             .jsonPath()
             .getLong("id"));
@@ -219,6 +224,7 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
                 entry("title", "권한자 대리 요청"),
                 entry("content", "구입 요청 관리 권한자가 등록합니다."),
                 entry("classroomId", CLASSROOM_ID),
+                entry("departmentId", DEPARTMENT_ID),
                 entry("paymentType", "PREPAID"),
                 entry("items", List.of(Map.ofEntries(
                     entry("name", "마커"),
@@ -250,6 +256,7 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
                 entry("title", "Bot 대리 구입 요청"),
                 entry("content", "Apps Script Bot이 시트 값을 동기화합니다."),
                 entry("classroomId", CLASSROOM_ID),
+                entry("departmentId", DEPARTMENT_ID),
                 entry("paymentType", "ACTUAL"),
                 entry("items", List.of(Map.ofEntries(
                     entry("name", "복사용지"),
@@ -279,6 +286,7 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
                 entry("title", "권한 없는 요청"),
                 entry("content", "권한 없는 사용자는 대리 생성할 수 없습니다."),
                 entry("classroomId", CLASSROOM_ID),
+                entry("departmentId", DEPARTMENT_ID),
                 entry("paymentType", "ACTUAL"),
                 entry("items", List.of(Map.ofEntries(
                     entry("name", "교재"),
@@ -303,6 +311,7 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
                 entry("title", "없는 요청자"),
                 entry("content", "존재하지 않는 사용자로 대리 생성할 수 없습니다."),
                 entry("classroomId", CLASSROOM_ID),
+                entry("departmentId", DEPARTMENT_ID),
                 entry("paymentType", "ACTUAL"),
                 entry("items", List.of(Map.ofEntries(
                     entry("name", "교재"),
@@ -313,6 +322,30 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
             .post()
             .then()
             .statusCode(404);
+    }
+
+    @Test
+    @DisplayName("관리자 대리 생성 시 departmentId 누락 → 400")
+    void createRequestByAdmin_missingDepartment_returns400() {
+        given()
+            .basePath("/api/v1/admin/purchase-requests")
+            .header(AUTH_HEADER, getAuthHeader(adminToken))
+            .contentType(ContentType.JSON)
+            .body(Map.ofEntries(
+                entry("requestedById", TEACHER2_ID),
+                entry("title", "담당 부서 없는 대리 요청"),
+                entry("content", "담당 부서는 필수입니다."),
+                entry("classroomId", CLASSROOM_ID),
+                entry("paymentType", "ACTUAL"),
+                entry("items", List.of(Map.ofEntries(
+                    entry("name", "교재"),
+                    entry("reason", "수업 준비"),
+                    entry("quantity", 1)
+                )))
+            ))
+            .post()
+            .then()
+            .statusCode(400);
     }
 
     private String loginAppsScriptBot() {
@@ -340,6 +373,7 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
                 entry("title", "제목"),
                 entry("content", "내용"),
                 entry("classroomId", CLASSROOM_ID),
+                entry("departmentId", DEPARTMENT_ID),
                 entry("paymentType", "ACTUAL"),
                 entry("items", List.of(Map.ofEntries(
                     entry("name", "품목"),
@@ -363,6 +397,7 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
                 entry("title", "제목"),
                 entry("content", "내용"),
                 entry("classroomId", CLASSROOM_ID),
+                entry("departmentId", DEPARTMENT_ID),
                 entry("paymentType", "ACTUAL"),
                 entry("items", List.of(Map.ofEntries(
                     entry("name", "품목"),
@@ -388,6 +423,31 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
                 entry("title", "제목"),
                 entry("content", "내용"),
                 entry("classroomId", 99999L),
+                entry("departmentId", DEPARTMENT_ID),
+                entry("paymentType", "ACTUAL"),
+                entry("items", List.of(Map.ofEntries(
+                    entry("name", "품목"),
+                    entry("reason", "사유"),
+                    entry("quantity", 1)
+                )))
+            ))
+            .post()
+            .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 부서 ID → 404")
+    void createRequest_nonExistentDepartment_returns404() {
+        given()
+            .basePath("/api/v1/purchase-requests")
+            .header(AUTH_HEADER, getAuthHeader(volunteerToken))
+            .contentType(ContentType.JSON)
+            .body(Map.ofEntries(
+                entry("title", "제목"),
+                entry("content", "내용"),
+                entry("classroomId", CLASSROOM_ID),
+                entry("departmentId", 99999L),
                 entry("paymentType", "ACTUAL"),
                 entry("items", List.of(Map.ofEntries(
                     entry("name", "품목"),
@@ -403,6 +463,29 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
     // ── 유효성 오류 ───────────────────────────────────────
 
     @Test
+    @DisplayName("departmentId 누락 → 400")
+    void createRequest_missingDepartment_returns400() {
+        given()
+            .basePath("/api/v1/purchase-requests")
+            .header(AUTH_HEADER, getAuthHeader(volunteerToken))
+            .contentType(ContentType.JSON)
+            .body(Map.ofEntries(
+                entry("title", "제목"),
+                entry("content", "내용"),
+                entry("classroomId", CLASSROOM_ID),
+                entry("paymentType", "ACTUAL"),
+                entry("items", List.of(Map.ofEntries(
+                    entry("name", "품목"),
+                    entry("reason", "사유"),
+                    entry("quantity", 1)
+                )))
+            ))
+            .post()
+            .then()
+            .statusCode(400);
+    }
+
+    @Test
     @DisplayName("title 이 빈 문자열 → 400")
     void createRequest_blankTitle_returns400() {
         given()
@@ -413,6 +496,7 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
                 entry("title", ""),
                 entry("content", "내용"),
                 entry("classroomId", CLASSROOM_ID),
+                entry("departmentId", DEPARTMENT_ID),
                 entry("paymentType", "ACTUAL"),
                 entry("items", List.of(Map.ofEntries(
                     entry("name", "품목"),
@@ -436,6 +520,7 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
                 entry("title", "제목"),
                 entry("content", "내용"),
                 entry("classroomId", CLASSROOM_ID),
+                entry("departmentId", DEPARTMENT_ID),
                 entry("paymentType", "ACTUAL"),
                 entry("items", List.of())
             ))
@@ -455,6 +540,7 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
                 entry("title", "제목"),
                 entry("content", "내용"),
                 entry("classroomId", CLASSROOM_ID),
+                entry("departmentId", DEPARTMENT_ID),
                 entry("items", List.of(Map.ofEntries(
                     entry("name", "품목"),
                     entry("reason", "사유"),
@@ -477,6 +563,7 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
                 entry("title", "제목"),
                 entry("content", "내용"),
                 entry("classroomId", CLASSROOM_ID),
+                entry("departmentId", DEPARTMENT_ID),
                 entry("paymentType", "ACTUAL"),
                 entry("items", List.of(Map.ofEntries(
                     entry("name", "품목"),
@@ -500,6 +587,7 @@ class PurchaseRequestCreateTest extends RequestBaseTest {
                 entry("title", "제목"),
                 entry("content", "내용"),
                 entry("classroomId", CLASSROOM_ID),
+                entry("departmentId", DEPARTMENT_ID),
                 entry("paymentType", "ACTUAL"),
                 entry("items", List.of(Map.ofEntries(
                     entry("name", ""),

--- a/src/test/java/geumjeongyahak/e2e/request/purchase/PurchaseRequestExpenseDocumentTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/purchase/PurchaseRequestExpenseDocumentTest.java
@@ -421,6 +421,7 @@ class PurchaseRequestExpenseDocumentTest extends RequestBaseTest {
                 entry("title", "지출증빙서류 E2E"),
                 entry("content", "지출증빙서류 생성 API 테스트입니다."),
                 entry("classroomId", CLASSROOM_ID),
+                entry("departmentId", DEPARTMENT_ID),
                 entry("paymentType", paymentType),
                 entry("items", items)
             ))

--- a/src/test/java/geumjeongyahak/e2e/request/purchase/PurchaseRequestFileCleanupTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/purchase/PurchaseRequestFileCleanupTest.java
@@ -98,6 +98,7 @@ class PurchaseRequestFileCleanupTest extends RequestBaseTest {
                 entry("title", "영수증 연결 구입 요청"),
                 entry("content", "영수증 파일이 품목에 연결된 요청입니다."),
                 entry("classroomId", CLASSROOM_ID),
+                entry("departmentId", DEPARTMENT_ID),
                 entry("paymentType", "ACTUAL"),
                 entry("items", List.of(Map.ofEntries(
                     entry("name", "복사용지"),

--- a/src/test/java/geumjeongyahak/e2e/request/purchase/PurchaseRequestProposalTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/purchase/PurchaseRequestProposalTest.java
@@ -585,6 +585,7 @@ class PurchaseRequestProposalTest extends RequestBaseTest {
             .body(Map.ofEntries(
                 entry("title", title),
                 entry("classroomId", CLASSROOM_ID),
+                entry("departmentId", DEPARTMENT_ID),
                 entry("paymentType", "PREPAID"),
                 entry("items", List.of(Map.ofEntries(
                     entry("name", "교재"),

--- a/src/test/java/geumjeongyahak/e2e/request/purchase/PurchaseRequestStatusTest.java
+++ b/src/test/java/geumjeongyahak/e2e/request/purchase/PurchaseRequestStatusTest.java
@@ -402,10 +402,64 @@ class PurchaseRequestStatusTest extends RequestBaseTest {
             });
     }
 
-    // ── 관리자 수정 (update) ─────────────────────────────
+    // ── 수정 (update) ────────────────────────────────────
 
     @Test
-    @DisplayName("Apps Script Bot이 PENDING 구입 요청 수정 → 200, 기본 정보와 품목 교체")
+    @DisplayName("작성자가 본인의 PENDING 구입 요청 수정 → 200")
+    void update_asRequesterAndPending_returns200() {
+        currentRequestId = setupPendingRequest();
+
+        given()
+            .basePath("/api/v1/purchase-requests")
+            .header(AUTH_HEADER, getAuthHeader(volunteerToken))
+            .contentType(ContentType.JSON)
+            .body(Map.of(
+                "classroomId", 2L,
+                "departmentId", 3L,
+                "title", "작성자 수정 구입 요청",
+                "content", "작성자가 수정한 내용입니다.",
+                "items", List.of(Map.of(
+                    "name", "작성자 수정 품목",
+                    "reason", "작성자 수정 검증",
+                    "quantity", 2
+                ))
+            ))
+            .put("/{requestId}", currentRequestId)
+            .then()
+            .statusCode(200)
+            .body("classroomId", equalTo(2))
+            .body("departmentId", equalTo(3))
+            .body("title", equalTo("작성자 수정 구입 요청"))
+            .body("items[0].name", equalTo("작성자 수정 품목"));
+    }
+
+    @Test
+    @DisplayName("다른 작성자가 PENDING 구입 요청 수정 → 403")
+    void update_asOtherRequester_returns403() {
+        currentRequestId = setupPendingRequest();
+
+        given()
+            .basePath("/api/v1/purchase-requests")
+            .header(AUTH_HEADER, getAuthHeader(volunteer2Token))
+            .contentType(ContentType.JSON)
+            .body(Map.of(
+                "classroomId", CLASSROOM_ID,
+                "departmentId", DEPARTMENT_ID,
+                "title", "타인 수정 시도",
+                "content", "다른 작성자는 수정할 수 없습니다.",
+                "items", List.of(Map.of(
+                    "name", "수정 시도 품목",
+                    "reason", "접근 권한 검증",
+                    "quantity", 1
+                ))
+            ))
+            .put("/{requestId}", currentRequestId)
+            .then()
+            .statusCode(403);
+    }
+
+    @Test
+    @DisplayName("Apps Script Bot이 PENDING 구입 요청 수정 → 200, 분반·부서·기본 정보·품목 교체")
     void update_asAppsScriptBotAndPending_returns200() {
         currentRequestId = setupPendingRequest();
         String botAccessToken = loginAppsScriptBot();
@@ -415,6 +469,8 @@ class PurchaseRequestStatusTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(botAccessToken))
             .contentType(ContentType.JSON)
             .body(Map.of(
+                "classroomId", 2L,
+                "departmentId", 3L,
                 "title", "시트 수정 구입 요청",
                 "content", "Apps Script에서 수정한 내용입니다.",
                 "items", List.of(Map.of(
@@ -423,9 +479,13 @@ class PurchaseRequestStatusTest extends RequestBaseTest {
                     "quantity", 3
                 ))
             ))
-            .patch("/{requestId}", currentRequestId)
+            .put("/{requestId}", currentRequestId)
             .then()
             .statusCode(200)
+            .body("classroomId", equalTo(2))
+            .body("classroomName", equalTo("장미반"))
+            .body("departmentId", equalTo(3))
+            .body("departmentName", equalTo("생활안전부"))
             .body("title", equalTo("시트 수정 구입 요청"))
             .body("content", equalTo("Apps Script에서 수정한 내용입니다."))
             .body("status", equalTo("PENDING"))
@@ -433,6 +493,29 @@ class PurchaseRequestStatusTest extends RequestBaseTest {
             .body("items[0].name", equalTo("수정된 품목"))
             .body("items[0].quantity", equalTo(3))
             .body("paymentType", equalTo("ACTUAL"));
+    }
+
+    @Test
+    @DisplayName("구입 요청 수정 시 분반·담당 부서 누락 → 400")
+    void update_missingClassroomAndDepartment_returns400() {
+        currentRequestId = setupPendingRequest();
+
+        given()
+            .basePath("/api/v1/admin/purchase-requests")
+            .header(AUTH_HEADER, getAuthHeader(adminToken))
+            .contentType(ContentType.JSON)
+            .body(Map.of(
+                "title", "필수값 누락 수정",
+                "content", "분반과 담당 부서를 전송하지 않습니다.",
+                "items", List.of(Map.of(
+                    "name", "수정 품목",
+                    "reason", "필수값 검증",
+                    "quantity", 1
+                ))
+            ))
+            .put("/{requestId}", currentRequestId)
+            .then()
+            .statusCode(400);
     }
 
     @Test
@@ -455,6 +538,8 @@ class PurchaseRequestStatusTest extends RequestBaseTest {
             .header(AUTH_HEADER, getAuthHeader(botAccessToken))
             .contentType(ContentType.JSON)
             .body(Map.of(
+                "classroomId", CLASSROOM_ID,
+                "departmentId", DEPARTMENT_ID,
                 "title", "승인 후 수정",
                 "content", "승인 후에는 수정할 수 없습니다.",
                 "items", List.of(Map.of(
@@ -463,7 +548,7 @@ class PurchaseRequestStatusTest extends RequestBaseTest {
                     "quantity", 1
                 ))
             ))
-            .patch("/{requestId}", currentRequestId)
+            .put("/{requestId}", currentRequestId)
             .then()
             .statusCode(409);
     }
@@ -1398,6 +1483,7 @@ class PurchaseRequestStatusTest extends RequestBaseTest {
                 "title", "실 결제 다중 거래처 검증",
                 "content", "품목별 거래처 검증",
                 "classroomId", CLASSROOM_ID,
+                "departmentId", DEPARTMENT_ID,
                 "paymentType", "ACTUAL",
                 "items", List.of(
                     Map.of("name", "교재", "reason", "수업 자료", "quantity", 1),


### PR DESCRIPTION
## 개요

결제 신청 생성 시 신청자의 소속 부서를 자동 저장하던 방식을 변경하고, 담당 분반과 부서를 직접 선택하도록 수정했습니다.

작성자와 관리자가 `PENDING` 상태의 결제 신청에서 분반·담당 부서·기본 정보·품목을 수정할 수 있도록 수정 API와 관리자 화면도 함께 개선했습니다.

## 변경 유형

- [x] 새 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [x] 테스트 (test)
- [ ] 기타 (chore)

## 변경 내용

- 일반 및 관리자 대리 결제 신청 생성 요청에 필수 `departmentId` 필드 추가
- 신청자의 소속 부서 대신 요청에서 선택한 담당 부서 저장
- 선금 결제와 실 결제 모두 분반·담당 부서 직접 선택
- 작성자용 결제 신청 수정 API 추가
- 관리자 수정 API를 `PATCH`에서 전체 교체 방식의 `PUT`으로 변경
- `PENDING` 상태에서 분반·부서·제목·내용·품목 수정 지원
- 관리자 웹 생성·수정 화면에 담당 부서 선택 기능 추가
- 생성·수정 권한, 상태, 필수값 및 부서 검증 테스트 추가
- Swagger 요청·응답 설명 수정

## 관련 이슈

Closes #211

## 스크린샷 (선택)

## 체크리스트

- [x] 코드 컨벤션을 준수했습니다
- [x] 테스트 코드를 작성/수정했습니다
- [x] 결제 신청 관련 E2E 테스트가 통과합니다
- [x] API 문서를 업데이트했습니다

## 리뷰어에게

- 생성 및 수정 시 `classroomId`, `departmentId`를 모두 필수로 입력받습니다.
- 신청자의 실제 소속과 관계없이 요청에서 선택한 담당 부서를 저장합니다.
- 기본 정보 수정은 `PENDING` 상태에서만 가능하며 결제 유형과 신청자는 변경하지 않습니다.
- 관리자 수정 API가 `PATCH`에서 `PUT`으로 변경되었습니다.
- DB 스키마 변경은 없습니다.