### PR TITLE
[FEAT] 월별 수업일지 시트 응답에 출퇴근 시각 추가

### DIFF
--- a/docs/api/DailySchedules.md
+++ b/docs/api/DailySchedules.md
@@ -160,7 +160,8 @@ GET /api/v1/daily-schedules/journal-sheet-data?month=2026-07
 - `month`는 필수이며 `yyyy-MM` 형식으로 입력합니다. 형식이 잘못되거나 누락되면 `400 Bad Request`를 반환합니다.
 - 요청한 월에 속하고 삭제되지 않은 DailySchedule을 수업 날짜 오름차순, ID 오름차순으로 반환합니다.
 - 같은 분반과 날짜의 활성 Lesson note 중 하나라도 작성된 일정만 반환합니다.
-- 교사 출석 정보가 없으면 `teacherAttendanceStatus`는 `null`입니다.
+- 교사 출석 정보가 없으면 `teacherAttendanceStatus`, `attendedAt`, `checkedOutAt`은 모두 `null`입니다.
+- `attendedAt`, `checkedOutAt`은 교사 출석 레코드에 저장된 출근·퇴근 시각입니다. 기록되지 않은 시각은 각각 `null`로 반환하며, 활동 시작·종료 시간이나 현재 시각으로 대체하지 않습니다.
 - `residentRegistrationNumberPrefix`는 수업일지에 저장한 값을 우선 사용하고, 없으면 담당 교사 정보의 주민번호 앞자리를 사용합니다.
 - 관리자용 시트 연동 데이터이므로 `personalInfoConsent` 값과 관계없이 주민번호 앞자리를 반환합니다. 이 API의 접근 권한을 일반 사용자에게 부여하면 안 됩니다.
 - `lessons`는 교시 오름차순이며 각 항목에 `lessonId`, 교시, 수업 시간, 과목명, 일지 내용을 포함합니다.
@@ -176,10 +177,61 @@ GET /api/v1/daily-schedules/journal-sheet-data?month=2026-07
 | `residentRegistrationNumberPrefix` | string, nullable | 주민등록번호 앞자리 |
 | `lessonDate` | date | 수업 날짜 |
 | `activityStartTime`, `activityEndTime` | time, nullable | 활동 시작·종료 시간 |
+| `attendedAt` | datetime, nullable | 저장된 출근 시각. 출근 기록이 없으면 `null` |
+| `checkedOutAt` | datetime, nullable | 저장된 퇴근 시각. 퇴근 기록이 없으면 `null` |
 | `status` | enum | DailySchedule 상태 |
 | `teacherAttendanceStatus` | enum, nullable | 교사 출석 상태 |
 | `personalInfoConsent` | boolean | 수업일지 개인정보 활용 동의 여부 |
 | `lessons` | array | 교시별 수업 식별자, 시간, 과목명, 일지 내용 |
+
+응답 예시:
+
+```json
+[
+  {
+    "dailyScheduleId": 100,
+    "classroomId": 1,
+    "classroomName": "장미반",
+    "teacherId": 2,
+    "teacherName": "홍길동",
+    "teacherPhoneNumber": "010-1234-5678",
+    "residentRegistrationNumberPrefix": "900101",
+    "lessonDate": "2026-07-15",
+    "activityStartTime": "14:00:00",
+    "activityEndTime": "16:00:00",
+    "attendedAt": "2026-07-15T13:55:00",
+    "checkedOutAt": "2026-07-15T16:05:00",
+    "status": "COMPLETED",
+    "teacherAttendanceStatus": "PRESENT",
+    "personalInfoConsent": true,
+    "lessons": [
+      {
+        "lessonId": 1353,
+        "period": 1,
+        "startTime": "14:00:00",
+        "endTime": "16:00:00",
+        "subjectName": "국어",
+        "note": "국어 읽기 활동을 진행했습니다."
+      }
+    ]
+  }
+]
+```
+
+출퇴근 시각 해석 및 시트 연동:
+
+- `activityStartTime`, `activityEndTime`은 활동 시간이며 출퇴근 체크 시각과 다를 수 있습니다. 시트에서는 기존 활동 시간 칼럼을 유지하고 출근·퇴근 칼럼을 별도로 표시합니다.
+- 출퇴근 시각은 기존 상세 조회와 동일한 `LocalDateTime`의 ISO 8601 문자열입니다. 예: `2026-07-15T13:55:00`. 소수초가 포함될 수 있으며, `Z`나 `+09:00` 같은 시간대 정보는 포함하지 않습니다.
+- 서버의 출퇴근 체크는 `Asia/Seoul` 기준입니다. Apps Script에서 날짜·시간으로 변환할 때 UTC로 간주하지 말고, 시트와 스크립트의 시간대가 `Asia/Seoul`인지 확인합니다.
+
+| 기록 상태 | `attendedAt` | `checkedOutAt` | 시트 표시 |
+|-----------|--------------|----------------|-----------|
+| 출근·퇴근 모두 기록 | 저장된 출근 시각 | 저장된 퇴근 시각 | 두 시각 표시 |
+| 출근만 기록 | 저장된 출근 시각 | `null` | 퇴근 칸은 빈칸 |
+| 두 시각 모두 미기록 | `null` | `null` | 두 칸 모두 빈칸 |
+| 출석 레코드 없음 | `null` | `null` | 두 칸 모두 빈칸 |
+
+이번 연동은 출퇴근 기록의 조회·출력만 지원합니다. 시트에서 셀을 수정해도 서버 기록에는 반영되지 않으며, 선택 행 저장·동기화 기능은 포함하지 않습니다. 기존 관리자 출퇴근 보정 API와 봉사시간 계산 방식은 변경하지 않습니다. Apps Script의 칼럼 추가와 출력 설정은 별도 작업입니다.
 
 ## 수업 일지 정책
 

--- a/src/main/java/geumjeongyahak/domain/daily_schedule/v1/dto/response/DailyScheduleJournalSheetRowResponse.java
+++ b/src/main/java/geumjeongyahak/domain/daily_schedule/v1/dto/response/DailyScheduleJournalSheetRowResponse.java
@@ -7,6 +7,7 @@ import geumjeongyahak.domain.daily_schedule.enums.DailyTeacherAttendanceStatus;
 import geumjeongyahak.domain.lesson.entity.Lesson;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -41,6 +42,12 @@ public record DailyScheduleJournalSheetRowResponse(
     @Schema(description = "활동 종료 시간", example = "16:00:00", nullable = true)
     LocalTime activityEndTime,
 
+    @Schema(description = "실제 출근 시각. 출근 기록이 없으면 null입니다.", example = "2026-07-15T13:55:00", nullable = true)
+    LocalDateTime attendedAt,
+
+    @Schema(description = "실제 퇴근 시각. 퇴근 기록이 없으면 null입니다.", example = "2026-07-15T16:05:00", nullable = true)
+    LocalDateTime checkedOutAt,
+
     @Schema(description = "하루 일정 상태", example = "COMPLETED")
     DailyScheduleStatus status,
 
@@ -70,6 +77,8 @@ public record DailyScheduleJournalSheetRowResponse(
             dailySchedule.getLessonDate(),
             dailySchedule.getActivityStartTime(),
             dailySchedule.getActivityEndTime(),
+            teacherAttendance != null ? teacherAttendance.getAttendedAt() : null,
+            teacherAttendance != null ? teacherAttendance.getCheckedOutAt() : null,
             dailySchedule.getStatus(),
             teacherAttendance != null ? teacherAttendance.getStatus() : null,
             dailySchedule.isPersonalInfoConsent(),

--- a/src/test/java/geumjeongyahak/e2e/daily_schedule/DailyScheduleReadTest.java
+++ b/src/test/java/geumjeongyahak/e2e/daily_schedule/DailyScheduleReadTest.java
@@ -2,8 +2,10 @@ package geumjeongyahak.e2e.daily_schedule;
 
 import static io.restassured.RestAssured.given;
 import static java.util.Map.entry;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 import geumjeongyahak.domain.auth.v1.dto.request.LocalLoginRequest;
 import geumjeongyahak.e2e.BaseE2ETest;
@@ -125,6 +127,62 @@ public class DailyScheduleReadTest extends BaseE2ETest {
             .get("/journal-sheet-data")
             .then()
             .statusCode(200);
+    }
+
+    @Test
+    @DisplayName("월별 시트 조회는 출퇴근 미기록을 null로 반환하고 저장된 시각을 활동 시간과 구분한다")
+    void getMonthlyJournalSheetData_returnsNullOrRecordedAttendanceTimes() {
+        LocalDate lessonDate = nextLessonDate();
+        Long lessonId = createDailyScheduleSource("시트출퇴근조회-" + SEQUENCE.get(), lessonDate);
+        Long dailyScheduleId = given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .contentType(ContentType.JSON)
+            .body(Map.of(
+                "lessonDate", lessonDate.toString(),
+                "classroomId", CLASSROOM_ID,
+                "personalInfoConsent", true,
+                "residentRegistrationNumberPrefix", "900101",
+                "lessonJournals", List.of(Map.of("lessonId", lessonId, "note", "출퇴근 시각 조회용 수업 일지"))
+            ))
+            .post("/journal")
+            .then()
+            .statusCode(200)
+            .extract().jsonPath().getLong("dailyScheduleId");
+        String rowPath = "find { it.dailyScheduleId == " + dailyScheduleId + " }";
+        String month = java.time.YearMonth.from(lessonDate).toString();
+        String botAccessToken = loginAppsScriptBot();
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(botAccessToken))
+            .queryParam("month", month)
+            .get("/journal-sheet-data")
+            .then()
+            .statusCode(200)
+            .body(rowPath, hasKey("attendedAt"))
+            .body(rowPath, hasKey("checkedOutAt"))
+            .body(rowPath + ".attendedAt", nullValue())
+            .body(rowPath + ".checkedOutAt", nullValue());
+
+        String attendedAt = lessonDate + "T08:55:00";
+        String checkedOutAt = lessonDate + "T10:05:00";
+        given()
+            .header(AUTH_HEADER, getAuthHeader(adminAccessToken))
+            .contentType(ContentType.JSON)
+            .body(Map.of("status", "PRESENT", "attendedAt", attendedAt, "checkedOutAt", checkedOutAt))
+            .patch("/{dailyScheduleId}/teacher-attendance/adjustment", dailyScheduleId)
+            .then()
+            .statusCode(200);
+
+        given()
+            .header(AUTH_HEADER, getAuthHeader(botAccessToken))
+            .queryParam("month", month)
+            .get("/journal-sheet-data")
+            .then()
+            .statusCode(200)
+            .body(rowPath + ".attendedAt", is(attendedAt))
+            .body(rowPath + ".checkedOutAt", is(checkedOutAt))
+            .body(rowPath + ".activityStartTime", is("09:00:00"))
+            .body(rowPath + ".activityEndTime", is("10:00:00"));
     }
 
     @Test

--- a/src/test/java/geumjeongyahak/unit/daily_schedule/DailyScheduleAdminServiceTest.java
+++ b/src/test/java/geumjeongyahak/unit/daily_schedule/DailyScheduleAdminServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import geumjeongyahak.domain.auth.enums.RoleType;
 import geumjeongyahak.domain.classroom.entity.Classroom;
@@ -44,6 +45,8 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -175,6 +178,54 @@ class DailyScheduleAdminServiceTest {
 
         assertThat(responses).isEmpty();
         verifyNoInteractions(lessonProxyService, dailyTeacherAttendanceRepository);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "true, 2026-07-15T13:55:00, 2026-07-15T16:05:00",
+        "true, 2026-07-15T13:55:00,",
+        "true,,",
+        "false,,"
+    })
+    void getMonthlyJournalSheetData_returnsRecordedAttendanceTimes(
+        boolean hasAttendanceRecord,
+        LocalDateTime attendedAt,
+        LocalDateTime checkedOutAt
+    ) {
+        YearMonth month = YearMonth.of(2026, 7);
+        LocalDate lessonDate = month.atDay(15);
+        Classroom classroom = classroom(1L);
+        User teacher = teacher(2L, "홍길동");
+        DailySchedule dailySchedule = dailySchedule(100L, classroom, teacher, lessonDate);
+        Lesson lesson = lesson(subject(classroom, teacher, lessonDate), teacher, lessonDate);
+        lesson.updateNote("국어 수업 내용");
+        DailyTeacherAttendance attendance = new DailyTeacherAttendance(dailySchedule, 120);
+        if (attendedAt != null) {
+            attendance.correctAttendance(DailyTeacherAttendanceStatus.PRESENT, attendedAt, checkedOutAt);
+        }
+
+        given(dailyScheduleRepository.findAllByIsDeletedFalseAndLessonDateBetweenOrderByLessonDateAscIdAsc(
+            month.atDay(1), month.atEndOfMonth()
+        )).willReturn(List.of(dailySchedule));
+        given(lessonProxyService.getActiveLessonsByClassroomIdsAndDates(
+            Set.of(classroom.getId()), Set.of(lessonDate)
+        )).willReturn(List.of(lesson));
+        given(dailyTeacherAttendanceRepository.findAllByDailyScheduleIdInAndIsDeletedFalse(
+            List.of(dailySchedule.getId())
+        )).willReturn(hasAttendanceRecord ? List.of(attendance) : List.of());
+
+        List<DailyScheduleJournalSheetRowResponse> responses =
+            dailyScheduleAdminService.getMonthlyJournalSheetData(month);
+
+        assertThat(responses).hasSize(1);
+        DailyScheduleJournalSheetRowResponse response = responses.get(0);
+        assertThat(response.attendedAt()).isEqualTo(attendedAt);
+        assertThat(response.checkedOutAt()).isEqualTo(checkedOutAt);
+        assertThat(response.activityStartTime()).isEqualTo(LocalTime.of(14, 0));
+        assertThat(response.activityEndTime()).isEqualTo(LocalTime.of(16, 0));
+        verify(dailyTeacherAttendanceRepository)
+            .findAllByDailyScheduleIdInAndIsDeletedFalse(List.of(dailySchedule.getId()));
+        verifyNoMoreInteractions(dailyTeacherAttendanceRepository);
     }
 
     @Test


### PR DESCRIPTION
## 개요

월별 수업일지 시트 연동 데이터에서 교사의 실제 출근 시각과 퇴근 시각을 확인할 수 있도록 응답 필드를 추가합니다.

기존 `activityStartTime`, `activityEndTime`은 활동 시간이라 실제 출퇴근 체크 시각과 다를 수 있으므로, 시트 출력용 응답에 `attendedAt`, `checkedOutAt`을 별도로 제공합니다.

## 변경 유형

- [x] 새 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 문서 수정 (docs)
- [x] 테스트 (test)
- [ ] 기타 (chore)

## 변경 내용

- 월별 수업일지 시트 데이터 응답 DTO에 `attendedAt`, `checkedOutAt` 필드를 추가했습니다.
- 교사 출석 기록이 없거나 출퇴근 시각이 일부만 기록된 경우 `null`로 반환하도록 처리했습니다.
- 관련 단위 테스트와 E2E 테스트에서 신규 응답 필드를 검증하도록 보강했습니다.
- API 문서에 신규 필드, null 처리 기준, 시트 연동 시 해석 기준을 추가했습니다.
- 시트에서 출퇴근 시간을 수정하거나 서버로 동기화하는 기능은 이번 PR 범위에 포함하지 않았습니다.

## 관련 이슈

Closes #223

## 스크린샷 (선택)



## 체크리스트

- [x] 코드 컨벤션을 준수했습니다
- [x] 테스트 코드를 작성/수정했습니다
- [ ] 머지 전 `./gradlew test`가 통과합니다
- [x] 문서를 업데이트했습니다 (필요한 경우)

## 리뷰어에게

이번 PR은 월별 수업일지 시트 데이터의 조회 응답만 확장합니다.

`activityStartTime`, `activityEndTime`은 기존처럼 활동 시간으로 유지하고, 실제 출퇴근 체크 시각은 `attendedAt`, `checkedOutAt`으로 별도 제공됩니다. 시트 수정 후 서버 동기화나 출퇴근 기록 생성/수정 API 변경은 포함하지 않았습니다.

검증한 테스트는 다음과 같습니다.

```bash
.\gradlew.bat test --init-script C:/Users/Public/Documents/ESTsoft/CreatorTemp/gjlearn-223-test.init.gradle --tests geumjeongyahak.unit.daily_schedule.DailyScheduleAdminServiceTest --tests geumjeongyahak.unit.daily_schedule.DailyScheduleControllerJournalSheetTest --tests geumjeongyahak.e2e.daily_schedule.DailyScheduleReadTest
```