### PR TITLE
[FEAT] 월별 수업일지 조회 API 및 목록 조회 성능 개선

### DIFF
--- a/docs/api/DailySchedules.md
+++ b/docs/api/DailySchedules.md
@@ -14,6 +14,8 @@ DailySchedule은 같은 분반과 같은 날짜의 Lesson들을 하루 단위로
 | `GET /api/v1/daily-schedules/detail` | `VOLUNTEER`, `MANAGER`, `ADMIN` |
 | `GET /api/v1/daily-schedules/{dailyScheduleId}` | `VOLUNTEER`, `MANAGER`, `ADMIN` |
 | `GET /api/v1/daily-schedules/volunteer-hours` | `VOLUNTEER`, `MANAGER`, `ADMIN` |
+| `GET /api/v1/daily-schedules/journal-sheet-link` | `ADMIN`, `daily-schedule:manage:*` |
+| `GET /api/v1/daily-schedules/journal-sheet-data` | `ADMIN`, `daily-schedule:manage:*` |
 | `POST /api/v1/daily-schedules/journal` | 담당 교사, `ADMIN`, `daily-schedule:manage:*` |
 | `PATCH /api/v1/daily-schedules/{dailyScheduleId}/journal` | 담당 교사, `ADMIN`, `daily-schedule:manage:*` |
 | `DELETE /api/v1/daily-schedules/{dailyScheduleId}/journal` | 담당 교사, `ADMIN`, `daily-schedule:manage:*` |
@@ -28,6 +30,7 @@ DailySchedule은 같은 분반과 같은 날짜의 Lesson들을 하루 단위로
 - `VOLUNTEER`, `MANAGER`, `ADMIN`은 DailySchedule 목록, 상세, 봉사 시간을 조회할 수 있습니다.
 - 상세 응답의 담당 교사 연락처와 주민번호 앞자리는 담당 교사 본인, `ADMIN`, `daily-schedule:read:*`, `daily-schedule:manage:*` 권한 보유자에게만 노출됩니다.
 - 다른 교사의 봉사 시간을 조회하려면 `ADMIN`, `daily-schedule:read:*`, `daily-schedule:manage:*` 권한이 필요합니다.
+- 수업일지 관리 시트 링크와 월별 시트 데이터는 `ADMIN` 또는 `daily-schedule:manage:*` 권한 보유자만 조회할 수 있습니다.
 - 담당 교사가 아닌 사용자는 `ADMIN` 또는 `daily-schedule:manage:*` 권한이 있어야 수업 일지, 출석, 상태를 변경할 수 있습니다.
 - 상태 변경 API는 운영 보정용 관리자 API입니다. 일반 완료 처리는 교사 출석과 수업 일지 작성 완료 시 자동으로 수행됩니다.
 
@@ -131,6 +134,52 @@ GET /api/v1/daily-schedules/detail?classroomId=1&lessonDate=2026-06-20
 ```
 
 응답 구조는 `GET /api/v1/daily-schedules/{dailyScheduleId}`와 동일합니다. 해당 날짜와 분반에 연결된 활성 DailySchedule이 없으면 `404 Not Found`를 반환합니다.
+
+## Google Sheets 수업일지 연동
+
+### 관리 시트 링크 조회
+
+```http
+GET /api/v1/daily-schedules/journal-sheet-link
+```
+
+봉사시간 증빙용 수업일지 관리 Google Sheets URL을 반환합니다. 월별 시트 생성과 갱신은 반환된 시트의 Apps Script 메뉴에서 수행합니다.
+
+```json
+{
+  "url": "https://docs.google.com/spreadsheets/d/example/edit"
+}
+```
+
+### 월별 시트 데이터 조회
+
+```http
+GET /api/v1/daily-schedules/journal-sheet-data?month=2026-07
+```
+
+- `month`는 필수이며 `yyyy-MM` 형식으로 입력합니다. 형식이 잘못되거나 누락되면 `400 Bad Request`를 반환합니다.
+- 요청한 월에 속하고 삭제되지 않은 DailySchedule을 수업 날짜 오름차순, ID 오름차순으로 반환합니다.
+- 같은 분반과 날짜의 활성 Lesson note 중 하나라도 작성된 일정만 반환합니다.
+- 교사 출석 정보가 없으면 `teacherAttendanceStatus`는 `null`입니다.
+- `residentRegistrationNumberPrefix`는 수업일지에 저장한 값을 우선 사용하고, 없으면 담당 교사 정보의 주민번호 앞자리를 사용합니다.
+- 관리자용 시트 연동 데이터이므로 `personalInfoConsent` 값과 관계없이 주민번호 앞자리를 반환합니다. 이 API의 접근 권한을 일반 사용자에게 부여하면 안 됩니다.
+- `lessons`는 교시 오름차순이며 각 항목에 `lessonId`, 교시, 수업 시간, 과목명, 일지 내용을 포함합니다.
+
+주요 응답 필드:
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `dailyScheduleId` | long | 하루 일정 식별자 |
+| `classroomId`, `classroomName` | long, string | 분반 식별자와 이름 |
+| `teacherId`, `teacherName` | long, string | 담당 교사 식별자와 이름 |
+| `teacherPhoneNumber` | string, nullable | 담당 교사 연락처 |
+| `residentRegistrationNumberPrefix` | string, nullable | 주민등록번호 앞자리 |
+| `lessonDate` | date | 수업 날짜 |
+| `activityStartTime`, `activityEndTime` | time, nullable | 활동 시작·종료 시간 |
+| `status` | enum | DailySchedule 상태 |
+| `teacherAttendanceStatus` | enum, nullable | 교사 출석 상태 |
+| `personalInfoConsent` | boolean | 수업일지 개인정보 활용 동의 여부 |
+| `lessons` | array | 교시별 수업 식별자, 시간, 과목명, 일지 내용 |
 
 ## 수업 일지 정책
 

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleAdminService.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleAdminService.java
@@ -14,8 +14,17 @@ import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyScheduleSt
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyTeacherAttendanceCorrectionRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleDetailResponse;
 import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleJournalSheetLinkResponse;
+import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleJournalSheetRowResponse;
+import geumjeongyahak.domain.lesson.entity.Lesson;
 import geumjeongyahak.domain.lesson.enums.LessonStatus;
 import geumjeongyahak.domain.lesson.service.LessonProxyService;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -42,6 +51,49 @@ public class DailyScheduleAdminService {
             throw new DailyScheduleJournalSheetLinkNotConfiguredException();
         }
         return new DailyScheduleJournalSheetLinkResponse(journalSheetUrl.trim());
+    }
+
+    public List<DailyScheduleJournalSheetRowResponse> getMonthlyJournalSheetData(YearMonth month) {
+        LocalDate from = month.atDay(1);
+        LocalDate to = month.atEndOfMonth();
+        log.debug("DailySchedule 월별 수업일지 시트 조회 요청 (month={}, from={}, to={})", month, from, to);
+
+        List<DailySchedule> dailySchedules = dailyScheduleRepository
+            .findAllByIsDeletedFalseAndLessonDateBetweenOrderByLessonDateAscIdAsc(from, to);
+        if (dailySchedules.isEmpty()) {
+            return List.of();
+        }
+
+        Map<DailyScheduleLessonKey, List<Lesson>> lessonsByScheduleKey = getLessonsByScheduleKey(dailySchedules);
+        List<DailySchedule> writtenSchedules = dailySchedules.stream()
+            .filter(dailySchedule -> hasWrittenJournal(
+                lessonsByScheduleKey.getOrDefault(DailyScheduleLessonKey.from(dailySchedule), List.of())
+            ))
+            .toList();
+        if (writtenSchedules.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> dailyScheduleIds = writtenSchedules.stream()
+            .map(DailySchedule::getId)
+            .toList();
+        Map<Long, DailyTeacherAttendance> attendanceByScheduleId = dailyTeacherAttendanceRepository
+            .findAllByDailyScheduleIdInAndIsDeletedFalse(dailyScheduleIds)
+            .stream()
+            .collect(Collectors.toMap(
+                attendance -> attendance.getDailySchedule().getId(),
+                Function.identity()
+            ));
+
+        List<DailyScheduleJournalSheetRowResponse> responses = writtenSchedules.stream()
+            .map(dailySchedule -> DailyScheduleJournalSheetRowResponse.of(
+                dailySchedule,
+                attendanceByScheduleId.get(dailySchedule.getId()),
+                lessonsByScheduleKey.getOrDefault(DailyScheduleLessonKey.from(dailySchedule), List.of())
+            ))
+            .toList();
+        log.debug("DailySchedule 월별 수업일지 시트 조회 완료 (month={}, count={})", month, responses.size());
+        return responses;
     }
 
     @Transactional
@@ -127,6 +179,25 @@ public class DailyScheduleAdminService {
         };
     }
 
+    private Map<DailyScheduleLessonKey, List<Lesson>> getLessonsByScheduleKey(
+        List<DailySchedule> dailySchedules
+    ) {
+        Set<Long> classroomIds = dailySchedules.stream()
+            .map(dailySchedule -> dailySchedule.getClassroom().getId())
+            .collect(Collectors.toSet());
+        Set<LocalDate> lessonDates = dailySchedules.stream()
+            .map(DailySchedule::getLessonDate)
+            .collect(Collectors.toSet());
+
+        return lessonProxyService.getActiveLessonsByClassroomIdsAndDates(classroomIds, lessonDates)
+            .stream()
+            .collect(Collectors.groupingBy(DailyScheduleLessonKey::from));
+    }
+
+    private boolean hasWrittenJournal(List<Lesson> lessons) {
+        return lessons.stream().anyMatch(lesson -> lesson.getNote() != null && !lesson.getNote().isBlank());
+    }
+
     private void validateTeacherAttendanceCorrectionState(DailySchedule dailySchedule) {
         if (dailySchedule.getStatus() != DailyScheduleStatus.CANCELLED) {
             return;
@@ -157,6 +228,23 @@ public class DailyScheduleAdminService {
                 dailySchedule.getId(),
                 request.attendedAt(),
                 request.checkedOutAt()
+            );
+        }
+    }
+
+    private record DailyScheduleLessonKey(Long classroomId, LocalDate lessonDate) {
+
+        private static DailyScheduleLessonKey from(DailySchedule dailySchedule) {
+            return new DailyScheduleLessonKey(
+                dailySchedule.getClassroom().getId(),
+                dailySchedule.getLessonDate()
+            );
+        }
+
+        private static DailyScheduleLessonKey from(Lesson lesson) {
+            return new DailyScheduleLessonKey(
+                lesson.getSubject().getClassroom().getId(),
+                lesson.getDate()
             );
         }
     }

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleService.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/service/DailyScheduleService.java
@@ -156,13 +156,17 @@ public class DailyScheduleService {
             .filter(dailySchedule -> request.status() == null || dailySchedule.getStatus() == request.status())
             .toList();
         Map<DailyScheduleLessonKey, List<Lesson>> lessonsByScheduleKey = getLessonsByScheduleKey(dailySchedules);
+        Map<Long, DailyTeacherAttendance> attendanceByScheduleId = getTeacherAttendancesByScheduleId(dailySchedules);
         List<DailyScheduleSummaryResponse> responses = dailySchedules
             .stream()
             .map(dailySchedule -> new DailyScheduleWithLessons(
                 dailySchedule,
                 lessonsByScheduleKey.getOrDefault(DailyScheduleLessonKey.from(dailySchedule), List.of())
             ))
-            .map(this::toSummaryResponse)
+            .map(dailyScheduleWithLessons -> toSummaryResponse(
+                dailyScheduleWithLessons,
+                attendanceByScheduleId.get(dailyScheduleWithLessons.dailySchedule().getId())
+            ))
             .toList();
         log.debug("DailySchedule 목록 조회 완료 - 총 {}건", responses.size());
         return responses;
@@ -241,23 +245,31 @@ public class DailyScheduleService {
                 || dailySchedule.getTeacher().getId().equals(requesterId))
             .toList();
         Map<DailyScheduleLessonKey, List<Lesson>> lessonsByScheduleKey = getLessonsByScheduleKey(dailySchedules);
-        List<DailyScheduleSummaryResponse> responses = dailySchedules
-            .stream()
+        List<DailyScheduleWithLessons> filteredSchedules = dailySchedules.stream()
             .map(dailySchedule -> new DailyScheduleWithLessons(
                 dailySchedule,
                 lessonsByScheduleKey.getOrDefault(DailyScheduleLessonKey.from(dailySchedule), List.of())
             ))
             .filter(dailyScheduleWithLessons -> hasWrittenJournal(dailyScheduleWithLessons.lessons()))
             .filter(dailyScheduleWithLessons -> matchesKeyword(dailyScheduleWithLessons, request.getKeyword()))
-            .map(this::toSummaryResponse)
             .toList();
         PageRequest pageRequest = request.toRequest();
-        int start = Math.min((int) pageRequest.getOffset(), responses.size());
-        int end = Math.min(start + pageRequest.getPageSize(), responses.size());
+        int start = Math.min((int) pageRequest.getOffset(), filteredSchedules.size());
+        int end = Math.min(start + pageRequest.getPageSize(), filteredSchedules.size());
+        List<DailyScheduleWithLessons> pageSchedules = filteredSchedules.subList(start, end);
+        Map<Long, DailyTeacherAttendance> attendanceByScheduleId = getTeacherAttendancesByScheduleId(
+            pageSchedules.stream().map(DailyScheduleWithLessons::dailySchedule).toList()
+        );
+        List<DailyScheduleSummaryResponse> responses = pageSchedules.stream()
+            .map(dailyScheduleWithLessons -> toSummaryResponse(
+                dailyScheduleWithLessons,
+                attendanceByScheduleId.get(dailyScheduleWithLessons.dailySchedule().getId())
+            ))
+            .toList();
         return new PaginationResponse<>(new PageImpl<>(
-            responses.subList(start, end),
+            responses,
             pageRequest,
-            responses.size()
+            filteredSchedules.size()
         ));
     }
 
@@ -1035,11 +1047,28 @@ public class DailyScheduleService {
             .collect(Collectors.groupingBy(DailyScheduleLessonKey::from));
     }
 
-    private DailyScheduleSummaryResponse toSummaryResponse(DailyScheduleWithLessons dailyScheduleWithLessons) {
+    private Map<Long, DailyTeacherAttendance> getTeacherAttendancesByScheduleId(
+        List<DailySchedule> dailySchedules
+    ) {
+        if (dailySchedules.isEmpty()) {
+            return Map.of();
+        }
+        List<Long> dailyScheduleIds = dailySchedules.stream()
+            .map(DailySchedule::getId)
+            .toList();
+        return dailyTeacherAttendanceRepository.findAllByDailyScheduleIdInAndIsDeletedFalse(dailyScheduleIds)
+            .stream()
+            .collect(toMap(
+                attendance -> attendance.getDailySchedule().getId(),
+                Function.identity()
+            ));
+    }
+
+    private DailyScheduleSummaryResponse toSummaryResponse(
+        DailyScheduleWithLessons dailyScheduleWithLessons,
+        DailyTeacherAttendance teacherAttendance
+    ) {
         DailySchedule dailySchedule = dailyScheduleWithLessons.dailySchedule();
-        DailyTeacherAttendance teacherAttendance = dailyTeacherAttendanceRepository
-            .findByDailyScheduleIdAndIsDeletedFalse(dailySchedule.getId())
-            .orElse(null);
         List<DailyScheduleLessonResponse> lessons = dailyScheduleWithLessons.lessons()
             .stream()
             .map(DailyScheduleLessonResponse::from)

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/DailyScheduleAdminController.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/v1/controller/DailyScheduleAdminController.java
@@ -6,11 +6,15 @@ import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyScheduleSt
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyTeacherAttendanceCorrectionRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleDetailResponse;
 import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleJournalSheetLinkResponse;
+import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleJournalSheetRowResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.time.YearMonth;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.GrantedAuthority;
@@ -20,6 +24,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -49,6 +54,21 @@ public class DailyScheduleAdminController {
     public ResponseEntity<DailyScheduleJournalSheetLinkResponse> getJournalSheetLink() {
         log.debug("GET /api/v1/daily-schedules/journal-sheet-link - 관리자 수업일지 관리 시트 링크 조회 요청");
         return ResponseEntity.ok(dailyScheduleAdminService.getJournalSheetLink());
+    }
+
+    @PreAuthorize(DAILY_SCHEDULE_MANAGE_ACCESS)
+    @Operation(
+        summary = "월별 수업일지 시트 데이터 조회",
+        description = "요청한 월의 작성된 수업일지와 교사 출석을 Google Sheets 연동용으로 조회합니다."
+    )
+    @GetMapping("/journal-sheet-data")
+    public ResponseEntity<List<DailyScheduleJournalSheetRowResponse>> getMonthlyJournalSheetData(
+        @RequestParam
+        @DateTimeFormat(pattern = "yyyy-MM")
+        YearMonth month
+    ) {
+        log.debug("GET /api/v1/daily-schedules/journal-sheet-data - 월별 수업일지 시트 데이터 조회 (month={})", month);
+        return ResponseEntity.ok(dailyScheduleAdminService.getMonthlyJournalSheetData(month));
     }
 
     @PreAuthorize(DAILY_SCHEDULE_MANAGE_ACCESS)

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/v1/dto/response/DailyScheduleJournalSheetRowResponse.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/v1/dto/response/DailyScheduleJournalSheetRowResponse.java
@@ -1,0 +1,87 @@
+package geumjeongyahak.domain.daily_schedule.v1.dto.response;
+
+import geumjeongyahak.domain.daily_schedule.entity.DailySchedule;
+import geumjeongyahak.domain.daily_schedule.entity.DailyTeacherAttendance;
+import geumjeongyahak.domain.daily_schedule.enums.DailyScheduleStatus;
+import geumjeongyahak.domain.daily_schedule.enums.DailyTeacherAttendanceStatus;
+import geumjeongyahak.domain.lesson.entity.Lesson;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public record DailyScheduleJournalSheetRowResponse(
+    @Schema(description = "하루 일정 식별자", example = "1")
+    Long dailyScheduleId,
+
+    @Schema(description = "분반 식별자", example = "1")
+    Long classroomId,
+
+    @Schema(description = "분반명", example = "장미반")
+    String classroomName,
+
+    @Schema(description = "담당 교사 식별자", example = "2")
+    Long teacherId,
+
+    @Schema(description = "담당 교사명", example = "홍길동")
+    String teacherName,
+
+    @Schema(description = "담당 교사 연락처", example = "010-1234-5678", nullable = true)
+    String teacherPhoneNumber,
+
+    @Schema(description = "주민등록번호 앞자리", example = "900101", nullable = true)
+    String residentRegistrationNumberPrefix,
+
+    @Schema(description = "수업 날짜", example = "2026-07-15")
+    LocalDate lessonDate,
+
+    @Schema(description = "활동 시작 시간", example = "14:00:00", nullable = true)
+    LocalTime activityStartTime,
+
+    @Schema(description = "활동 종료 시간", example = "16:00:00", nullable = true)
+    LocalTime activityEndTime,
+
+    @Schema(description = "하루 일정 상태", example = "COMPLETED")
+    DailyScheduleStatus status,
+
+    @Schema(description = "교사 출석 상태", example = "PRESENT", nullable = true)
+    DailyTeacherAttendanceStatus teacherAttendanceStatus,
+
+    @Schema(description = "개인정보 활용 동의 여부", example = "true")
+    boolean personalInfoConsent,
+
+    @Schema(description = "교시별 수업 일지")
+    List<DailyScheduleLessonResponse> lessons
+) {
+
+    public static DailyScheduleJournalSheetRowResponse of(
+        DailySchedule dailySchedule,
+        DailyTeacherAttendance teacherAttendance,
+        List<Lesson> lessons
+    ) {
+        return new DailyScheduleJournalSheetRowResponse(
+            dailySchedule.getId(),
+            dailySchedule.getClassroom().getId(),
+            dailySchedule.getClassroom().getName(),
+            dailySchedule.getTeacher().getId(),
+            dailySchedule.getTeacher().getName(),
+            dailySchedule.getTeacher().getPhoneNumber(),
+            resolveResidentRegistrationNumberPrefix(dailySchedule),
+            dailySchedule.getLessonDate(),
+            dailySchedule.getActivityStartTime(),
+            dailySchedule.getActivityEndTime(),
+            dailySchedule.getStatus(),
+            teacherAttendance != null ? teacherAttendance.getStatus() : null,
+            dailySchedule.isPersonalInfoConsent(),
+            lessons.stream().map(DailyScheduleLessonResponse::from).toList()
+        );
+    }
+
+    private static String resolveResidentRegistrationNumberPrefix(DailySchedule dailySchedule) {
+        String journalValue = dailySchedule.getResidentRegistrationNumberPrefix();
+        if (journalValue != null && !journalValue.isBlank()) {
+            return journalValue;
+        }
+        return dailySchedule.getTeacher().getResidentRegistrationNumberPrefix();
+    }
+}

--- a/src/test/java/geumjeongyahak/e2e/daily_schedule/DailyScheduleReadTest.java
+++ b/src/test/java/geumjeongyahak/e2e/daily_schedule/DailyScheduleReadTest.java
@@ -102,6 +102,67 @@ public class DailyScheduleReadTest extends BaseE2ETest {
     }
 
     @Test
+    @DisplayName("관리자는 월별 수업일지 시트 데이터를 조회할 수 있다")
+    void getMonthlyJournalSheetData_asAdmin_success() {
+        given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .queryParam("month", "2051-01")
+            .when()
+            .get("/journal-sheet-data")
+            .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @DisplayName("Apps Script Bot은 월별 수업일지 시트 데이터를 조회할 수 있다")
+    void getMonthlyJournalSheetData_asAppsScriptBot_success() {
+        String botAccessToken = loginAppsScriptBot();
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(botAccessToken))
+            .queryParam("month", "2051-01")
+            .when()
+            .get("/journal-sheet-data")
+            .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @DisplayName("일반 봉사자는 월별 수업일지 시트 데이터를 조회할 수 없다")
+    void getMonthlyJournalSheetData_asVolunteer_forbidden() {
+        given()
+            .header(AUTH_HEADER, getAuthHeader(volunteerAccessToken))
+            .queryParam("month", "2051-01")
+            .when()
+            .get("/journal-sheet-data")
+            .then()
+            .statusCode(403);
+    }
+
+    @Test
+    @DisplayName("월 형식이 잘못되면 월별 수업일지 시트 조회를 할 수 없다")
+    void getMonthlyJournalSheetData_invalidMonth_badRequest() {
+        given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .queryParam("month", "2051-13")
+            .when()
+            .get("/journal-sheet-data")
+            .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @DisplayName("월을 입력하지 않으면 월별 수업일지 시트 조회를 할 수 없다")
+    void getMonthlyJournalSheetData_missingMonth_badRequest() {
+        given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .when()
+            .get("/journal-sheet-data")
+            .then()
+            .statusCode(400);
+    }
+
+    @Test
     @DisplayName("Apps Script Bot은 날짜와 분반 ID로 DailySchedule 상세를 조회할 수 있다")
     void getDailyScheduleByClassroomAndDate_asAppsScriptBot_success() {
         LocalDate lessonDate = nextLessonDate();

--- a/src/test/java/geumjeongyahak/e2e/util/TestLessonHelper.java
+++ b/src/test/java/geumjeongyahak/e2e/util/TestLessonHelper.java
@@ -16,14 +16,14 @@ import org.springframework.stereotype.Component;
  * <p>
  * - Subject: SUBJECT_SEQ(100번~)로 name·dayOfWeek·period를 자동 조합하고, 날짜 범위를
  *   2050-01-01 기준으로 seq마다 1일씩 증가시켜 classroom+dayOfWeek+period 중복 충돌 방지.
- * - Lesson: DATE_OFFSET으로 날짜를 자동 증가 → 동일 teacher+date 충돌 방지
+ * - Lesson: 실행 시점 기준 1년 후부터 날짜를 자동 증가 → 수업 시작 전 조건과 teacher+date 중복 방지
  * </p>
  */
 @Component
 public class TestLessonHelper {
 
     private static final LocalDate SUBJECT_BASE_DATE = LocalDate.of(2050, 1, 1);
-    private static final LocalDate LESSON_BASE_DATE = LocalDate.of(2026, 8, 1);
+    private static final LocalDate LESSON_BASE_DATE = LocalDate.now().plusYears(1);
     private static final AtomicLong SUBJECT_SEQUENCE = new AtomicLong();
     private static final AtomicLong LESSON_SEQUENCE = new AtomicLong();
     private final List<Long> createdSubjectIds = new ArrayList<>();
@@ -138,7 +138,7 @@ public class TestLessonHelper {
 
     /**
      * 테스트용 수업을 생성하고 lessonId를 반환한다.
-     * 날짜는 BASE_DATE(2026-08-01)에서 자동 증가하여 teacher+date 충돌을 방지한다.
+     * 날짜는 실행 시점 기준 1년 후부터 자동 증가하여 수업 시작 전 조건과 teacher+date 충돌을 방지한다.
      */
     public Long createLessonAndGetId(String authHeader, Long subjectId, Long teacherId) {
         long sequence = LESSON_SEQUENCE.incrementAndGet();

--- a/src/test/java/geumjeongyahak/unit/daily_schedule/DailyScheduleAdminServiceTest.java
+++ b/src/test/java/geumjeongyahak/unit/daily_schedule/DailyScheduleAdminServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import geumjeongyahak.domain.auth.enums.RoleType;
 import geumjeongyahak.domain.classroom.entity.Classroom;
@@ -24,6 +25,7 @@ import geumjeongyahak.domain.daily_schedule.service.DailyScheduleService;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyScheduleStatusRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.request.UpdateDailyTeacherAttendanceCorrectionRequest;
 import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleDetailResponse;
+import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleJournalSheetRowResponse;
 import geumjeongyahak.domain.lesson.entity.Lesson;
 import geumjeongyahak.domain.lesson.enums.LessonStatus;
 import geumjeongyahak.domain.lesson.service.LessonProxyService;
@@ -35,8 +37,10 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -110,6 +114,121 @@ class DailyScheduleAdminServiceTest {
         assertThatThrownBy(dailyScheduleAdminService::getJournalSheetLink)
             .isInstanceOf(DailyScheduleJournalSheetLinkNotConfiguredException.class)
             .hasMessage("수업일지 관리 시트 링크가 설정되어 있지 않습니다.");
+    }
+
+    @Test
+    void getMonthlyJournalSheetData_returnsOnlyWrittenJournalsForRequestedMonth() {
+        YearMonth month = YearMonth.of(2026, 7);
+        LocalDate firstDay = month.atDay(1);
+        LocalDate lastDay = month.atEndOfMonth();
+        Classroom classroom = classroom(1L);
+        User teacher = teacherWithPersonalInfo(2L, "홍길동", "010-1234-5678", "010101");
+        DailySchedule writtenSchedule = dailySchedule(100L, classroom, teacher, firstDay);
+        writtenSchedule.updateJournalPersonalInfo("900101", true);
+        DailySchedule emptySchedule = dailySchedule(101L, classroom, teacher, lastDay);
+        Lesson writtenLesson = lesson(subject(classroom, teacher, firstDay), teacher, firstDay);
+        ReflectionTestUtils.setField(writtenLesson, "id", 1353L);
+        writtenLesson.updateNote("국어 수업 내용");
+        Lesson emptyLesson = lesson(subject(classroom, teacher, lastDay), teacher, lastDay);
+        DailyTeacherAttendance teacherAttendance = teacherAttendance(writtenSchedule);
+
+        given(dailyScheduleRepository.findAllByIsDeletedFalseAndLessonDateBetweenOrderByLessonDateAscIdAsc(
+            firstDay,
+            lastDay
+        )).willReturn(List.of(writtenSchedule, emptySchedule));
+        given(lessonProxyService.getActiveLessonsByClassroomIdsAndDates(
+            Set.of(classroom.getId()),
+            Set.of(firstDay, lastDay)
+        )).willReturn(List.of(writtenLesson, emptyLesson));
+        given(dailyTeacherAttendanceRepository.findAllByDailyScheduleIdInAndIsDeletedFalse(
+            List.of(writtenSchedule.getId())
+        )).willReturn(List.of(teacherAttendance));
+
+        List<DailyScheduleJournalSheetRowResponse> responses =
+            dailyScheduleAdminService.getMonthlyJournalSheetData(month);
+
+        assertThat(responses).hasSize(1);
+        DailyScheduleJournalSheetRowResponse response = responses.get(0);
+        assertThat(response.dailyScheduleId()).isEqualTo(writtenSchedule.getId());
+        assertThat(response.teacherPhoneNumber()).isEqualTo("010-1234-5678");
+        assertThat(response.residentRegistrationNumberPrefix()).isEqualTo("900101");
+        assertThat(response.personalInfoConsent()).isTrue();
+        assertThat(response.teacherAttendanceStatus()).isEqualTo(DailyTeacherAttendanceStatus.PRESENT);
+        assertThat(response.lessons()).hasSize(1);
+        assertThat(response.lessons().get(0).lessonId()).isEqualTo(1353L);
+        assertThat(response.lessons().get(0).period()).isEqualTo(1);
+        assertThat(response.lessons().get(0).note()).isEqualTo("국어 수업 내용");
+        verify(dailyTeacherAttendanceRepository)
+            .findAllByDailyScheduleIdInAndIsDeletedFalse(List.of(writtenSchedule.getId()));
+    }
+
+    @Test
+    void getMonthlyJournalSheetData_returnsEmptyListWhenMonthHasNoSchedules() {
+        YearMonth month = YearMonth.of(2026, 7);
+        given(dailyScheduleRepository.findAllByIsDeletedFalseAndLessonDateBetweenOrderByLessonDateAscIdAsc(
+            month.atDay(1),
+            month.atEndOfMonth()
+        )).willReturn(List.of());
+
+        List<DailyScheduleJournalSheetRowResponse> responses =
+            dailyScheduleAdminService.getMonthlyJournalSheetData(month);
+
+        assertThat(responses).isEmpty();
+        verifyNoInteractions(lessonProxyService, dailyTeacherAttendanceRepository);
+    }
+
+    @Test
+    void getMonthlyJournalSheetData_skipsAttendanceQueryWhenNoJournalIsWritten() {
+        YearMonth month = YearMonth.of(2026, 7);
+        LocalDate lessonDate = month.atDay(15);
+        Classroom classroom = classroom(1L);
+        User teacher = teacher(2L, "홍길동");
+        DailySchedule dailySchedule = dailySchedule(100L, classroom, teacher, lessonDate);
+        Lesson lesson = lesson(subject(classroom, teacher, lessonDate), teacher, lessonDate);
+
+        given(dailyScheduleRepository.findAllByIsDeletedFalseAndLessonDateBetweenOrderByLessonDateAscIdAsc(
+            month.atDay(1),
+            month.atEndOfMonth()
+        )).willReturn(List.of(dailySchedule));
+        given(lessonProxyService.getActiveLessonsByClassroomIdsAndDates(
+            Set.of(classroom.getId()),
+            Set.of(lessonDate)
+        )).willReturn(List.of(lesson));
+
+        List<DailyScheduleJournalSheetRowResponse> responses =
+            dailyScheduleAdminService.getMonthlyJournalSheetData(month);
+
+        assertThat(responses).isEmpty();
+        verifyNoInteractions(dailyTeacherAttendanceRepository);
+    }
+
+    @Test
+    void getMonthlyJournalSheetData_returnsTeacherResidentNumberWithoutConsent() {
+        YearMonth month = YearMonth.of(2026, 7);
+        LocalDate lessonDate = month.atDay(15);
+        Classroom classroom = classroom(1L);
+        User teacher = teacherWithPersonalInfo(2L, "홍길동", "010-1234-5678", "000101");
+        DailySchedule dailySchedule = dailySchedule(100L, classroom, teacher, lessonDate);
+        Lesson lesson = lesson(subject(classroom, teacher, lessonDate), teacher, lessonDate);
+        lesson.updateNote("국어 수업 내용");
+
+        given(dailyScheduleRepository.findAllByIsDeletedFalseAndLessonDateBetweenOrderByLessonDateAscIdAsc(
+            month.atDay(1),
+            month.atEndOfMonth()
+        )).willReturn(List.of(dailySchedule));
+        given(lessonProxyService.getActiveLessonsByClassroomIdsAndDates(
+            Set.of(classroom.getId()),
+            Set.of(lessonDate)
+        )).willReturn(List.of(lesson));
+        given(dailyTeacherAttendanceRepository.findAllByDailyScheduleIdInAndIsDeletedFalse(
+            List.of(dailySchedule.getId())
+        )).willReturn(List.of());
+
+        DailyScheduleJournalSheetRowResponse response =
+            dailyScheduleAdminService.getMonthlyJournalSheetData(month).get(0);
+
+        assertThat(response.personalInfoConsent()).isFalse();
+        assertThat(response.residentRegistrationNumberPrefix()).isEqualTo("000101");
     }
 
     @Test
@@ -405,6 +524,22 @@ class DailyScheduleAdminServiceTest {
     private User teacher(Long id, String name) {
         User teacher = User.builder()
             .name(name)
+            .role(RoleType.VOLUNTEER)
+            .build();
+        ReflectionTestUtils.setField(teacher, "id", id);
+        return teacher;
+    }
+
+    private User teacherWithPersonalInfo(
+        Long id,
+        String name,
+        String phoneNumber,
+        String residentRegistrationNumberPrefix
+    ) {
+        User teacher = User.builder()
+            .name(name)
+            .phoneNumber(phoneNumber)
+            .residentRegistrationNumberPrefix(residentRegistrationNumberPrefix)
             .role(RoleType.VOLUNTEER)
             .build();
         ReflectionTestUtils.setField(teacher, "id", id);

--- a/src/test/java/geumjeongyahak/unit/daily_schedule/DailyScheduleControllerJournalSheetTest.java
+++ b/src/test/java/geumjeongyahak/unit/daily_schedule/DailyScheduleControllerJournalSheetTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.verify;
 import geumjeongyahak.domain.daily_schedule.service.DailyScheduleAdminService;
 import geumjeongyahak.domain.daily_schedule.v1.controller.DailyScheduleAdminController;
 import geumjeongyahak.domain.daily_schedule.v1.dto.response.DailyScheduleJournalSheetLinkResponse;
+import java.time.YearMonth;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -29,5 +31,17 @@ class DailyScheduleControllerJournalSheetTest {
 
         assertThat(response.getBody()).isEqualTo(serviceResponse);
         verify(dailyScheduleAdminService).getJournalSheetLink();
+    }
+
+    @Test
+    void getMonthlyJournalSheetData_returnsServiceResponse() {
+        DailyScheduleAdminController controller = new DailyScheduleAdminController(dailyScheduleAdminService);
+        YearMonth month = YearMonth.of(2026, 7);
+        given(dailyScheduleAdminService.getMonthlyJournalSheetData(month)).willReturn(List.of());
+
+        var response = controller.getMonthlyJournalSheetData(month);
+
+        assertThat(response.getBody()).isEmpty();
+        verify(dailyScheduleAdminService).getMonthlyJournalSheetData(month);
     }
 }

--- a/src/test/java/geumjeongyahak/unit/daily_schedule/DailyScheduleServiceReadTest.java
+++ b/src/test/java/geumjeongyahak/unit/daily_schedule/DailyScheduleServiceReadTest.java
@@ -2,7 +2,9 @@ package geumjeongyahak.unit.daily_schedule;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import geumjeongyahak.domain.auth.enums.RoleType;
@@ -112,8 +114,9 @@ class DailyScheduleServiceReadTest {
             lessonDate,
             lessonDate
         )).willReturn(List.of(dailySchedule));
-        given(dailyTeacherAttendanceRepository.findByDailyScheduleIdAndIsDeletedFalse(dailySchedule.getId()))
-            .willReturn(Optional.of(teacherAttendance));
+        given(dailyTeacherAttendanceRepository.findAllByDailyScheduleIdInAndIsDeletedFalse(
+            List.of(dailySchedule.getId())
+        )).willReturn(List.of(teacherAttendance));
         given(lessonProxyService.getActiveLessonsByClassroomIdsAndDates(Set.of(classroom.getId()), Set.of(lessonDate)))
             .willReturn(List.of(lesson(subject(classroom, teacher, lessonDate), teacher, lessonDate, 1)));
 
@@ -131,6 +134,11 @@ class DailyScheduleServiceReadTest {
         assertThat(responses.get(0).isExchanged()).isTrue();
         assertThat(responses.get(0).isAbsent()).isTrue();
         assertThat(responses.get(0).exchangedLessonDate()).isEqualTo(exchangedLessonDate);
+        verify(dailyTeacherAttendanceRepository).findAllByDailyScheduleIdInAndIsDeletedFalse(
+            List.of(dailySchedule.getId())
+        );
+        verify(dailyTeacherAttendanceRepository, never())
+            .findByDailyScheduleIdAndIsDeletedFalse(anyLong());
     }
 
     @Test
@@ -151,8 +159,9 @@ class DailyScheduleServiceReadTest {
             Set.of(classroom.getId()),
             Set.of(lessonDate, lessonDate.plusDays(1))
         )).willReturn(List.of(writtenLesson, emptyLesson));
-        given(dailyTeacherAttendanceRepository.findByDailyScheduleIdAndIsDeletedFalse(writtenSchedule.getId()))
-            .willReturn(Optional.empty());
+        given(dailyTeacherAttendanceRepository.findAllByDailyScheduleIdInAndIsDeletedFalse(
+            List.of(writtenSchedule.getId())
+        )).willReturn(List.of());
 
         PaginationResponse<DailyScheduleSummaryResponse> response = dailyScheduleService.getJournalDailySchedules(
             journalPaginationRequest("수학", true, 0, 1),
@@ -165,6 +174,11 @@ class DailyScheduleServiceReadTest {
         assertThat(response.getContent().get(0).dailyScheduleId()).isEqualTo(writtenSchedule.getId());
         assertThat(response.getContent().get(0).lessons()).hasSize(1);
         assertThat(response.getContent().get(0).lessons().get(0).note()).isEqualTo("수학 수업 내용");
+        verify(dailyTeacherAttendanceRepository).findAllByDailyScheduleIdInAndIsDeletedFalse(
+            List.of(writtenSchedule.getId())
+        );
+        verify(dailyTeacherAttendanceRepository, never())
+            .findByDailyScheduleIdAndIsDeletedFalse(anyLong());
     }
 
     @Test


### PR DESCRIPTION
## 개요

Google Sheets에서 월별 수업일지 데이터를 효율적으로 조회할 수 있는 관리자 API를 추가하고, 기존 수업일지 목록 조회에서 발생하던 교사 출석 N+1 문제를 개선합니다.

## 변경 유형

- [x] 새 기능 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [x] 문서 수정 (docs)
- [x] 테스트 (test)
- [ ] 기타 (chore)

## 변경 내용

- `GET /api/v1/daily-schedules/journal-sheet-data` 월별 수업일지 시트 데이터 조회 API 추가
  - `yyyy-MM` 형식으로 조회 월 지정
  - 작성된 수업일지만 날짜·ID 오름차순으로 반환
  - 교시별 `lessonId`, 수업 시간, 과목명, 일지 내용 반환
  - 관리자 및 `daily-schedule:manage:*` 권한만 접근 가능
- Google Sheets 작성에 필요한 교사 연락처, 주민번호 앞자리, 개인정보 동의 여부 및 교사 출석 상태 제공
  - 수업일지에 저장된 주민번호 앞자리를 우선 사용
  - 저장값이 없으면 담당 교사 정보의 주민번호 앞자리 사용
- 기존 수업일지 목록의 교사 출석 N+1 문제 개선
  - 일정별 단건 조회 대신 일정 ID 목록 기반 일괄 조회
  - 페이지에 포함되는 일정의 출석 정보만 조회
  - 기존 검색·정렬·메모리 페이징 동작은 유지
- 관리자·Apps Script Bot 권한, 월 형식 검증 및 응답 변환 테스트 추가
- DailySchedule 로컬 API 문서에 Google Sheets 연동 정책과 응답 필드 추가

## 관련 이슈

Closes #217

## 스크린샷 (선택)



## 체크리스트

- [x] 코드 컨벤션을 준수했습니다
- [x] 테스트 코드를 작성/수정했습니다
- [ ] 머지 전 `./gradlew test`가 통과합니다
- [x] 문서를 업데이트했습니다 (필요한 경우)

## 리뷰어에게

- 월별 시트 API는 활성 Lesson의 note가 하나라도 작성된 일정만 반환합니다.
- 관리자용 시트 연동 정책에 따라 개인정보 동의 여부와 관계없이 주민번호 앞자리를 반환합니다.
- 기존 목록 API는 DB 페이징으로 변경하지 않고 교사 출석 N+1만 제거했습니다.
- 관련 DailySchedule 단위·E2E 테스트, 전체 테스트는 통과했습니다.